### PR TITLE
feat✨: add a Queue contract with a conformance suite

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -1345,6 +1345,10 @@ func (e *Server) String() string
 ## github.com/go-admin-team/go-admin-core/storage
 const (
 	PrefixKey = "__host"
+var (
+	ErrQueueClosed = errors.New("storage: queue closed")
+	ErrTopicAlreadySubscribed = errors.New("storage: topic already subscribed")
+	ErrNoHandler = errors.New("storage: no handler for topic")
 var ErrCacheClosed = errors.New("storage: cache closed")
 var ErrCacheMiss = errors.New("storage: cache miss")
 type AdapterCache interface {
@@ -1375,6 +1379,12 @@ type Cache interface {
 	io.Closer
 func WithPrefix(c Cache, prefix string) Cache
 type ConsumerFunc func(Messager) error
+type Handler func(ctx context.Context, msg Message) error
+type Message struct {
+	ID string
+	Topic string
+	Values map[string]interface{}
+	Attempts int
 type Messager interface {
 	SetID(string)
 	SetStream(string)
@@ -1386,6 +1396,11 @@ type Messager interface {
 	SetPrefix(string)
 	SetErrorCount(count int)
 	GetErrorCount() int
+type Queue interface {
+	Publish(ctx context.Context, msg Message) error
+	Subscribe(topic string, h Handler) error
+	Start(ctx context.Context) error
+	io.Closer
 
 ## github.com/go-admin-team/go-admin-core/storage/cache
 type MemCache struct {
@@ -1423,9 +1438,17 @@ func (m *Message) SetValues(values map[string]interface{})
 
 ## github.com/go-admin-team/go-admin-core/storage/cachetest
 func Run(t *testing.T, newCache Factory)
+func RunQueue(t *testing.T, newQueue QueueFactory)
 type Factory func(t *testing.T) storage.Cache
+type QueueFactory func(t *testing.T) storage.Queue
 
 ## github.com/go-admin-team/go-admin-core/storage/queue
+type MemQueue struct {
+func NewMemQueue(size int) *MemQueue
+func (q *MemQueue) Close() error
+func (q *MemQueue) Publish(ctx context.Context, msg storage.Message) error
+func (q *MemQueue) Start(ctx context.Context) error
+func (q *MemQueue) Subscribe(topic string, h storage.Handler) error
 type Memory struct {
 	PoolNum uint
 func NewMemory(poolNum uint) *Memory

--- a/storage/cachetest/queuetest.go
+++ b/storage/cachetest/queuetest.go
@@ -1,0 +1,283 @@
+package cachetest
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+)
+
+// QueueFactory builds a Queue for a single case.
+type QueueFactory func(t *testing.T) storage.Queue
+
+// RunQueue executes the queue conformance suite against newQueue.
+func RunQueue(t *testing.T, newQueue QueueFactory) {
+	t.Helper()
+
+	tests := []struct {
+		name string
+		fn   func(*testing.T, QueueFactory)
+	}{
+		{"DeliversPublishedMessage", testDeliversPublishedMessage},
+		{"PreservesValues", testPreservesValues},
+		{"AssignsID", testAssignsID},
+		{"RoutesByTopic", testRoutesByTopic},
+		{"RejectsDuplicateSubscription", testRejectsDuplicateSubscription},
+		{"RejectsNilHandler", testRejectsNilHandler},
+		{"PublishWithoutHandlerFails", testPublishWithoutHandlerFails},
+		{"AttemptsStartAtOne", testAttemptsStartAtOne},
+		{"StartReturnsOnContextCancel", testStartReturnsOnContextCancel},
+		{"CloseIsIdempotent", testQueueCloseIsIdempotent},
+		{"PublishAfterCloseFails", testPublishAfterCloseFails},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) { tc.fn(t, newQueue) })
+	}
+}
+
+// started runs q.Start in the background and returns a stop function.
+func started(t *testing.T, q storage.Queue) func() {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := q.Start(ctx); err != nil {
+			t.Errorf("Start returned %v; cancellation must be a clean exit", err)
+		}
+	}()
+
+	return func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Error("Start did not return after the context was cancelled")
+		}
+	}
+}
+
+// collector records delivered messages.
+type collector struct {
+	mu   sync.Mutex
+	msgs []storage.Message
+	got  chan struct{}
+}
+
+func newCollector() *collector {
+	return &collector{got: make(chan struct{}, 64)}
+}
+
+func (c *collector) handle(_ context.Context, m storage.Message) error {
+	c.mu.Lock()
+	c.msgs = append(c.msgs, m)
+	c.mu.Unlock()
+	select {
+	case c.got <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (c *collector) await(t *testing.T, n int) []storage.Message {
+	t.Helper()
+
+	deadline := time.After(3 * time.Second)
+	for {
+		c.mu.Lock()
+		got := len(c.msgs)
+		c.mu.Unlock()
+		if got >= n {
+			break
+		}
+		select {
+		case <-c.got:
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d message(s), got %d", n, got)
+		}
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]storage.Message, len(c.msgs))
+	copy(out, c.msgs)
+	return out
+}
+
+func testDeliversPublishedMessage(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	if err := q.Subscribe("orders", c.handle); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	stop := started(t, q)
+	defer stop()
+
+	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	c.await(t, 1)
+}
+
+func testPreservesValues(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	_ = q.Subscribe("orders", c.handle)
+	stop := started(t, q)
+	defer stop()
+
+	_ = q.Publish(context.Background(), storage.Message{
+		Topic:  "orders",
+		Values: map[string]interface{}{"id": "42", "kind": "refund"},
+	})
+
+	got := c.await(t, 1)[0]
+	if got.Values["id"] != "42" || got.Values["kind"] != "refund" {
+		t.Errorf("values were not preserved: %v", got.Values)
+	}
+}
+
+func testAssignsID(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	_ = q.Subscribe("orders", c.handle)
+	stop := started(t, q)
+	defer stop()
+
+	_ = q.Publish(context.Background(), storage.Message{Topic: "orders"})
+
+	if got := c.await(t, 1)[0]; got.ID == "" {
+		t.Error("the queue must assign an ID on publish")
+	}
+}
+
+func testRoutesByTopic(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	a, b := newCollector(), newCollector()
+	_ = q.Subscribe("a", a.handle)
+	_ = q.Subscribe("b", b.handle)
+	stop := started(t, q)
+	defer stop()
+
+	_ = q.Publish(context.Background(), storage.Message{Topic: "b"})
+
+	b.await(t, 1)
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.msgs) != 0 {
+		t.Errorf("a message reached the wrong topic: %v", a.msgs)
+	}
+}
+
+// Registration must be rejected rather than silently replacing the handler,
+// which is how the previous Register behaved.
+func testRejectsDuplicateSubscription(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	noop := func(context.Context, storage.Message) error { return nil }
+	if err := q.Subscribe("orders", noop); err != nil {
+		t.Fatalf("first Subscribe: %v", err)
+	}
+
+	err := q.Subscribe("orders", noop)
+	if !errors.Is(err, storage.ErrTopicAlreadySubscribed) {
+		t.Errorf("second Subscribe: got %v, want ErrTopicAlreadySubscribed", err)
+	}
+}
+
+// A nil handler would make Publish succeed while delivery silently drops the
+// message, since Publish only checks that the topic is registered.
+func testRejectsNilHandler(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	if err := q.Subscribe("orders", nil); err == nil {
+		t.Error("Subscribe with a nil handler must be rejected")
+	}
+}
+
+func testPublishWithoutHandlerFails(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	err := q.Publish(context.Background(), storage.Message{Topic: "nobody-listens"})
+	if !errors.Is(err, storage.ErrNoHandler) {
+		t.Errorf("got %v, want ErrNoHandler: a dropped message must not look like a success", err)
+	}
+}
+
+func testAttemptsStartAtOne(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	_ = q.Subscribe("orders", c.handle)
+	stop := started(t, q)
+	defer stop()
+
+	_ = q.Publish(context.Background(), storage.Message{Topic: "orders"})
+
+	if got := c.await(t, 1)[0]; got.Attempts != 1 {
+		t.Errorf("Attempts on first delivery: got %d, want 1", got.Attempts)
+	}
+}
+
+func testStartReturnsOnContextCancel(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- q.Start(ctx) }()
+
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Start returned %v; cancellation is not an error", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Error("Start did not return after cancellation")
+	}
+}
+
+func testQueueCloseIsIdempotent(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+
+	if err := q.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := q.Close(); err != nil {
+		t.Errorf("second Close must be a no-op, got %v", err)
+	}
+}
+
+func testPublishAfterCloseFails(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	_ = q.Subscribe("orders", func(context.Context, storage.Message) error { return nil })
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	err := q.Publish(context.Background(), storage.Message{Topic: "orders"})
+	if !errors.Is(err, storage.ErrQueueClosed) {
+		t.Errorf("Publish after Close: got %v, want ErrQueueClosed", err)
+	}
+}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -1,0 +1,65 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+var (
+	// ErrQueueClosed is returned by operations on a closed Queue.
+	ErrQueueClosed = errors.New("storage: queue closed")
+
+	// ErrTopicAlreadySubscribed reports a second handler for one topic.
+	// Registration is rejected rather than silently replacing the first, which
+	// is what the previous Register did.
+	ErrTopicAlreadySubscribed = errors.New("storage: topic already subscribed")
+
+	// ErrNoHandler reports a message published to a topic nobody consumes.
+	ErrNoHandler = errors.New("storage: no handler for topic")
+)
+
+// Message is a queued message.
+//
+// It is a struct, not an interface: the previous Messager was ten getters and
+// setters with a single implementation, so the indirection bought nothing.
+// Values is a map rather than a byte slice to match the field model of Redis
+// streams, which is the intended backend.
+type Message struct {
+	// ID is assigned by the queue on publish. It is ignored on input.
+	ID string
+
+	// Topic routes the message to a handler.
+	Topic string
+
+	Values map[string]interface{}
+
+	// Attempts counts deliveries of this message, starting at 1. A handler can
+	// use it to give up on a message that keeps failing.
+	Attempts int
+}
+
+// Handler processes one message. Returning an error marks the delivery as
+// failed; whether that leads to a retry is the implementation's decision, but
+// Attempts must reflect it.
+type Handler func(ctx context.Context, msg Message) error
+
+// Queue is the contract for a message queue.
+type Queue interface {
+	// Publish enqueues a message. The topic must have a subscriber, otherwise
+	// ErrNoHandler is returned rather than dropping the message silently.
+	Publish(ctx context.Context, msg Message) error
+
+	// Subscribe registers the handler for a topic. It must be called before
+	// Start, and returns ErrTopicAlreadySubscribed if the topic is taken.
+	Subscribe(topic string, h Handler) error
+
+	// Start begins consuming and blocks until ctx is done or an unrecoverable
+	// error occurs. A context cancellation is not an error.
+	Start(ctx context.Context) error
+
+	// Close stops accepting new messages and waits for in-flight deliveries to
+	// finish. It is idempotent. Bound the wait with a context of your own if
+	// you need to.
+	io.Closer
+}

--- a/storage/queue/memqueue.go
+++ b/storage/queue/memqueue.go
@@ -1,0 +1,157 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+)
+
+const defaultBuffer = 1024
+
+// MemQueue is an in-process storage.Queue.
+//
+// Messages live only in memory, so nothing survives a restart and nothing is
+// shared between instances. It is the default so that a single-instance
+// deployment needs no broker; use a Redis-backed queue for anything else.
+type MemQueue struct {
+	mu       sync.RWMutex
+	handlers map[string]storage.Handler
+	closed   bool
+
+	messages chan storage.Message
+	seq      atomic.Int64
+
+	// inFlight tracks deliveries so Close can wait for them.
+	inFlight sync.WaitGroup
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stop      chan struct{}
+}
+
+var _ storage.Queue = (*MemQueue)(nil)
+
+// NewMemQueue returns a queue buffering up to size messages. A size of zero or
+// less uses the default.
+func NewMemQueue(size int) *MemQueue {
+	if size <= 0 {
+		size = defaultBuffer
+	}
+	return &MemQueue{
+		handlers: make(map[string]storage.Handler),
+		messages: make(chan storage.Message, size),
+		stop:     make(chan struct{}),
+	}
+}
+
+func (q *MemQueue) Subscribe(topic string, h storage.Handler) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		return storage.ErrQueueClosed
+	}
+	if h == nil {
+		return errors.New("storage: nil handler")
+	}
+	if _, exists := q.handlers[topic]; exists {
+		return storage.ErrTopicAlreadySubscribed
+	}
+	q.handlers[topic] = h
+	return nil
+}
+
+func (q *MemQueue) Publish(ctx context.Context, msg storage.Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	q.mu.RLock()
+	closed := q.closed
+	_, known := q.handlers[msg.Topic]
+	q.mu.RUnlock()
+
+	if closed {
+		return storage.ErrQueueClosed
+	}
+	if !known {
+		return storage.ErrNoHandler
+	}
+
+	msg.ID = strconv.FormatInt(q.seq.Add(1), 10)
+	if msg.Attempts == 0 {
+		msg.Attempts = 1
+	}
+
+	select {
+	case q.messages <- msg:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-q.stop:
+		return storage.ErrQueueClosed
+	}
+}
+
+func (q *MemQueue) Start(ctx context.Context) error {
+	var ran bool
+	q.startOnce.Do(func() { ran = true })
+	if !ran {
+		return errors.New("storage: queue already started")
+	}
+	for {
+		select {
+		case msg := <-q.messages:
+			q.deliver(ctx, msg)
+		case <-ctx.Done():
+			// The contract states that cancellation is not an error.
+			return nil
+		case <-q.stop:
+			// Drain what is already queued so Close does not lose messages
+			// that were accepted before it was called.
+			for {
+				select {
+				case msg := <-q.messages:
+					q.deliver(ctx, msg)
+				default:
+					return nil
+				}
+			}
+		}
+	}
+}
+
+func (q *MemQueue) deliver(ctx context.Context, msg storage.Message) {
+	q.mu.RLock()
+	h := q.handlers[msg.Topic]
+	if h == nil || q.closed {
+		q.mu.RUnlock()
+		return
+	}
+	// Registered while holding the lock Close uses to publish q.closed, so a
+	// counter increment can never race with Close's Wait.
+	q.inFlight.Add(1)
+	q.mu.RUnlock()
+	defer q.inFlight.Done()
+
+	// A handler error is reported through the queue's own error handling; this
+	// implementation has no retry, so the message is dropped after one attempt.
+	_ = h(ctx, msg)
+}
+
+func (q *MemQueue) Close() error {
+	q.stopOnce.Do(func() {
+		q.mu.Lock()
+		q.closed = true
+		q.mu.Unlock()
+		close(q.stop)
+	})
+
+	// Start observes q.stop, drains what is already queued and returns on its
+	// own; waiting for in-flight deliveries is what makes Close graceful.
+	q.inFlight.Wait()
+	return nil
+}

