### PR TITLE
docs📝: 更正 README 中过时的依赖与版本信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@
 - **Production-Ready Config** - Built-in best practices (async + sampling + sanitization)
 - **Concurrency Safe** - Verified with Race Detector, zero data races
 
+### 🔐 JWT Authentication
+
+- **Gin middleware** - Login, refresh and identity handling for Gin applications
+- **Bounded token lifetime** - `MaxRefresh` caps how long a token may be renewed
+  for, measured from its original issuance
+- **Configurable** - `Timeout` and `MaxRefresh` are both driven by configuration
+
 ### 🚀 Other Components
 
 - [x] Cache component (memory support)
@@ -23,7 +30,7 @@
 - [x] Configuration management (multiple data sources)
 - [x] Log writer (file rotation support)
 
-> **Latest Version:** Go 1.25.1 | 119 dependencies upgraded | 35 unit tests + 30+ performance benchmarks
+> **Latest Version:** Go 1.25 | 35 unit tests + 30+ performance benchmarks
 
 ---
 
@@ -35,7 +42,7 @@
 go get -u github.com/go-admin-team/go-admin-core
 ```
 
-**System Requirements:** Go 1.25.1 or higher
+**System Requirements:** Go 1.25 or higher (see the `go` directive in `go.mod`)
 
 ### Basic Logging
 
@@ -173,12 +180,16 @@ go test ./logger -race
 ## 📦 Main Dependencies
 
 ```go
-github.com/casbin/casbin/v2         v2.135.0
+github.com/casbin/casbin/v3         v3.8.1
 github.com/gin-gonic/gin            v1.11.0
+github.com/golang-jwt/jwt/v5        v5.3.0
 gorm.io/gorm                        v1.31.1
-github.com/sirupsen/logrus          v1.9.3
+github.com/sirupsen/logrus          v1.9.4
 golang.org/x/crypto                 v0.47.0
 ```
+
+Versions above reflect `go.mod` at the time of writing; that file is the source
+of truth.
 
 ---
 
@@ -187,10 +198,20 @@ golang.org/x/crypto                 v0.47.0
 We welcome Issues and Pull Requests!
 
 1. Fork this repository
-2. Create your feature branch (`git checkout -b feature/AmazingFeature`)
+2. Create your feature branch from `main` (`git checkout -b feature/AmazingFeature`)
 3. Commit your changes (`git commit -m 'Add some AmazingFeature'`)
 4. Push to the branch (`git push origin feature/AmazingFeature`)
-5. Open a Pull Request
+5. Open a Pull Request **against `main`**
+
+> **Branches:** `main` is the only active branch and the source of every release.
+> `master` and `dev` are historical and no longer accept changes — `master` in
+> particular has not moved since 2022 and was never part of the release lineage.
+
+### Reporting a vulnerability
+
+Please do not open a public issue for security problems. Use
+[private vulnerability reporting](https://github.com/go-admin-team/go-admin-core/security/advisories/new)
+instead.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,12 @@
 - **生产级配置** - 内置最佳实践配置（异步 + 采样 + 脱敏）
 - **并发安全** - Race Detector 验证通过，零数据竞争
 
+### 🔐 JWT 认证
+
+- **Gin 中间件** — 为 Gin 应用提供登录、续期与身份解析
+- **有界的令牌生命周期** — `MaxRefresh` 限定令牌可被续期的总时长，自首次签发起计算
+- **可配置** — `Timeout` 与 `MaxRefresh` 均由配置驱动
+
 ### 🚀 其他组件
 
 - [x] 缓存组件（支持 memory）
@@ -23,7 +29,7 @@
 - [x] 配置管理（支持多种数据源）
 - [x] 日志写入器（支持文件分割）
 
-> **最新版本:** Go 1.25.1 | 119 个依赖包已升级 | 35 个单元测试 + 30+ 性能基准测试
+> **最新版本:** Go 1.25 | 35 个单元测试 + 30+ 性能基准测试
 
 ---
 
@@ -35,7 +41,7 @@
 go get -u github.com/go-admin-team/go-admin-core
 ```
 
