### PR TITLE
feat✨: add a Cache contract with a conformance suite

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -1345,6 +1345,8 @@ func (e *Server) String() string
 ## github.com/go-admin-team/go-admin-core/storage
 const (
 	PrefixKey = "__host"
+var ErrCacheClosed = errors.New("storage: cache closed")
+var ErrCacheMiss = errors.New("storage: cache miss")
 type AdapterCache interface {
 	String() string
 	Get(key string) (string, error)
@@ -1355,6 +1357,7 @@ type AdapterCache interface {
 	Increase(key string) error
 	Decrease(key string) error
 	Expire(key string, dur time.Duration) error
+func LegacyAdapter(c Cache) AdapterCache
 type AdapterLocker interface {
 	String() string
 type AdapterQueue interface {
@@ -1363,6 +1366,14 @@ type AdapterQueue interface {
 	Register(name string, f ConsumerFunc)
 	Run()
 	Shutdown()
+type Cache interface {
+	Get(ctx context.Context, key string) (string, error)
+	Set(ctx context.Context, key, val string, ttl time.Duration) error
+	Del(ctx context.Context, keys ...string) error
+	Incr(ctx context.Context, key string, delta int64) (int64, error)
+	Expire(ctx context.Context, key string, ttl time.Duration) error
+	io.Closer
+func WithPrefix(c Cache, prefix string) Cache
 type ConsumerFunc func(Messager) error
 type Messager interface {
 	SetID(string)
@@ -1377,6 +1388,15 @@ type Messager interface {
 	GetErrorCount() int
 
 ## github.com/go-admin-team/go-admin-core/storage/cache
+type MemCache struct {
+func NewMemCache() *MemCache
+func NewMemCacheWithSweep(interval time.Duration) *MemCache
+func (m *MemCache) Close() error
+func (m *MemCache) Del(ctx context.Context, keys ...string) error
+func (m *MemCache) Expire(ctx context.Context, key string, ttl time.Duration) error
+func (m *MemCache) Get(ctx context.Context, key string) (string, error)
+func (m *MemCache) Incr(ctx context.Context, key string, delta int64) (int64, error)
+func (m *MemCache) Set(ctx context.Context, key, val string, ttl time.Duration) error
 type Memory struct {
 func NewMemory() *Memory
 func NewMemoryWithCleanupInterval(interval time.Duration) *Memory
@@ -1400,6 +1420,10 @@ func (m *Message) SetID(id string)
 func (m *Message) SetPrefix(prefix string)
 func (m *Message) SetStream(stream string)
 func (m *Message) SetValues(values map[string]interface{})
+
+## github.com/go-admin-team/go-admin-core/storage/cachetest
+func Run(t *testing.T, newCache Factory)
+type Factory func(t *testing.T) storage.Cache
 
 ## github.com/go-admin-team/go-admin-core/storage/queue
 type Memory struct {

--- a/storage/cache.go
+++ b/storage/cache.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+// ErrCacheMiss reports that a key is absent.
+//
+// A key that never existed and a key that has expired are the same fact and
+// return the same error. Callers must test with errors.Is; treating any
+// non-nil error as "no data" turns a backend outage into a full cache
+// bypass and stampedes the database.
+var ErrCacheMiss = errors.New("storage: cache miss")
+
+// ErrCacheClosed is returned by operations on a closed Cache.
+var ErrCacheClosed = errors.New("storage: cache closed")
+
+// Cache is the contract for a key/value cache.
+//
+// Implementations must honour ctx cancellation and deadlines, and must not
+// swallow ctx.Err(). The context is checked first: a cancelled context yields
+// its own error even on a closed Cache, so a caller that gave up is never told
+// something else went wrong.
+type Cache interface {
+	// Get returns the value stored under key, or ErrCacheMiss when the key is
+	// absent or expired. An empty string is a legal value and is returned with
+	// a nil error.
+	Get(ctx context.Context, key string) (string, error)
+
+	// Set stores a value with a time to live. A ttl of zero or less means the
+	// entry never expires.
+	Set(ctx context.Context, key, val string, ttl time.Duration) error
+
+	// Del removes keys. Removing an absent key is not an error.
+	Del(ctx context.Context, keys ...string) error
+
+	// Incr atomically adds delta and returns the resulting value. An absent key
+	// starts from zero. delta may be negative. A key created this way has no
+	// ttl; call Expire to add one. The read-modify-write must be atomic.
+	Incr(ctx context.Context, key string, delta int64) (int64, error)
+
+	// Expire resets the time to live, returning ErrCacheMiss when the key is
+	// absent. A ttl of zero or less makes the entry permanent.
+	Expire(ctx context.Context, key string, ttl time.Duration) error
+
+	// Close releases the underlying resources. It is idempotent. Afterwards
+	// every other method returns ErrCacheClosed, unless ctx is already done,
+	// in which case the context error wins.
+	io.Closer
+}
+
+// WithPrefix returns a Cache that prefixes every key, so that several
+// applications can share one backend.
+//
+// This is a decorator rather than a method on the interface, mirroring the
+// Logger decorators already used in this repository.
+func WithPrefix(c Cache, prefix string) Cache {
+	if prefix == "" {
+		return c
+	}
+	return &prefixedCache{inner: c, prefix: prefix}
+}
+
+type prefixedCache struct {
+	inner  Cache
+	prefix string
+}
+
+func (p *prefixedCache) key(k string) string { return p.prefix + k }
+
+func (p *prefixedCache) Get(ctx context.Context, key string) (string, error) {
+	return p.inner.Get(ctx, p.key(key))
+}
+
+func (p *prefixedCache) Set(ctx context.Context, key, val string, ttl time.Duration) error {
+	return p.inner.Set(ctx, p.key(key), val, ttl)
+}
+
+func (p *prefixedCache) Del(ctx context.Context, keys ...string) error {
+	prefixed := make([]string, len(keys))
+	for i, k := range keys {
+		prefixed[i] = p.key(k)
+	}
+	return p.inner.Del(ctx, prefixed...)
+}
+
+func (p *prefixedCache) Incr(ctx context.Context, key string, delta int64) (int64, error) {
+	return p.inner.Incr(ctx, p.key(key), delta)
+}
+
+func (p *prefixedCache) Expire(ctx context.Context, key string, ttl time.Duration) error {
+	return p.inner.Expire(ctx, p.key(key), ttl)
+}
+
+func (p *prefixedCache) Close() error { return p.inner.Close() }

--- a/storage/cache/memcache.go
+++ b/storage/cache/memcache.go
@@ -1,0 +1,208 @@
+package cache
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+)
+
+const defaultSweepInterval = time.Minute
+
+type entry struct {
+	value string
+	// expiresAt is the zero time when the entry never expires.
+	expiresAt time.Time
+}
+
+func (e entry) expired(now time.Time) bool {
+	return !e.expiresAt.IsZero() && e.expiresAt.Before(now)
+}
+
+// MemCache is an in-process storage.Cache.
+//
+// A single mutex guards the map. Incr must be atomic, and sync.Map cannot
+// express a read-modify-write, which is how the previous implementation lost
+// updates under concurrency.
+type MemCache struct {
+	mu     sync.Mutex
+	items  map[string]entry
+	closed bool
+
+	stop     chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+var _ storage.Cache = (*MemCache)(nil)
+
+// NewMemCache returns a cache that sweeps expired entries every
+// defaultSweepInterval. Call Close when the instance is not process-wide.
+func NewMemCache() *MemCache {
+	return NewMemCacheWithSweep(defaultSweepInterval)
+}
+
+// NewMemCacheWithSweep sets the sweep interval. Zero or less starts no
+// sweeper, leaving expiry entirely lazy.
+func NewMemCacheWithSweep(interval time.Duration) *MemCache {
+	m := &MemCache{
+		items: make(map[string]entry),
+		stop:  make(chan struct{}),
+	}
+	if interval > 0 {
+		m.wg.Add(1)
+		go m.sweep(interval)
+	}
+	return m
+}
+
+func (m *MemCache) sweep(interval time.Duration) {
+	defer m.wg.Done()
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-t.C:
+			m.deleteExpired()
+		case <-m.stop:
+			return
+		}
+	}
+}
+
+func (m *MemCache) deleteExpired() {
+	now := time.Now()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, e := range m.items {
+		if e.expired(now) {
+			delete(m.items, k)
+		}
+	}
+}
+
+func expiry(ttl time.Duration) time.Time {
+	if ttl <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(ttl)
+}
+
+func (m *MemCache) Get(ctx context.Context, key string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return "", storage.ErrCacheClosed
+	}
+
+	e, ok := m.items[key]
+	if !ok {
+		return "", storage.ErrCacheMiss
+	}
+	if e.expired(time.Now()) {
+		delete(m.items, key)
+		return "", storage.ErrCacheMiss
+	}
+	return e.value, nil
+}
+
+func (m *MemCache) Set(ctx context.Context, key, val string, ttl time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return storage.ErrCacheClosed
+	}
+
+	m.items[key] = entry{value: val, expiresAt: expiry(ttl)}
+	return nil
+}
+
+func (m *MemCache) Del(ctx context.Context, keys ...string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return storage.ErrCacheClosed
+	}
+
+	for _, k := range keys {
+		delete(m.items, k)
+	}
+	return nil
+}
+
+func (m *MemCache) Incr(ctx context.Context, key string, delta int64) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return 0, storage.ErrCacheClosed
+	}
+
+	var current int64
+	if e, ok := m.items[key]; ok && !e.expired(time.Now()) {
+		n, err := strconv.ParseInt(e.value, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		current = n
+	}
+
+	current += delta
+	// A counter created here carries no ttl, matching Redis INCR.
+	m.items[key] = entry{value: strconv.FormatInt(current, 10)}
+	return current, nil
+}
+
+func (m *MemCache) Expire(ctx context.Context, key string, ttl time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.closed {
+		return storage.ErrCacheClosed
+	}
+
+	e, ok := m.items[key]
+	if !ok || e.expired(time.Now()) {
+		delete(m.items, key)
+		return storage.ErrCacheMiss
+	}
+
+	e.expiresAt = expiry(ttl)
+	m.items[key] = e
+	return nil
+}
+
+func (m *MemCache) Close() error {
+	m.stopOnce.Do(func() {
+		close(m.stop)
+	})
+	m.wg.Wait()
+
+	m.mu.Lock()
+	m.closed = true
+	m.items = nil
+	m.mu.Unlock()
+	return nil
+}

--- a/storage/cache/memcache_test.go
+++ b/storage/cache/memcache_test.go
@@ -1,0 +1,22 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+	"github.com/go-admin-team/go-admin-core/storage/cache"
+	"github.com/go-admin-team/go-admin-core/storage/cachetest"
+)
+
+func TestMemCacheConformance(t *testing.T) {
+	cachetest.Run(t, func(t *testing.T) storage.Cache {
+		// No sweeper: the suite asserts lazy expiry, which must hold on its own.
+		return cache.NewMemCacheWithSweep(0)
+	})
+}
+
+func TestMemCacheWithSweeperConformance(t *testing.T) {
+	cachetest.Run(t, func(t *testing.T) storage.Cache {
+		return cache.NewMemCache()
+	})
+}

--- a/storage/cachetest/cachetest.go
+++ b/storage/cachetest/cachetest.go
@@ -1,0 +1,314 @@
+// Package cachetest provides a black-box conformance suite for
+// storage.Cache implementations.
+//
+// Every implementation must pass the same suite. A contract exercised by only
+// one implementation is not a contract: the previous AdapterCache was shaped
+// around Redis, its Redis implementation was removed, and the remaining
+// in-memory one emulated the shape with string concatenation — nothing checked
+// that the two ever agreed.
+package cachetest
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+)
+
+// Factory builds a Cache for a single test. Cleanup is the caller's business;
+// the suite always calls Close.
+type Factory func(t *testing.T) storage.Cache
+
+// Run executes the full suite against the implementation built by newCache.
+func Run(t *testing.T, newCache Factory) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		fn   func(*testing.T, Factory)
+	}{
+		{"MissIsDistinguishable", testMissIsDistinguishable},
+		{"EmptyValueIsNotAMiss", testEmptyValueIsNotAMiss},
+		{"ExpiredKeyReportsMiss", testExpiredKeyReportsMiss},
+		{"ZeroTTLNeverExpires", testZeroTTLNeverExpires},
+		{"SetOverwrites", testSetOverwrites},
+		{"DelRemoves", testDelRemoves},
+		{"DelAbsentIsNotAnError", testDelAbsentIsNotAnError},
+		{"IncrFromAbsent", testIncrFromAbsent},
+		{"IncrAccumulates", testIncrAccumulates},
+		{"IncrIsAtomic", testIncrIsAtomic},
+		{"ExpireOnAbsentReportsMiss", testExpireOnAbsentReportsMiss},
+		{"ExpireShortensLifetime", testExpireShortensLifetime},
+		{"ExpireZeroMakesPermanent", testExpireZeroMakesPermanent},
+		{"CloseIsIdempotent", testCloseIsIdempotent},
+		{"UseAfterCloseReportsClosed", testUseAfterCloseReportsClosed},
+		{"ContextCancellationIsHonoured", testContextCancellationIsHonoured},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { tc.fn(t, newCache) })
+	}
+}
+
+func ctx() context.Context { return context.Background() }
+
+// The single most important property: a miss must be distinguishable from a
+// backend failure, otherwise an outage silently becomes a full cache bypass.
+func testMissIsDistinguishable(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	_, err := c.Get(ctx(), "absent")
+	if !errors.Is(err, storage.ErrCacheMiss) {
+		t.Fatalf("Get on an absent key: got %v, want ErrCacheMiss", err)
+	}
+}
+
+func testEmptyValueIsNotAMiss(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	if err := c.Set(ctx(), "empty", "", time.Minute); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	v, err := c.Get(ctx(), "empty")
+	if err != nil {
+		t.Fatalf("an empty value must not read as a miss: %v", err)
+	}
+	if v != "" {
+		t.Errorf("got %q, want an empty string", v)
+	}
+}
+
+func testExpiredKeyReportsMiss(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	if err := c.Set(ctx(), "brief", "v", 30*time.Millisecond); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		_, err := c.Get(ctx(), "brief")
+		return errors.Is(err, storage.ErrCacheMiss)
+	}, "an expired key must report ErrCacheMiss, the same error as an absent key")
+}
+
+func testZeroTTLNeverExpires(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	if err := c.Set(ctx(), "permanent", "v", 0); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	v, err := c.Get(ctx(), "permanent")
+	if err != nil {
+		t.Fatalf("a ttl of zero must mean no expiry, got %v", err)
+	}
+	if v != "v" {
+		t.Errorf("got %q, want %q", v, "v")
+	}
+}
+
+func testSetOverwrites(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	_ = c.Set(ctx(), "k", "first", time.Minute)
+	if err := c.Set(ctx(), "k", "second", time.Minute); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	v, err := c.Get(ctx(), "k")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if v != "second" {
+		t.Errorf("got %q, want %q", v, "second")
+	}
+}
+
+func testDelRemoves(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	_ = c.Set(ctx(), "a", "1", time.Minute)
+	_ = c.Set(ctx(), "b", "2", time.Minute)
+
+	if err := c.Del(ctx(), "a", "b"); err != nil {
+		t.Fatalf("Del: %v", err)
+	}
+
+	for _, k := range []string{"a", "b"} {
+		if _, err := c.Get(ctx(), k); !errors.Is(err, storage.ErrCacheMiss) {
+			t.Errorf("%q survived Del: %v", k, err)
+		}
+	}
+}
+
+func testDelAbsentIsNotAnError(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	if err := c.Del(ctx(), "never-existed"); err != nil {
+		t.Errorf("deleting an absent key must not fail: %v", err)
+	}
+}
+
+func testIncrFromAbsent(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	n, err := c.Incr(ctx(), "counter", 5)
+	if err != nil {
+		t.Fatalf("Incr: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("an absent key must start from zero: got %d, want 5", n)
+	}
+}
+
+func testIncrAccumulates(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	_, _ = c.Incr(ctx(), "counter", 10)
+	n, err := c.Incr(ctx(), "counter", -3)
+	if err != nil {
+		t.Fatalf("Incr: %v", err)
+	}
+	if n != 7 {
+		t.Errorf("got %d, want 7", n)
+	}
+}
+
+// Guards the defect the previous implementation shipped: its read-modify-write
+// was not atomic, so 200 concurrent increments landed on 151.
+func testIncrIsAtomic(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	const n = 200
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if _, err := c.Incr(ctx(), "atomic", 1); err != nil {
+				t.Errorf("Incr: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := c.Incr(ctx(), "atomic", 0)
+	if err != nil {
+		t.Fatalf("Incr: %v", err)
+	}
+	if got != n {
+		t.Errorf("lost updates: got %d after %d concurrent increments", got, n)
+	}
+}
+
+func testExpireOnAbsentReportsMiss(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	err := c.Expire(ctx(), "absent", time.Minute)
+	if !errors.Is(err, storage.ErrCacheMiss) {
+		t.Errorf("Expire on an absent key: got %v, want ErrCacheMiss", err)
+	}
+}
+
+func testExpireShortensLifetime(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	_ = c.Set(ctx(), "k", "v", time.Hour)
+	if err := c.Expire(ctx(), "k", 30*time.Millisecond); err != nil {
+		t.Fatalf("Expire: %v", err)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		_, err := c.Get(ctx(), "k")
+		return errors.Is(err, storage.ErrCacheMiss)
+	}, "Expire must shorten the lifetime")
+}
+
+func testExpireZeroMakesPermanent(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	_ = c.Set(ctx(), "k", "v", 40*time.Millisecond)
+	if err := c.Expire(ctx(), "k", 0); err != nil {
+		t.Fatalf("Expire: %v", err)
+	}
+
+	time.Sleep(80 * time.Millisecond)
+
+	if _, err := c.Get(ctx(), "k"); err != nil {
+		t.Errorf("a ttl of zero must clear the expiry, got %v", err)
+	}
+}
+
+func testCloseIsIdempotent(t *testing.T, newCache Factory) {
+	c := newCache(t)
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("second Close must be a no-op, got %v", err)
+	}
+}
+
+func testUseAfterCloseReportsClosed(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if err := c.Set(ctx(), "k", "v", time.Minute); !errors.Is(err, storage.ErrCacheClosed) {
+		t.Errorf("Set after Close: got %v, want ErrCacheClosed", err)
+	}
+	if _, err := c.Get(ctx(), "k"); !errors.Is(err, storage.ErrCacheClosed) {
+		t.Errorf("Get after Close: got %v, want ErrCacheClosed", err)
+	}
+}
+
+func testContextCancellationIsHonoured(t *testing.T, newCache Factory) {
+	c := newCache(t)
+	defer c.Close()
+
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.Set(cancelled, "k", "v", time.Minute)
+	if err == nil {
+		t.Error("Set with a cancelled context must fail")
+		return
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("got %v, want an error wrapping context.Canceled", err)
+	}
+}
+
+func waitFor(t *testing.T, limit time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(limit)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Error(strings.TrimSpace(msg))
+}

--- a/storage/legacy.go
+++ b/storage/legacy.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/spf13/cast"
+)
+
+// LegacyAdapter exposes a Cache through the older AdapterCache interface, so a
+// new backend can be adopted without touching the call sites that still take
+// AdapterCache — captcha.NewCacheStore and Runtime.SetCacheAdapter among them.
+//
+// It cannot repair the older contract, only preserve it:
+//
+//   - Get reports a miss as ("", nil), which is indistinguishable from a stored
+//     empty string. Callers that need to tell them apart must move to Cache.
+//   - HashGet and HashDel concatenate their arguments, matching the previous
+//     in-memory behaviour. That shares one flat key space with ordinary keys,
+//     so HashGet("a", "bc") and Set("abc", …) collide. The Hash family is not
+//     carried over to Cache for this reason.
+func LegacyAdapter(c Cache) AdapterCache {
+	return &legacyAdapter{inner: c}
+}
+
+type legacyAdapter struct {
+	inner Cache
+}
+
+func (l *legacyAdapter) String() string { return "legacy" }
+
+func (l *legacyAdapter) Get(key string) (string, error) {
+	v, err := l.inner.Get(context.Background(), key)
+	if errors.Is(err, ErrCacheMiss) {
+		return "", nil
+	}
+	return v, err
+}
+
+func (l *legacyAdapter) Set(key string, val interface{}, expire int) error {
+	s, err := cast.ToStringE(val)
+	if err != nil {
+		return err
+	}
+	return l.inner.Set(context.Background(), key, s, time.Duration(expire)*time.Second)
+}
+
+func (l *legacyAdapter) Del(key string) error {
+	return l.inner.Del(context.Background(), key)
+}
+
+func (l *legacyAdapter) HashGet(hk, key string) (string, error) {
+	return l.Get(hk + key)
+}
+
+func (l *legacyAdapter) HashDel(hk, key string) error {
+	return l.Del(hk + key)
+}
+
+func (l *legacyAdapter) Increase(key string) error {
+	_, err := l.inner.Incr(context.Background(), key, 1)
+	return err
+}
+
+func (l *legacyAdapter) Decrease(key string) error {
+	_, err := l.inner.Incr(context.Background(), key, -1)
+	return err
+}
+
+func (l *legacyAdapter) Expire(key string, dur time.Duration) error {
+	err := l.inner.Expire(context.Background(), key, dur)
+	if errors.Is(err, ErrCacheMiss) {
+		// The older contract reported this as a plain error.
+		return errors.New(key + " not exist")
+	}
+	return err
+}

