### PR TITLE
fix🐛: 内存队列满时不再泄漏 goroutine

### DIFF
--- a/storage/queue/memory.go
+++ b/storage/queue/memory.go
@@ -1,6 +1,8 @@
 package queue
 
 import (
+	"fmt"
+	"log"
 	"sync"
 	"time"
 
@@ -61,10 +63,21 @@ func (m *Memory) Append(message storage.Messager) error {
 		q = m.makeQueue()
 		m.queue.Store(message.GetStream(), q)
 	}
-	go func(gm storage.Messager, gq queue) {
-		gm.SetID(uuid.New().String())
-		gq <- gm
-	}(memoryMessage, q)
+	// 不再为每条消息起 goroutine 投递。
+	//
+	// 原实现中，队列满时 goroutine 会阻塞在 channel 写入上且永不退出；
+	// 只要生产速度长期高于消费速度，goroutine 就会无上限累积，最终 OOM。
+	// 日志走的正是这条队列，高频写日志的服务尤其容易触发。
+	//
+	// 改为非阻塞投递：队列满时立即丢弃该消息并返回错误，由调用方决定如何
+	// 处理，而不是把压力转成不可见的 goroutine 泄漏。
+	memoryMessage.SetID(uuid.New().String())
+	select {
+	case q <- memoryMessage:
+	default:
+		log.Printf("memory queue for stream %s is full, dropping message", message.GetStream())
+		return fmt.Errorf("memory queue for stream %s is full", message.GetStream())
+	}
 	return nil
 }
 
@@ -110,7 +123,7 @@ func (m *Memory) Run() {
 	}
 	m.running = true
 	m.mutex.Unlock()
-	
+
 	m.wait.Add(1)
 	m.wait.Wait()
 }
@@ -118,7 +131,7 @@ func (m *Memory) Run() {
 func (m *Memory) Shutdown() {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	
+
 	// 只有在运行状态才调用 Done()
 	if m.running {
 		m.running = false

--- a/storage/queue/memory_leak_test.go
+++ b/storage/queue/memory_leak_test.go
@@ -1,0 +1,78 @@
+package queue
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+)
+
+// 这些测试锁定「队列写满时不得泄漏 goroutine」这一约定。
+//
+// 缺陷背景：Append 原本为每条消息启动一个 goroutine 执行 channel 写入。
+// 队列满时该 goroutine 永久阻塞且无法退出，只要生产速度长期高于消费速度，
+// goroutine 就会无上限累积直至 OOM。日志正是走的这条队列。
+// 由 @Hemingway-ai 通过 pprof 定位（PR #89）。
+
+func newTestMessage(stream string) storage.Messager {
+	m := new(Message)
+	m.SetStream(stream)
+	m.SetValues(map[string]interface{}{"k": "v"})
+	return m
+}
+
+// 向已满的队列持续投递，goroutine 数量不得随投递次数增长
+func TestAppendDoesNotLeakGoroutines(t *testing.T) {
+	// 容量为 1，投递第二条起队列即满
+	m := NewMemory(1)
+
+	if err := m.Append(newTestMessage("leak")); err != nil {
+		t.Fatalf("首次投递不应失败: %v", err)
+	}
+
+	// 等待可能存在的异步投递完成，再取基线
+	time.Sleep(50 * time.Millisecond)
+	runtime.GC()
+	before := runtime.NumGoroutine()
+
+	// 队列已满，继续投递 500 条
+	for i := 0; i < 500; i++ {
+		_ = m.Append(newTestMessage("leak"))
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC()
+	after := runtime.NumGoroutine()
+
+	// 留出少量余量以容忍运行时自身的 goroutine 波动
+	if after-before > 10 {
+		t.Errorf("投递 500 条消息后 goroutine 增加了 %d 个（%d → %d），存在泄漏",
+			after-before, before, after)
+	}
+}
+
+// 队列满时必须返回错误，而不是静默积压
+func TestAppendReturnsErrorWhenFull(t *testing.T) {
+	m := NewMemory(1)
+
+	if err := m.Append(newTestMessage("full")); err != nil {
+		t.Fatalf("首次投递不应失败: %v", err)
+	}
+
+	// 容量已用尽
+	if err := m.Append(newTestMessage("full")); err == nil {
+		t.Error("队列已满时 Append 返回了 nil，调用方无从得知消息被丢弃")
+	}
+}
+
+// 未满时应正常投递并返回 nil
+func TestAppendSucceedsWhenNotFull(t *testing.T) {
+	m := NewMemory(8)
+
+	for i := 0; i < 8; i++ {
+		if err := m.Append(newTestMessage("ok")); err != nil {
+			t.Fatalf("第 %d 次投递失败（容量 8，不应满）: %v", i+1, err)
+		}
+	}
+}


### PR DESCRIPTION
移植 #89 的修复到 `main`。原 PR 由 @Hemingway-ai 通过 pprof 定位并提交，但基于已停止维护的 `master` 分支 —— 改 base 后会连带引入 118 行 master 血脉的无关改动（含已废弃的 `sdk/pkg/jwtauth`），因此在此重新提交，保留 `Co-authored-by` 署名。

## 问题

`Append` 为每条消息启动一个 goroutine 执行 channel 写入：

```go
go func(gm storage.Messager, gq queue) {
    gm.SetID(uuid.New().String())
    gq <- gm          // ← 队列满时在此永久阻塞
}(memoryMessage, q)
return nil            // ← 且始终返回 nil
```

队列满时该 goroutine 阻塞且无法退出。只要生产速度长期高于消费速度，goroutine
就会无上限累积直至 OOM。**日志正是走的这条队列**，高频写日志的服务尤其容易触发。

该缺陷在 `main` 上原封不动地存在（代码与 `master` 一字不差）。

## 修复

改为非阻塞投递，队列满时丢弃并返回错误：

```go
memoryMessage.SetID(uuid.New().String())
select {
case q <- memoryMessage:
default:
    log.Printf("memory queue for stream %s is full, dropping message", message.GetStream())
    return fmt.Errorf("memory queue for stream %s is full", message.GetStream())
}
```

## 测试

| 测试 | 锁定的约定 |
|---|---|
| `TestAppendDoesNotLeakGoroutines` | 满队列下连续投递 500 条，goroutine 不得增长 |
| `TestAppendReturnsErrorWhenFull` | 队列满时必须返回错误 |
| `TestAppendSucceedsWhenNotFull` | 未满时正常投递 |

**已验证测试能捕获该缺陷** —— 还原为原 goroutine 写法后：

```
--- FAIL: TestAppendDoesNotLeakGoroutines
    投递 500 条消息后 goroutine 增加了 500 个（2 → 502），存在泄漏
--- FAIL: TestAppendReturnsErrorWhenFull
    队列已满时 Append 返回了 nil，调用方无从得知消息被丢弃
```

500 条消息对应 500 个泄漏的 goroutine，一比一。

## 行为变更

队列满时 `Append` 由静默返回 `nil` 改为返回错误。此前消息同样没有被处理，
只是调用方无从得知 —— 现在至少可感知并决定如何应对。

## 关于 #89

建议合并本 PR 后关闭 #89，并在其中说明原因。修复方案完全采用其提交内容。