-**系统要求:** Go 1.25.1 或更高版本
+**系统要求:** Go 1.25 或更高版本（以 `go.mod` 中的 `go` 指令为准）
 
 ### 基础日志使用
 
@@ -173,12 +179,15 @@ go test ./logger -race
 ## 📦 主要依赖
 
 ```go
-github.com/casbin/casbin/v2         v2.135.0
+github.com/casbin/casbin/v3         v3.8.1
 github.com/gin-gonic/gin            v1.11.0
+github.com/golang-jwt/jwt/v5        v5.3.0
 gorm.io/gorm                        v1.31.1
-github.com/sirupsen/logrus          v1.9.3
+github.com/sirupsen/logrus          v1.9.4
 golang.org/x/crypto                 v0.47.0
 ```
+
+以上版本为撰写时 `go.mod` 的内容，该文件为准。
 
 ---
 
@@ -187,13 +196,35 @@ golang.org/x/crypto                 v0.47.0
 欢迎提交 Issue 和 Pull Request！
 
 1. Fork 本仓库
-2. 创建特性分支 (`git checkout -b feature/AmazingFeature`)
+2. 基于 `main` 创建特性分支 (`git checkout -b feature/AmazingFeature`)
 3. 提交更改 (`git commit -m 'Add some AmazingFeature'`)
 4. 推送到分支 (`git push origin feature/AmazingFeature`)
-5. 开启 Pull Request
+5. **向 `main` 开启 Pull Request**
+
+> **分支说明：** `main` 是唯一活跃的分支，也是所有发布版本的来源。
+> `master` 与 `dev` 均为历史分支，不再接受改动 —— 其中 `master` 自 2022 年
+> 起未再变动，且从未进入过发布线。
+
+### 漏洞报告
+
+安全问题请勿开公开 issue，改用
+[私密漏洞报告](https://github.com/go-admin-team/go-admin-core/security/advisories/new)。
 
 ---
 
 ## 📝 License
 
 Apache License 2.0 - 详见 [LICENSE](LICENSE) 文件
+
+---
+
+## 🔗 相关项目
+
+- [go-admin](https://github.com/go-admin-team/go-admin) - 基于 Gin + Vue + Element UI 的前后端分离权限管理系统
+- [go-admin-ui](https://github.com/go-admin-team/go-admin-ui) - go-admin 的前端项目
+
+---
+
+## ⭐ Star History
+
+如果这个项目对你有帮助，欢迎点一个 Star ⭐


### PR DESCRIPTION
## Problem

The **Main Dependencies** section did not match `go.mod`:

| README claimed | Actual |
|---|---|
| `casbin/v2 v2.135.0` | `casbin/v3 v3.8.1` — wrong **major** version |
| `logrus v1.9.3` | `logrus v1.9.4` |
| (missing) | `golang-jwt/jwt/v5 v5.3.0` |

System requirements stated Go 1.25.1 while the `go` directive in `go.mod` is
1.25.

The library's **JWT authentication** was not mentioned anywhere, even though
`jwtauth` is a core component and v1.7.0 just fixed a token renewal defect in it
and added a `MaxRefresh` configuration field.

## Changes

- Corrected the dependency table; added a note that `go.mod` is the source of
  truth so these numbers do not drift again
- Go requirement now points at the `go` directive rather than a specific patch
  release. The `1.25.1` in the benchmark section is left as-is — that records
  the version the benchmarks actually ran on, not a minimum
- Added a **JWT Authentication** section covering the bounded token lifetime and
  its configuration
- Contributing guide now states which branch to target, plus a private
  vulnerability reporting link

### On the branch note

Several pull requests were opened against `master` over the years, and some of
them proposed fixes that already existed on the release line — the contributors
had no way to know. `master` had not moved since 2022-11 and was never part of
that lineage. Saying so explicitly in the README should prevent a repeat.

## Chinese README

`README.zh-CN.md` receives the same corrections, and gains the **Related
Projects** and **Star History** sections that existed only in the English
version. Both files now have matching structure (25 headings each).