--- a/storage/legacy_test.go
+++ b/storage/legacy_test.go
@@ -1,0 +1,60 @@
+package storage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+	"github.com/go-admin-team/go-admin-core/storage/cache"
+)
+
+// The adapter must satisfy the older contract exactly, so existing call sites
+// keep working when a new backend is put behind it.
+func TestLegacyAdapterPreservesOldContract(t *testing.T) {
+	a := storage.LegacyAdapter(cache.NewMemCacheWithSweep(0))
+
+	if err := a.Set("k", "v", 60); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if v, err := a.Get("k"); err != nil || v != "v" {
+		t.Fatalf("Get: got (%q, %v)", v, err)
+	}
+
+	// A miss is reported as an empty string with no error, as before.
+	if v, err := a.Get("absent"); err != nil || v != "" {
+		t.Errorf("miss: got (%q, %v), want (\"\", nil)", v, err)
+	}
+
+	// Set accepts non-string values through cast, as before.
+	if err := a.Set("n", 42, 60); err != nil {
+		t.Fatalf("Set(int): %v", err)
+	}
+	if err := a.Increase("n"); err != nil {
+		t.Fatalf("Increase: %v", err)
+	}
+	if v, _ := a.Get("n"); v != "43" {
+		t.Errorf("Increase: got %q, want %q", v, "43")
+	}
+	if err := a.Decrease("n"); err != nil {
+		t.Fatalf("Decrease: %v", err)
+	}
+	if v, _ := a.Get("n"); v != "42" {
+		t.Errorf("Decrease: got %q, want %q", v, "42")
+	}
+
+	if err := a.Expire("k", time.Minute); err != nil {
+		t.Errorf("Expire: %v", err)
+	}
+	if err := a.Expire("absent", time.Minute); err == nil {
+		t.Error("Expire on an absent key must fail, as before")
+	}
+
+	if err := a.Del("k"); err != nil {
+		t.Errorf("Del: %v", err)
+	}
+}
+
+// captcha.NewCacheStore takes an AdapterCache; the adapter must fit it.
+func TestLegacyAdapterSatisfiesAdapterCache(t *testing.T) {
+	var _ storage.AdapterCache = storage.LegacyAdapter(cache.NewMemCacheWithSweep(0))
+}

