### PR TITLE
fix🐛: 续期时保留 orig_iat，修复 token 可无限续期

### DIFF
--- a/jwtauth/jwtauth.go
+++ b/jwtauth/jwtauth.go
@@ -539,7 +539,16 @@ func (mw *GinJWTMiddleware) RefreshToken(c *gin.Context) (string, time.Time, err
 
 	expire := mw.TimeFunc().Add(mw.Timeout)
 	newClaims["exp"] = expire.Unix()
-	newClaims["orig_iat"] = mw.TimeFunc().Unix()
+
+	// orig_iat 保持首次签发时的值，不随续期更新。
+	//
+	// CheckIfTokenExpire 用 orig_iat 判断是否超出 MaxRefresh 上限；此处若重置
+	// 它，上限的计时起点会随每次续期后移，MaxRefresh 永远无法到达 —— token
+	// 可被无限续期，泄露后等同于永久访问权（issue go-admin-team/go-admin#820）。
+	//
+	// 上面的拷贝循环已将 orig_iat 带入 newClaims，且 CheckIfTokenExpire 会在
+	// 缺失该字段时直接返回错误，因此此处无需再赋值。
+
 	tokenString, err := mw.signedString(newToken)
 
 	if err != nil {

--- a/jwtauth/jwtauth_refresh_test.go
+++ b/jwtauth/jwtauth_refresh_test.go
@@ -1,0 +1,180 @@
+package jwtauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// 这些测试锁定 token 续期的生命周期上限。
+//
+// 缺陷背景：RefreshToken 此前在生成新 token 时把 orig_iat 重置为当前时间，
+// 而 CheckIfTokenExpire 正是依据 orig_iat 判断是否超出 MaxRefresh。两者相互
+// 抵消，使 MaxRefresh 永远无法到达，token 可被无限续期
+// （issue go-admin-team/go-admin#820）。
+//
+// 关于时间：ParseTokenString 调用 jwt.Parse 时未传入 jwt.WithTimeFunc，
+// 因此 exp 始终按真实时钟校验，mw.TimeFunc 只影响 MaxRefresh 的判定。
+// 测试据此以真实时间为基准，并将 Timeout 取得足够长，使 token 在真实时钟
+// 下始终有效，从而把被测行为限定在 MaxRefresh 这一条路径上。
+
+const (
+	refreshTestKey = "test-secret-key-for-jwtauth-refresh"
+	// 远长于测试模拟的时间跨度，确保 exp 在真实时钟下不会到期
+	refreshTestTimeout = 72 * time.Hour
+)
+
+// newRefreshTestMiddleware 构造时钟可控的中间件
+func newRefreshTestMiddleware(now func() time.Time, maxRefresh time.Duration) *GinJWTMiddleware {
+	return &GinJWTMiddleware{
+		Realm:            "test",
+		Key:              []byte(refreshTestKey),
+		SigningAlgorithm: "HS256",
+		Timeout:          refreshTestTimeout,
+		MaxRefresh:       maxRefresh,
+		TimeFunc:         now,
+		TokenLookup:      "header: Authorization",
+		TokenHeadName:    "Bearer",
+	}
+}
+
+// issueToken 签发一个带指定 orig_iat 的 token，模拟「签发于某个时刻」
+func issueToken(t *testing.T, mw *GinJWTMiddleware, origIat time.Time) string {
+	t.Helper()
+	token := jwt.New(jwt.GetSigningMethod(mw.SigningAlgorithm))
+	claims := token.Claims.(jwt.MapClaims)
+	claims["identity"] = "tester"
+	claims["exp"] = origIat.Add(refreshTestTimeout).Unix()
+	claims["orig_iat"] = origIat.Unix()
+
+	s, err := token.SignedString(mw.Key)
+	if err != nil {
+		t.Fatalf("签发测试 token 失败: %v", err)
+	}
+	return s
+}
+
+// requestWithToken 构造携带 token 的请求上下文
+func requestWithToken(token string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	req := httptest.NewRequest(http.MethodGet, "/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	c.Request = req
+	return c
+}
+
+// claimsOf 解析 token 取出 claims，跳过时间校验
+func claimsOf(t *testing.T, mw *GinJWTMiddleware, tokenString string) jwt.MapClaims {
+	t.Helper()
+	parsed, err := jwt.Parse(
+		tokenString,
+		func(*jwt.Token) (interface{}, error) { return mw.Key, nil },
+		jwt.WithoutClaimsValidation(),
+	)
+	if err != nil {
+		t.Fatalf("解析 token 失败: %v", err)
+	}
+	return parsed.Claims.(jwt.MapClaims)
+}
+
+// 续期后 orig_iat 必须保持不变 —— 它是 MaxRefresh 的计时起点
+func TestRefreshTokenKeepsOrigIat(t *testing.T) {
+	base := time.Now()
+	now := base
+	mw := newRefreshTestMiddleware(func() time.Time { return now }, 24*time.Hour)
+
+	original := issueToken(t, mw, base)
+
+	// 模拟 30 分钟后续期
+	now = base.Add(30 * time.Minute)
+	refreshed, _, err := mw.RefreshToken(requestWithToken(original))
+	if err != nil {
+		t.Fatalf("续期失败: %v", err)
+	}
+
+	got := int64(claimsOf(t, mw, refreshed)["orig_iat"].(float64))
+	if got != base.Unix() {
+		t.Errorf("orig_iat 被重置了：got %d, want %d（续期不应改变首次签发时间）", got, base.Unix())
+	}
+}
+
+// 超出 MaxRefresh 后必须拒绝续期。
+// 这是缺陷的核心：修复前无论经过多久，只要持续续期就永远不会被拒绝。
+func TestRefreshTokenRejectedAfterMaxRefresh(t *testing.T) {
+	base := time.Now()
+	now := base
+	const maxRefresh = 2 * time.Hour
+	mw := newRefreshTestMiddleware(func() time.Time { return now }, maxRefresh)
+
+	token := issueToken(t, mw, base)
+
+	// 每 30 分钟续期一次，持续 4 小时 —— 远超 2 小时的上限
+	var lastErr error
+	for elapsed := 30 * time.Minute; elapsed <= 4*time.Hour; elapsed += 30 * time.Minute {
+		now = base.Add(elapsed)
+
+		newToken, _, err := mw.RefreshToken(requestWithToken(token))
+		if err != nil {
+			lastErr = err
+			break
+		}
+		token = newToken
+	}
+
+	if lastErr == nil {
+		t.Fatal("token 在超出 MaxRefresh 后仍可续期 —— 上限失效，可被无限续期")
+	}
+	if lastErr != ErrExpiredToken {
+		t.Errorf("期望 ErrExpiredToken，实际为 %v", lastErr)
+	}
+}
+
+// MaxRefresh 之内应当允许续期，确保修复没有把正常续期一并禁掉
+func TestRefreshTokenAllowedWithinMaxRefresh(t *testing.T) {
+	base := time.Now()
+	now := base
+	mw := newRefreshTestMiddleware(func() time.Time { return now }, 24*time.Hour)
+
+	token := issueToken(t, mw, base)
+
+	// 连续三次续期，均在上限之内，都应成功
+	for i := 1; i <= 3; i++ {
+		now = base.Add(time.Duration(i) * 30 * time.Minute)
+
+		newToken, _, err := mw.RefreshToken(requestWithToken(token))
+		if err != nil {
+			t.Fatalf("第 %d 次续期被拒绝（仍在 MaxRefresh 之内）: %v", i, err)
+		}
+		token = newToken
+	}
+}
+
+// 续期必须顺延 exp，否则新 token 一签发就是过期的
+func TestRefreshTokenExtendsExpiry(t *testing.T) {
+	base := time.Now()
+	now := base
+	mw := newRefreshTestMiddleware(func() time.Time { return now }, 24*time.Hour)
+
+	token := issueToken(t, mw, base)
+
+	now = base.Add(30 * time.Minute)
+	refreshed, expire, err := mw.RefreshToken(requestWithToken(token))
+	if err != nil {
+		t.Fatalf("续期失败: %v", err)
+	}
+
+	wantExp := now.Add(refreshTestTimeout)
+	if !expire.Equal(wantExp) {
+		t.Errorf("返回的过期时间不正确：got %v, want %v", expire, wantExp)
+	}
+
+	got := int64(claimsOf(t, mw, refreshed)["exp"].(float64))
+	if got != wantExp.Unix() {
+		t.Errorf("token 中的 exp 不正确：got %d, want %d", got, wantExp.Unix())
+	}
+}

--- a/sdk/config/jwt.go
+++ b/sdk/config/jwt.go
@@ -1,8 +1,16 @@
 package config
 
 type Jwt struct {
-	Secret  string
+	Secret string
+	// Timeout token 有效期，单位：秒
 	Timeout int64
+	// MaxRefresh 续期上限，单位：秒。
+	//
+	// 自 token 首次签发起计算，超过该时长后不再允许续期，必须重新登录。
+	// 一个 token 的最长存活时间为 Timeout + MaxRefresh。
+	//
+	// 为 0 时由使用方决定默认值，本结构不做兜底。
+	MaxRefresh int64
 }
 
 var JwtConfig = new(Jwt)


### PR DESCRIPTION
> 本 PR 基于 `dev`。此前误开在 `master` 上（#91，已关闭）—— 该分支最新提交停在 2022-11，实际维护的是 `dev`。

## 问题

`RefreshToken` 在生成新 token 时把 `orig_iat` 重置为当前时间，而
`CheckIfTokenExpire` 正是依据 `orig_iat` 判断是否超出 `MaxRefresh`：

```go
// RefreshToken (jwtauth/jwtauth.go)
for key := range claims {
    newClaims[key] = claims[key]        // orig_iat 已拷贝过来
}
newClaims["exp"] = expire.Unix()
newClaims["orig_iat"] = mw.TimeFunc().Unix()   // ← 又覆盖成当前时间
```

```go
// CheckIfTokenExpire
if origIat < mw.TimeFunc().Add(-mw.MaxRefresh).Unix() {
    return nil, ErrExpiredToken
}
```

两者相互抵消：只要在窗口内续期一次，计时起点就回到当前时刻，**上限永远无法
到达**。`MaxRefresh` 的语义从「一个 token 最多能续期这么久」退化为「两次续期
的最大间隔」。

### 与自身文档矛盾

`MaxRefresh` 字段注释写着：

> This means that the maximum validity timespan for a token is **TokenTime + MaxRefresh**.

实际行为与之直接冲突。这不是设计取舍，是缺陷。

### 影响

攻击者取得任意一个有效 token 后，只需周期性调用续期接口即可无限期维持访问。
即便管理员改了密码、禁用了该用户，只要持续续期，访问不会中断。本库**没有任何
吊销机制**，防守方无法在服务端切断该会话 —— 而本缺陷恰好让「自然过期」不会发生。

相关 issue：go-admin-team/go-admin#820（2024-10-29 由 @dangweiwu 报告，已公开近两年）

## 改动

| 提交 | 内容 |
|---|---|
| `fix🐛` | 移除续期时对 `orig_iat` 的重置 + 四项测试 |
| `feat✨` | `sdk/config/jwt.go` 新增 `MaxRefresh` 配置项 |

### 为什么同时加配置项

修复使 `MaxRefresh` 恢复为真正的上限后，该值必须可调。下游 go-admin 目前将其
**硬编码为 `time.Hour`**，用户无处修改。

若不提供配置，修复发布后依赖长期免登录的使用者会因突然频繁掉登录而回退版本，
反而使漏洞继续存在。

## 测试

本包此前无针对续期的测试，本次补充四项：

| 测试 | 锁定的约定 |
|---|---|
| `TestRefreshTokenKeepsOrigIat` | 续期后 `orig_iat` 保持不变 |
| `TestRefreshTokenRejectedAfterMaxRefresh` | 超出上限后返回 `ErrExpiredToken` |
| `TestRefreshTokenAllowedWithinMaxRefresh` | 上限之内允许连续续期 |
| `TestRefreshTokenExtendsExpiry` | 续期正确顺延 `exp` |

**已验证测试能捕获该缺陷** —— 将修复还原后重跑：

```
--- FAIL: TestRefreshTokenKeepsOrigIat
    orig_iat 被重置了：got 1786879286, want 1786877486
--- FAIL: TestRefreshTokenRejectedAfterMaxRefresh
    token 在超出 MaxRefresh 后仍可续期 —— 上限失效，可被无限续期
```

### 一处与测试设计相关的发现

`ParseTokenString` 调用 `jwt.Parse` 时**未传入 `jwt.WithTimeFunc(mw.TimeFunc)`**，
因此 `exp` 始终按真实时钟校验，`TimeFunc` 只影响 `MaxRefresh` 判定。这与
`TimeFunc` 的文档描述（"useful for testing"）不完全一致。

本 PR 未改动该行为（会影响既有语义），测试据此以真实时间为基准并取较长的
`Timeout`，将被测行为限定在 `MaxRefresh` 一条路径上。

## 行为变更

token 自首次签发起最长存活 `Timeout + MaxRefresh`，此后必须重新登录。

依赖长期免登录的使用者应**调大 `MaxRefresh`**，而不是回退此修复。

## 后续

上游 `appleboy/gin-jwt` 已改为真正的双 token 设计（独立 refresh token +
`TokenStore` 接口 + 刷新时吊销旧 token），一并解决了吊销缺失的问题。本库是其
旧分叉，长期看应考虑回归上游。本 PR 只做最小缺陷修复，不阻塞该讨论。