### PR TITLE
reset error when api MakeContext

### DIFF
--- a/sdk/api/api.go
+++ b/sdk/api/api.go
@@ -42,6 +42,7 @@ func (e *Api) AddError(err error) {
 func (e *Api) MakeContext(c *gin.Context) *Api {
 	e.Context = c
 	e.Logger = GetRequestLogger(c)
+	e.Errors = nil
 	return e
 }
 


### PR DESCRIPTION
每次设置http上下文时，将error重置，避免当用户将Api的接收者设置成指针类型时，多次请求互相影响。