--- a/storage/type.go
+++ b/storage/type.go
@@ -8,6 +8,13 @@ const (
 	PrefixKey = "__host"
 )
 
+// AdapterCache is the original cache contract.
+//
+// Deprecated: use Cache. This interface cannot report a miss (Get returns an
+// empty string and a nil error for both an absent key and a stored empty
+// string), carries no context, has no Close, and its Hash family shares one
+// flat key space with ordinary keys. Wrap a Cache with LegacyAdapter to keep
+// existing call sites working. To be removed in v2.0.0.
 type AdapterCache interface {
 	String() string
 	Get(key string) (string, error)


### PR DESCRIPTION
First step of the storage rework. Redis follows in a separate pull request, since it needs a CI service container.

## Why the old contract had to be replaced

`AdapterCache` cannot express a miss. `Get` returns `("", nil)` both for an absent key and for a stored empty string, so **a backend outage is indistinguishable from a cache miss** and degrades into a full database bypass. It also carries no context, has no `Close`, mixes units (`Set` takes seconds, `Expire` a `Duration`), and its Hash family shares one flat key space with ordinary keys — `HashGet("a", "bc")` and `Set("abc", …)` collide.

## The suite is the point of this change

A contract exercised by a single implementation is not a contract. The old interface was shaped around Redis, its Redis implementation was deleted in 2024, and the remaining in-memory one emulated the shape closely enough that nothing noticed it had:

- lost updates under concurrency (200 increments landed on 151)
- expired entries written with a ttl of zero, on the next nanosecond
- reported misses as successes

`storage/cachetest` is a black-box suite of 16 cases that every implementation must pass. **Verified by reintroducing each of those three defects and confirming the suite fails** — miss semantics, `ZeroTTLNeverExpires`, and the race detector firing inside `IncrIsAtomic`.

## What is in this PR

| | |
|---|---|
| `storage.Cache` | explicit `ErrCacheMiss`, ctx honoured, `Close` in the interface, `Duration` throughout, `Incr` returns the new value and must be atomic |
| `storage/cachetest` | the conformance suite |
| `cache.MemCache` | a new implementation, not a patch — `Incr` needs a read-modify-write, which `sync.Map` cannot express |
| `storage.LegacyAdapter` | wraps a `Cache` in `AdapterCache` so existing call sites keep working unchanged |
| `storage.WithPrefix` | key namespacing as a decorator, mirroring the Logger decorators already in this repo |

The Hash family is deliberately not carried over: it was never a hash, and no consumer calls it.

`AdapterCache` is deprecated but left in place. `LegacyAdapter` means a new backend can be adopted without touching `captcha.NewCacheStore` or `Runtime.SetCacheAdapter`.

## Verification

`make ci` green, downstream canary passes. The API snapshot gate did its job: it failed until the new exported surface was committed, so every added symbol is visible in this diff.