### PR TITLE
调整postgres限定符，使go-admin-ui能正常查询postgresql数据库内容

### DIFF
--- a/tools/search/query.go
+++ b/tools/search/query.go
@@ -34,11 +34,6 @@ func ResolveSearchQuery(driver string, q interface{}, condition Condition) {
 	var ok bool
 	var t *resolveSearchTag
 
-	var sep = "`"
-	if driver == Postgres {
-		sep = "\""
-	}
-
 	for i := 0; i < qType.NumField(); i++ {
 		tag, ok = "", false
 		tag, ok = qType.Field(i).Tag.Lookup(FromQueryTag)
@@ -69,41 +64,41 @@ func pgSql(driver string, t *resolveSearchTag, condition Condition, qValue refle
 	case "left":
 		//左关联
 		join := condition.SetJoinOn(t.Type, fmt.Sprintf(
-			"left join %s on %s.%s = %s.%s", t.Join, t.Join, t.On[0], t.Table, t.On[1],
+			"left join %s on \"%s\".\"%s\" = \"%s\".\"%s\"", t.Join, t.Join, t.On[0], t.Table, t.On[1],
 		))
 		ResolveSearchQuery(driver, qValue.Field(i).Interface(), join)
 	case "exact", "iexact":
-		condition.SetWhere(fmt.Sprintf("%s.%s = ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" = ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
 	case "icontains":
-		condition.SetWhere(fmt.Sprintf("%s.%s ilike ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String() + "%"})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" ilike ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String() + "%"})
 	case "contains":
-		condition.SetWhere(fmt.Sprintf("%s.%s like ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String() + "%"})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" like ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String() + "%"})
 	case "gt":
-		condition.SetWhere(fmt.Sprintf("%s.%s > ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" > ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
 	case "gte":
-		condition.SetWhere(fmt.Sprintf("%s.%s >= ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" >= ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
 	case "lt":
-		condition.SetWhere(fmt.Sprintf("%s.%s < ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" < ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
 	case "lte":
-		condition.SetWhere(fmt.Sprintf("%s.%s <= ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" <= ?", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
 	case "istartswith":
-		condition.SetWhere(fmt.Sprintf("%s.%s ilike ?", t.Table, t.Column), []interface{}{qValue.Field(i).String() + "%"})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" ilike ?", t.Table, t.Column), []interface{}{qValue.Field(i).String() + "%"})
 	case "startswith":
-		condition.SetWhere(fmt.Sprintf("%s.%s like ?", t.Table, t.Column), []interface{}{qValue.Field(i).String() + "%"})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" like ?", t.Table, t.Column), []interface{}{qValue.Field(i).String() + "%"})
 	case "iendswith":
-		condition.SetWhere(fmt.Sprintf("%s.%s ilike ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" ilike ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String()})
 	case "endswith":
-		condition.SetWhere(fmt.Sprintf("%s.%s like ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" like ?", t.Table, t.Column), []interface{}{"%" + qValue.Field(i).String()})
 	case "in":
-		condition.SetWhere(fmt.Sprintf("%s.%s in (?)", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
+		condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" in (?)", t.Table, t.Column), []interface{}{qValue.Field(i).Interface()})
 	case "isnull":
 		if !(qValue.Field(i).IsZero() && qValue.Field(i).IsNil()) {
-			condition.SetWhere(fmt.Sprintf("%s.%s isnull", t.Table, t.Column), make([]interface{}, 0))
+			condition.SetWhere(fmt.Sprintf("\"%s\".\"%s\" isnull", t.Table, t.Column), make([]interface{}, 0))
 		}
 	case "order":
 		switch strings.ToLower(qValue.Field(i).String()) {
 		case "desc", "asc":
-			condition.SetOrder(fmt.Sprintf("%s.%s %s", t.Table, t.Column, qValue.Field(i).String()))
+			condition.SetOrder(fmt.Sprintf("\"%s\".\"%s\" %s", t.Table, t.Column, qValue.Field(i).String()))
 		}
 	}
 }


### PR DESCRIPTION

### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
1.使用go-admin-ui示例代码，配置为postgresql数据库时，提示语法错误。原因为使用了mysql的限定符`，而postgresql的限定符是"。后查看go-admin-core代码，已经移除了postgresql接口使用是的`限定符，但移除后可能造成大小写不敏感导致的对象找不到
2.将postgresql相关接口修改为"限定符，与mysql一致
调整postgres限定符，使go-admin-ui能正常查询postgresql数据库内容，为防止后续postgresql和mysql语法上的可能差异，此次提交没有将两者合并

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |     Adjust postgres qualifiers so that go-admin-ui can query PostgreSQL database content correctly     |
| 🇨🇳 中文 |      调整postgres限定符，使go-admin-ui能正常查询postgresql数据库内容    |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
