### PR TITLE
fix🐛: 续期时保留 orig_iat，修复 token 可无限续期

### DIFF
--- a/sdk/config/jwt.go
+++ b/sdk/config/jwt.go
@@ -1,8 +1,16 @@
 package config
 
 type Jwt struct {
-	Secret  string
+	Secret string
+	// Timeout token 有效期，单位：秒
 	Timeout int64
+	// MaxRefresh 续期上限，单位：秒。
+	//
+	// 自 token 首次签发起计算，超过该时长后不再允许续期，必须重新登录。
+	// 一个 token 的最长存活时间为 Timeout + MaxRefresh。
+	//
+	// 为 0 时由使用方决定默认值，本结构不做兜底。
+	MaxRefresh int64
 }
 
 var JwtConfig = new(Jwt)

--- a/sdk/pkg/jwtauth/jwtauth.go
+++ b/sdk/pkg/jwtauth/jwtauth.go
@@ -527,7 +527,16 @@ func (mw *GinJWTMiddleware) RefreshToken(c *gin.Context) (string, time.Time, err
 
 	expire := mw.TimeFunc().Add(mw.Timeout)
 	newClaims["exp"] = expire.Unix()
-	newClaims["orig_iat"] = mw.TimeFunc().Unix()
+
+	// orig_iat 保持首次签发时的值，不随续期更新。
+	//
+	// CheckIfTokenExpire 用 orig_iat 判断是否超出 MaxRefresh 上限；此处若重置
+	// 它，上限的计时起点会随每次续期后移，MaxRefresh 永远无法到达 —— token
+	// 可被无限续期，泄露后等同于永久访问权（issue go-admin-team/go-admin#820）。
+	//
+	// 上面的拷贝循环已将 orig_iat 带入 newClaims，且 CheckIfTokenExpire 会在
+	// 缺失该字段时直接返回错误，因此此处无需再赋值。
+
 	tokenString, err := mw.signedString(newToken)
 
 	if err != nil {

--- a/sdk/pkg/jwtauth/jwtauth_test.go
+++ b/sdk/pkg/jwtauth/jwtauth_test.go
@@ -1,0 +1,175 @@
+package jwtauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+)
+
+// 这些测试锁定 token 续期的生命周期上限。
+//
+// 缺陷背景：RefreshToken 此前在生成新 token 时把 orig_iat 重置为当前时间，
+// 而 CheckIfTokenExpire 正是依据 orig_iat 判断是否超出 MaxRefresh。两者相互
+// 抵消，使 MaxRefresh 永远无法到达，token 可被无限续期
+// （issue go-admin-team/go-admin#820）。
+
+const testKey = "test-secret-key-for-jwtauth"
+
+// newTestMiddleware 构造一个时间可控的中间件，避免测试依赖真实时钟
+func newTestMiddleware(now func() time.Time, timeout, maxRefresh time.Duration) *GinJWTMiddleware {
+	return &GinJWTMiddleware{
+		Realm:            "test",
+		Key:              []byte(testKey),
+		SigningAlgorithm: "HS256",
+		Timeout:          timeout,
+		MaxRefresh:       maxRefresh,
+		TimeFunc:         now,
+		TokenLookup:      "header: Authorization",
+		TokenHeadName:    "Bearer",
+	}
+}
+
+// makeToken 直接签发一个带指定 orig_iat 的 token，模拟「签发于某个时刻」
+func makeToken(t *testing.T, mw *GinJWTMiddleware, origIat, exp time.Time) string {
+	t.Helper()
+	token := jwt.New(jwt.GetSigningMethod(mw.SigningAlgorithm))
+	claims := token.Claims.(jwt.MapClaims)
+	claims["identity"] = "tester"
+	claims["exp"] = exp.Unix()
+	claims["orig_iat"] = origIat.Unix()
+
+	s, err := token.SignedString(mw.Key)
+	if err != nil {
+		t.Fatalf("签发测试 token 失败: %v", err)
+	}
+	return s
+}
+
+// ctxWithToken 构造一个携带 token 的请求上下文
+func ctxWithToken(token string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodGet, "/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	c.Request = req
+	return c
+}
+
+func origIatOf(t *testing.T, mw *GinJWTMiddleware, tokenString string) int64 {
+	t.Helper()
+	parsed, err := jwt.Parse(tokenString, func(*jwt.Token) (interface{}, error) {
+		return mw.Key, nil
+	})
+	// token 可能已过期，过期不影响读取 claims
+	if parsed == nil {
+		t.Fatalf("解析 token 失败: %v", err)
+	}
+	claims := MapClaims(parsed.Claims.(jwt.MapClaims))
+	v, err := claims.OrigIat()
+	if err != nil {
+		t.Fatalf("读取 orig_iat 失败: %v", err)
+	}
+	return v
+}
+
+// 续期后 orig_iat 必须保持不变 —— 它是 MaxRefresh 的计时起点
+func TestRefreshTokenKeepsOrigIat(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := base
+	mw := newTestMiddleware(func() time.Time { return now }, time.Hour, 24*time.Hour)
+
+	original := makeToken(t, mw, base, base.Add(time.Hour))
+
+	// 30 分钟后续期
+	now = base.Add(30 * time.Minute)
+	refreshed, _, err := mw.RefreshToken(ctxWithToken(original))
+	if err != nil {
+		t.Fatalf("续期失败: %v", err)
+	}
+
+	if got, want := origIatOf(t, mw, refreshed), base.Unix(); got != want {
+		t.Errorf("orig_iat 被重置了：got %d, want %d（续期不应改变首次签发时间）", got, want)
+	}
+}
+
+// 超出 MaxRefresh 后必须拒绝续期。
+// 这是缺陷的核心：修复前无论经过多久，只要持续续期就永远不会被拒绝。
+func TestRefreshTokenRejectedAfterMaxRefresh(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := base
+	const maxRefresh = 2 * time.Hour
+	mw := newTestMiddleware(func() time.Time { return now }, time.Hour, maxRefresh)
+
+	token := makeToken(t, mw, base, base.Add(time.Hour))
+
+	// 每 30 分钟续期一次，持续 4 小时 —— 远超 2 小时的 MaxRefresh
+	var lastErr error
+	for elapsed := 30 * time.Minute; elapsed <= 4*time.Hour; elapsed += 30 * time.Minute {
+		now = base.Add(elapsed)
+
+		newToken, _, err := mw.RefreshToken(ctxWithToken(token))
+		if err != nil {
+			lastErr = err
+			break
+		}
+		token = newToken
+	}
+
+	if lastErr == nil {
+		t.Fatal("token 在超出 MaxRefresh 后仍可续期 —— 上限失效，可被无限续期")
+	}
+	if lastErr != ErrExpiredToken {
+		t.Errorf("期望 ErrExpiredToken，实际为 %v", lastErr)
+	}
+}
+
+// MaxRefresh 之内应当允许续期，确保修复没有把正常续期一并禁掉
+func TestRefreshTokenAllowedWithinMaxRefresh(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := base
+	mw := newTestMiddleware(func() time.Time { return now }, time.Hour, 24*time.Hour)
+
+	token := makeToken(t, mw, base, base.Add(time.Hour))
+
+	// 即使原 token 已过期（超过 Timeout），只要在 MaxRefresh 内仍可续期
+	now = base.Add(90 * time.Minute)
+	if _, _, err := mw.RefreshToken(ctxWithToken(token)); err != nil {
+		t.Fatalf("MaxRefresh 之内的续期被拒绝: %v", err)
+	}
+}
+
+// 续期必须刷新 exp，否则新 token 一签发就是过期的
+func TestRefreshTokenExtendsExpiry(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	now := base
+	const timeout = time.Hour
+	mw := newTestMiddleware(func() time.Time { return now }, timeout, 24*time.Hour)
+
+	token := makeToken(t, mw, base, base.Add(timeout))
+
+	now = base.Add(30 * time.Minute)
+	refreshed, expire, err := mw.RefreshToken(ctxWithToken(token))
+	if err != nil {
+		t.Fatalf("续期失败: %v", err)
+	}
+
+	if want := now.Add(timeout); !expire.Equal(want) {
+		t.Errorf("过期时间未按当前时刻顺延：got %v, want %v", expire, want)
+	}
+
+	parsed, _ := jwt.Parse(refreshed, func(*jwt.Token) (interface{}, error) {
+		return mw.Key, nil
+	})
+	claims := parsed.Claims.(jwt.MapClaims)
+	if got := int64(claims["exp"].(float64)); got != want(now, timeout) {
+		t.Errorf("token 中的 exp 不正确：got %d, want %d", got, want(now, timeout))
+	}
+}
+
+func want(now time.Time, timeout time.Duration) int64 {
+	return now.Add(timeout).Unix()
+}


### PR DESCRIPTION
## 问题

`RefreshToken` 在生成新 token 时把 `orig_iat` 重置为当前时间，而
`CheckIfTokenExpire` 正是依据 `orig_iat` 判断是否超出 `MaxRefresh`：

```go
// RefreshToken (jwtauth.go)
for key := range claims {
    newClaims[key] = claims[key]        // orig_iat 已拷贝过来
}
newClaims["exp"] = expire.Unix()
newClaims["orig_iat"] = mw.TimeFunc().Unix()   // ← 又覆盖成当前时间
```

```go
// CheckIfTokenExpire (jwtauth.go)
if origIat < mw.TimeFunc().Add(-mw.MaxRefresh).Unix() {
    return nil, ErrExpiredToken
}
```

两者相互抵消：只要在 `MaxRefresh` 窗口内调用一次续期，计时起点就回到当前
时刻，**上限永远无法到达**。

`MaxRefresh` 的语义因此从「一个 token 最多能续期这么久」退化为「两次续期
的最大间隔」，实际不再构成任何上限。

### 与自身文档矛盾

`MaxRefresh` 字段的注释写着：

> This means that the maximum validity timespan for a token is **TokenTime + MaxRefresh**.

实际行为与之直接冲突。这不是设计取舍，是缺陷。

### 影响

攻击者取得任意一个有效 token 后（XSS、日志泄露、客户端存储读取等），只需
周期性调用续期接口即可无限期维持访问。即便管理员改了密码、禁用了该用户，
只要持续续期，访问不会中断。

本库**没有任何吊销机制**（检索 blacklist / revoke 相关实现为 0 处），
防守方无法在服务端切断该会话 —— 而本缺陷恰好让「自然过期」不会发生。

相关 issue：go-admin-team/go-admin#820（2024-10-29 由 @dangweiwu 报告）

## 修复

移除续期时对 `orig_iat` 的重置。上方的 claims 拷贝循环已将其带入新 token，
且 `CheckIfTokenExpire` 在该字段缺失时会直接返回错误，因此无需再赋值。

## 测试

本包此前**零测试**，本次补充首批四项，使用可控的 `TimeFunc`，不依赖真实时钟：

| 测试 | 锁定的约定 |
|---|---|
| `TestRefreshTokenKeepsOrigIat` | 续期后 `orig_iat` 保持不变 |
| `TestRefreshTokenRejectedAfterMaxRefresh` | 超出上限后拒绝续期，返回 `ErrExpiredToken` |
| `TestRefreshTokenAllowedWithinMaxRefresh` | 上限之内允许续期（即使原 token 已过 `Timeout`） |
| `TestRefreshTokenExtendsExpiry` | 续期正确顺延 `exp` |

**已验证测试能捕获该缺陷** —— 将修复还原后重跑：

```
--- FAIL: TestRefreshTokenKeepsOrigIat
    orig_iat 被重置了：got 1767227400, want 1767225600
--- FAIL: TestRefreshTokenRejectedAfterMaxRefresh
    token 在超出 MaxRefresh 后仍可续期 —— 上限失效，可被无限续期
```

## 行为变更

token 自首次签发起最长存活 `Timeout + MaxRefresh`，此后必须重新登录。

依赖长期免登录的使用者应**调大 `MaxRefresh`**，而不是回退此修复。
下游 go-admin 目前将其硬编码为 `time.Hour`（`common/middleware/auth.go`），
建议同步改为可配置。

## 两处本 PR 未处理的发现

1. **`go vet` 报告 `claims.go:63` 存在既有缺陷** —— `fmt.Errorf(...)` 构造
   了错误却丢弃，等于空操作，遇到不支持的 claim 类型时静默返回空串。与本
   修复无关，未混入，可另行处理
2. **本仓库没有任何 CI**（无 `.github/workflows`），且 `.gitignore` 忽略了
   `go.sum`。新增的测试目前只能靠人工执行

## 后续

上游 `appleboy/gin-jwt` 已改为真正的双 token 设计（独立的 refresh token +
`TokenStore` 接口 + 刷新时吊销旧 token），一并解决了吊销缺失的问题。本库
是其旧分叉（747 行 vs 上游 1259 行），长期看应考虑回归上游而非自行补齐。
本 PR 只做最小缺陷修复，不阻塞该讨论。