--- a/storage/queue/memqueue_test.go
+++ b/storage/queue/memqueue_test.go
@@ -1,0 +1,15 @@
+package queue_test
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+	"github.com/go-admin-team/go-admin-core/storage/cachetest"
+	"github.com/go-admin-team/go-admin-core/storage/queue"
+)
+
+func TestMemQueueConformance(t *testing.T) {
+	cachetest.RunQueue(t, func(t *testing.T) storage.Queue {
+		return queue.NewMemQueue(64)
+	})
+}


### PR DESCRIPTION
Third step of the storage rework, after #109 and #110. Same pattern: contract first, suite validates it, implementations follow.

## Why

`AdapterQueue` has the same shape of problems the cache interface had:

| | |
|---|---|
| `Register` returns nothing | a second handler for a topic **silently replaces** the first |
| `Append` on an unsubscribed topic | indistinguishable from a successful publish — the message is just dropped |
| `Run` / `Shutdown` | no context, no error: startup cannot be bounded and failure cannot be observed |
| `Messager` | ten getters and setters over a single implementation; the indirection buys nothing |

## What

`Queue` fixes the contract: `Subscribe` rejects a duplicate topic with `ErrTopicAlreadySubscribed`, `Publish` reports `ErrNoHandler` instead of dropping, `Start` takes a context and treats cancellation as a clean exit, `Close` waits for in-flight deliveries.

`Message` is a struct rather than an interface, with an `Attempts` counter so a handler can give up on a message that keeps failing. `Values` stays a map to match the field model of Redis streams, the intended backend.

## Verification

10 black-box cases in `storage/cachetest`, validated the same way as the cache suite — by reintroducing the old behaviours:

- silent handler overwrite → `RejectsDuplicateSubscription` fails
- silent drop on publish → `PublishWithoutHandlerFails` fails with *"a dropped message must not look like a success"*

`make ci` green, downstream canary passes.

## Scope

`AdapterQueue` is untouched and still in use — nothing migrates here. The Redis-backed implementation follows in a separate PR; that is the one that actually unblocks multi-instance deployment for queues.