### PR TITLE
feat✨: add a Redis queue and select storage backends from configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 
 ### 🚀 Other Components
 
-- [x] Cache component (memory support)
-- [x] Queue component (memory support)
+- [x] Cache component (memory and Redis) — see [docs/storage](docs/storage/README.md)
+- [x] Queue component (memory and Redis streams) — see [docs/storage](docs/storage/README.md)
 - [x] Configuration management (multiple data sources)
 - [x] Log writer (file rotation support)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -24,8 +24,8 @@
 
 ### 🚀 其他组件
 
-- [x] 缓存组件（支持 memory）
-- [x] 队列组件（支持 memory）
+- [x] 缓存组件（支持 memory、Redis）——见 [docs/storage](docs/storage/README.md)
+- [x] 队列组件（支持 memory、Redis streams）——见 [docs/storage](docs/storage/README.md)
 - [x] 配置管理（支持多种数据源）
 - [x] 日志写入器（支持文件分割）
 

--- a/api/core.txt
+++ b/api/core.txt
@@ -886,7 +886,9 @@ type Application struct {
 	EnableDP      bool
 	TenantMode int `yaml:"tenantMode"`
 type Cache struct {
+	Redis  *RedisOptions
 	Memory interface{}
+func (e Cache) Open() (storage.Cache, error)
 func (e Cache) Setup() (storage.AdapterCache, error)
 type Config struct {
 	Application *Application          `yaml:"application"`
@@ -933,11 +935,31 @@ type Logger struct {
 	Rotation     *RotationConfig `yaml:"rotation"`
 func (e Logger) Setup()
 type Queue struct {
+	Redis  *RedisQueue
 	Memory *QueueMemory
 func (e Queue) Empty() bool
+func (e Queue) Open() (storage.Queue, error)
 func (e Queue) Setup() (storage.AdapterQueue, error)
 type QueueMemory struct {
 	PoolSize uint
+type RedisOptions struct {
+	URL        string `yaml:"url" json:"url"`
+	Network    string `yaml:"network" json:"network"`
+	Addr       string `yaml:"addr" json:"addr"`
+	Username   string `yaml:"username" json:"username"`
+	Password   string `yaml:"password" json:"password"`
+	DB         int    `yaml:"db" json:"db"`
+	PoolSize   int    `yaml:"pool_size" json:"pool_size"`
+	MaxRetries int    `yaml:"max_retries" json:"max_retries"`
+	Tls        *Tls   `yaml:"tls" json:"tls"`
+func (e RedisOptions) Client(ctx context.Context) (*goredis.Client, error)
+func (e RedisOptions) GetRedisOptions() (*goredis.Options, error)
+type RedisQueue struct {
+	RedisOptions `yaml:",inline"`
+	Group       string `yaml:"group" json:"group"`
+	KeyPrefix   string `yaml:"key_prefix" json:"key_prefix"`
+	MaxAttempts int    `yaml:"max_attempts" json:"max_attempts"`
+	ClaimMinIdleSeconds int `yaml:"claim_min_idle_seconds" json:"claim_min_idle_seconds"`
 type RotationConfig struct {
 	MaxSize    int  `yaml:"maxSize"`
 	MaxAge     int  `yaml:"maxAge"`
@@ -954,6 +976,10 @@ type Ssl struct {
 	Pem    string
 	Enable bool
 	Domain string
+type Tls struct {
+	Cert string `yaml:"cert" json:"cert"`
+	Key  string `yaml:"key" json:"key"`
+	Ca   string `yaml:"ca" json:"ca"`
 
 ## github.com/go-admin-team/go-admin-core/sdk/pkg
 const (
@@ -1349,6 +1375,8 @@ var (
 	ErrQueueClosed = errors.New("storage: queue closed")
 	ErrTopicAlreadySubscribed = errors.New("storage: topic already subscribed")
 	ErrNoHandler = errors.New("storage: no handler for topic")
+	ErrNilHandler = errors.New("storage: nil handler")
+	ErrQueueAlreadyStarted = errors.New("storage: queue already started")
 var ErrCacheClosed = errors.New("storage: cache closed")
 var ErrCacheMiss = errors.New("storage: cache miss")
 type AdapterCache interface {
@@ -1370,6 +1398,7 @@ type AdapterQueue interface {
 	Register(name string, f ConsumerFunc)
 	Run()
 	Shutdown()
+func LegacyQueueAdapter(q Queue) AdapterQueue
 type Cache interface {
 	Get(ctx context.Context, key string) (string, error)
 	Set(ctx context.Context, key, val string, ttl time.Duration) error
@@ -1412,6 +1441,7 @@ func (m *MemCache) Expire(ctx context.Context, key string, ttl time.Duration) er
 func (m *MemCache) Get(ctx context.Context, key string) (string, error)
 func (m *MemCache) Incr(ctx context.Context, key string, delta int64) (int64, error)
 func (m *MemCache) Set(ctx context.Context, key, val string, ttl time.Duration) error
+func (c *MemCache) String() string
 type Memory struct {
 func NewMemory() *Memory
 func NewMemoryWithCleanupInterval(interval time.Duration) *Memory
@@ -1448,6 +1478,7 @@ func NewMemQueue(size int) *MemQueue
 func (q *MemQueue) Close() error
 func (q *MemQueue) Publish(ctx context.Context, msg storage.Message) error
 func (q *MemQueue) Start(ctx context.Context) error
+func (q *MemQueue) String() string
 func (q *MemQueue) Subscribe(topic string, h storage.Handler) error
 type Memory struct {
 	PoolNum uint
@@ -1483,6 +1514,23 @@ func (c *Cache) Expire(ctx context.Context, key string, ttl time.Duration) error
 func (c *Cache) Get(ctx context.Context, key string) (string, error)
 func (c *Cache) Incr(ctx context.Context, key string, delta int64) (int64, error)
 func (c *Cache) Set(ctx context.Context, key, val string, ttl time.Duration) error
+func (c *Cache) String() string
+type Queue struct {
+func NewQueue(client goredis.UniversalClient, opts QueueOptions) *Queue
+func OpenQueue(ctx context.Context, url string, opts QueueOptions) (*Queue, error)
+func (q *Queue) Close() error
+func (q *Queue) Publish(ctx context.Context, msg storage.Message) error
+func (q *Queue) Start(ctx context.Context) error
+func (q *Queue) String() string
+func (q *Queue) Subscribe(topic string, h storage.Handler) error
+type QueueOptions struct {
+	Group string
+	Consumer string
+	KeyPrefix string
+	MaxAttempts int
+	Block time.Duration
+	ClaimMinIdle time.Duration
+	Batch int64
 
 ## github.com/go-admin-team/go-admin-core/tools/database
 type Configure interface {

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -1,0 +1,270 @@
+# storage
+
+Two contracts, `Cache` and `Queue`, each with an in-memory implementation for a
+single instance and a Redis implementation for several.
+
+Both contracts are enforced by a conformance suite in `storage/cachetest`. A
+contract exercised by one implementation is not a contract, so every backend
+runs the same cases.
+
+## Why these exist
+
+The previous `AdapterCache` and `AdapterQueue` interfaces had no context, no way
+to tell a cache miss from a backend failure, and only in-memory implementations.
+That last point is what blocked horizontal scaling: two instances of the same
+application did not share a cache, and a message published on one was never seen
+by the other.
+
+The older interfaces still exist and still work. Nothing has to be migrated.
+
+## Choosing a backend
+
+The backend is a configuration decision, not a code one. **Redis is never
+required.** With no `cache` or `queue` section the process runs entirely in
+memory and needs nothing beside it, which is what a single instance should do:
+
+```yaml
+settings:
+  # no cache section at all -> in-memory cache
+  queue:
+    memory:
+      poolSize: 100
+```
+
+Add a `redis` section only when more than one instance has to share state:
+
+```yaml
+settings:
+  cache:
+    redis:
+      addr: 127.0.0.1:6379
+      password: ""
+      db: 0
+  queue:
+    redis:
+      addr: 127.0.0.1:6379
+      db: 0
+      group: go-admin          # the same for every instance of one application
+      max_attempts: 3
+      claim_min_idle_seconds: 30
+```
+
+`url` replaces the individual fields where a provider hands one out, and
+`rediss://` selects TLS:
+
+```yaml
+  cache:
+    redis:
+      url: rediss://default:password@cache.example.com:6380/0
+```
+
+`config.CacheConfig.Setup()` and `config.QueueConfig.Setup()` read this and
+return the adapter, in the order `redis > memory`. A `redis` section that
+cannot be reached **fails the boot** rather than falling back to memory:
+falling back would silently give an operator who asked for a shared cache one
+that is not shared, and the symptom would only appear as strange behaviour
+under load.
+
+`Open()` returns the same backend through the current contract, for code that
+wants a miss it can detect or a context it can cancel:
+
+```go
+c, err := config.CacheConfig.Open()   // storage.Cache
+q, err := config.QueueConfig.Open()   // storage.Queue
+```
+
+### Switching a queue from memory to Redis
+
+`Setup()`'s memory branch still returns the original in-process queue, so that
+existing call sites keep the behaviour they were written against. It differs
+from the Redis one in two ways that only show up on the switch:
+
+- `Register` starts consuming by itself on memory. On Redis nothing is consumed
+  until `Run` is called, so a call site that registers without running goes
+  silently idle.
+- The original memory queue retries a failed message three times on its own.
+  Redis retries through `max_attempts`; `MemQueue`, which `Open()` returns, does
+  not retry at all.
+
+Code that wants one behaviour on both backends should move to `Open()` and the
+`Queue` contract.
+
+Everything below describes the interfaces those adapters are built on, for code
+that wants them directly.
+
+## Cache
+
+```go
+type Cache interface {
+	Get(ctx context.Context, key string) (string, error)
+	Set(ctx context.Context, key, val string, ttl time.Duration) error
+	Del(ctx context.Context, keys ...string) error
+	Incr(ctx context.Context, key string, delta int64) (int64, error)
+	Expire(ctx context.Context, key string, ttl time.Duration) error
+	io.Closer
+}
+```
+
+| Implementation | Constructor | Use |
+| --- | --- | --- |
+| memory | `cache.NewMemCache()` | one instance, nothing to run |
+| Redis | `redis.New(client)` / `redis.Open(ctx, url)` | several instances |
+
+`redis.New` borrows the client and leaves it open on `Close`; `redis.Open` owns
+its connection and closes it.
+
+Rules worth knowing before writing against it:
+
+- A miss is `ErrCacheMiss`, tested with `errors.Is`. Treating every error as
+  "no data" turns a Redis outage into a full cache bypass and stampedes the
+  database.
+- An empty string is a legal value, returned with a nil error.
+- A `ttl` of zero or less means no expiry. `Expire` with such a value makes an
+  entry permanent rather than deleting it.
+- `Incr` is atomic and starts an absent key from zero. The key it creates has
+  no ttl.
+- `ctx` is checked first, so a caller that gave up gets its own error rather
+  than `ErrCacheClosed`.
+
+`storage.WithPrefix(c, "app:")` namespaces one backend across applications.
+
+### Adopting it without changing call sites
+
+`config.CacheConfig.Setup()` already returns an `AdapterCache`, which is what
+`captcha.NewCacheStore` and `Runtime.SetCacheAdapter` accept, so switching to
+Redis is a configuration change and nothing else.
+
+It does that through `storage.LegacyAdapter(c)`, which is also available
+directly for a cache built by hand:
+
+```go
+c := cache.NewMemCache()          // or redis.New(client)
+runtime.SetCacheAdapter(storage.LegacyAdapter(c))
+```
+
+What the adapter cannot do is repair the old contract: `Get` still reports a
+miss as `("", nil)`, and the `Hash*` family still concatenates its arguments
+into one flat key space. Move to `Cache` directly where either matters.
+
+## Queue
+
+```go
+type Queue interface {
+	Publish(ctx context.Context, msg Message) error
+	Subscribe(topic string, h Handler) error
+	Start(ctx context.Context) error
+	io.Closer
+}
+```
+
+| Implementation | Constructor | Use |
+| --- | --- | --- |
+| memory | `queue.NewMemQueue(size)` | one instance, nothing survives a restart |
+| Redis streams | `redis.NewQueue(client, opts)` / `redis.OpenQueue(ctx, url, opts)` | several instances, messages survive a restart |
+
+Order of operations: `Subscribe` every topic, then `Start`. `Start` blocks until
+the context is done and reads only the topics registered when it was called.
+
+- Publishing to a topic nobody consumes returns `ErrNoHandler` rather than
+  dropping the message.
+- Subscribing a topic twice returns `ErrTopicAlreadySubscribed`. The previous
+  `Register` replaced the handler silently.
+- A cancelled context is a clean exit: `Start` returns nil.
+- `Message.Values` is transported as JSON, so only what JSON can express
+  survives. A number arrives as a `float64`. Keep to strings where the exact
+  type matters.
+
+### Delivery semantics
+
+Delivery is **at least once**. A handler must tolerate seeing the same message
+twice — make it idempotent, or key it on `Message.ID`.
+
+`Message.Attempts` counts deliveries and starts at 1.
+
+| | memory | Redis |
+| --- | --- | --- |
+| survives a restart | no | yes |
+| shared between instances | no | yes |
+| handler error | message dropped after one attempt | retried up to `MaxAttempts` |
+| instance disappears mid-handler | message lost | taken over by another instance |
+
+The Redis implementation uses one consumer group per application. A message is
+acknowledged only after its handler returns nil; a handler that returns an error
+leaves the entry pending, and a later sweep claims it back and delivers it
+again with `Attempts` incremented.
+
+After `MaxAttempts` deliveries the message stops being retried but is
+**deliberately not acknowledged**. It stays in the pending list, where an
+operator can find it:
+
+```
+XPENDING <topic> <group>
+XPENDING <topic> <group> - + 10
+```
+
+Acknowledging it there would have made an unhandled message look handled, which
+is the failure mode this whole package is trying to remove. Inspect the entry,
+fix the cause, then `XACK` or `XCLAIM` it by hand.
+
+### QueueOptions
+
+| Field | Settings key | Default | Notes |
+| --- | --- | --- | --- |
+| `Group` | `group` | `go-admin` | every instance of one application must share it; a different group gets its own copy of every message |
+| `KeyPrefix` | `key_prefix` | none | prepended to the topic to form the stream key |
+| `MaxAttempts` | `max_attempts` | 3 | deliveries before the message is left pending |
+| `ClaimMinIdle` | `claim_min_idle_seconds` | 30s | idle time before another consumer may take a delivery over, and the interval between retry sweeps. **Set it above the running time of the slowest handler**, otherwise a slow handler's message is redelivered while it is still working |
+| `Consumer` | — | hostname + pid | must be unique per instance |
+| `Block` | — | 1s | how long one read waits before looping, and therefore how long `Start` takes to notice a cancellation |
+| `Batch` | — | 16 | messages per read or sweep |
+
+The fields with no settings key can only be set in code, through
+`redis.NewQueue`. A key that is not listed here is ignored silently, as any
+unknown key in a settings file is.
+
+### Migrating from AdapterQueue
+
+`storage.LegacyQueueAdapter(q)` presents a `Queue` as an `AdapterQueue`, and is
+what `config.QueueConfig.Setup()` returns for a Redis queue. Existing call sites
+keep working unchanged; `Register` before `Run`, as they already do.
+
+Two things it cannot carry over:
+
+- `Register` returns nothing, so a duplicate topic or an unreachable backend is
+  logged rather than reported. The first handler stays in place; the older
+  `Register` replaced it silently.
+- `ConsumerFunc` takes no context, so a cancelled `Start` does not reach a
+  handler that is already running.
+
+Move a call site to `Queue` directly where either matters:
+
+| Before | After |
+| --- | --- |
+| `Register(name, f)` | `Subscribe(topic, handler)`, before `Start`, error checked |
+| `Append(msg)` | `Publish(ctx, storage.Message{Topic: …, Values: …})` |
+| `Run()` | `Start(ctx)` in a goroutine, error checked |
+| `Shutdown()` | `Close()`, or cancel the context passed to `Start` |
+| `Messager` getters | `storage.Message` fields |
+| `GetErrorCount()` | `Message.Attempts`, which counts deliveries from 1 rather than counting failures |
+
+## Testing your own implementation
+
+```go
+func TestMyQueue(t *testing.T) {
+	cachetest.RunQueue(t, func(t *testing.T) storage.Queue {
+		return NewMyQueue()
+	})
+}
+```
+
+`cachetest.Run` does the same for `Cache`. The factory is called once per case
+and must return a queue with an empty backing store.
+
+The Redis suites skip themselves unless `REDIS_URL` is set:
+
+```
+REDIS_URL=redis://localhost:6379/0 go test -race ./storage/...
+```
+
+CI provides a Redis service container, so both implementations are checked
+against the same cases on every push.

--- a/sdk/config/backend_test.go
+++ b/sdk/config/backend_test.go
@@ -166,24 +166,33 @@ func TestClientsAreNotSharedAcrossIdentities(t *testing.T) {
 	base := goredis.Options{Network: "tcp", Addr: "localhost:6379", Username: "app"}
 	key := cfg.clientKey(&base)
 
-	differs := func(name string, mutate func(*RedisOptions, *goredis.Options)) {
+	differs := func(name string, mutate func(*goredis.Options)) {
 		t.Helper()
-		c, o := cfg, base
-		mutate(&c, &o)
-		if c.clientKey(&o) == key {
+		o := base
+		mutate(&o)
+		if cfg.clientKey(&o) == key {
 			t.Errorf("a differing %s must not reuse the same client", name)
 		}
 	}
 
-	differs("password", func(_ *RedisOptions, o *goredis.Options) { o.Password = "secret" })
-	differs("username", func(_ *RedisOptions, o *goredis.Options) { o.Username = "other" })
-	differs("db", func(_ *RedisOptions, o *goredis.Options) { o.DB = 1 })
-	differs("tls", func(_ *RedisOptions, o *goredis.Options) { o.TLSConfig = &tls.Config{} })
-	// The certificate files never reach goredis.Options, so a key built only
-	// from those would miss them entirely.
-	differs("ca file", func(c *RedisOptions, _ *goredis.Options) {
-		c.Tls = &Tls{Cert: "a.pem", Key: "a.key", Ca: "corp.pem"}
-	})
+	differs("password", func(o *goredis.Options) { o.Password = "secret" })
+	differs("username", func(o *goredis.Options) { o.Username = "other" })
+	differs("db", func(o *goredis.Options) { o.DB = 1 })
+	// An empty config is the point: with no ServerName or skip-verify set, only
+	// the enabled flag separates "TLS with every default" from no TLS at all.
+	differs("tls", func(o *goredis.Options) { o.TLSConfig = &tls.Config{} })
+
+	// The certificate files never reach goredis.Options, so a key built from
+	// those alone would miss them. They count only when no url is set, because
+	// GetRedisOptions ignores the tls section in that case.
+	withCerts := RedisOptions{Tls: &Tls{Cert: "a.pem", Key: "a.key", Ca: "corp.pem"}}
+	if withCerts.clientKey(&base) == key {
+		t.Error("a differing ca file must not reuse the same client")
+	}
+	withCerts.URL = "redis://localhost:6379/0"
+	if withCerts.clientKey(&base) != key {
+		t.Error("a tls section that a url makes ineffective must not split the destination")
+	}
 
 	// The same inputs still have to agree, or nothing would ever be reused.
 	same := base

--- a/sdk/config/backend_test.go
+++ b/sdk/config/backend_test.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// The default must stay in memory. A deployment that never mentions Redis has
+// to keep working with nothing running beside it.
+func TestSetupDefaultsToMemory(t *testing.T) {
+	c, err := Cache{}.Setup()
+	if err != nil {
+		t.Fatalf("Cache.Setup: %v", err)
+	}
+	if c.String() != "memory" {
+		t.Errorf("an unconfigured cache must stay in memory, got %q", c.String())
+	}
+
+	q, err := Queue{}.Setup()
+	if err != nil {
+		t.Fatalf("Queue.Setup: %v", err)
+	}
+	if q.String() != "memory" {
+		t.Errorf("an unconfigured queue must stay in memory, got %q", q.String())
+	}
+}
+
+// Configuration reaches these structs as JSON, so the guarantee above has to
+// survive decoding a settings file that has no cache or queue section.
+func TestSettingsWithoutABackendSectionStayInMemory(t *testing.T) {
+	const settings = `{"application":{"mode":"dev"}}`
+
+	var decoded struct {
+		Cache Cache `json:"cache"`
+		Queue Queue `json:"queue"`
+	}
+	if err := json.Unmarshal([]byte(settings), &decoded); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	c, err := decoded.Cache.Setup()
+	if err != nil {
+		t.Fatalf("Cache.Setup: %v", err)
+	}
+	if c.String() != "memory" {
+		t.Errorf("a settings file with no cache section must stay in memory, got %q", c.String())
+	}
+
+	q, err := decoded.Queue.Setup()
+	if err != nil {
+		t.Fatalf("Queue.Setup: %v", err)
+	}
+	if q.String() != "memory" {
+		t.Errorf("a settings file with no queue section must stay in memory, got %q", q.String())
+	}
+	if !decoded.Queue.Empty() {
+		t.Error("a queue with no backend configured must report Empty")
+	}
+}
+
+// A memory section is still honoured, and does not accidentally select Redis.
+func TestMemorySectionSelectsMemory(t *testing.T) {
+	q, err := Queue{Memory: &QueueMemory{PoolSize: 10}}.Setup()
+	if err != nil {
+		t.Fatalf("Queue.Setup: %v", err)
+	}
+	if q.String() != "memory" {
+		t.Errorf("got %q, want memory", q.String())
+	}
+	if (Queue{Memory: &QueueMemory{}}).Empty() {
+		t.Error("a configured memory queue must not report Empty")
+	}
+}
+
+// A redis section that cannot be reached must fail the boot rather than fall
+// back, otherwise an operator who asked for Redis silently gets a cache that is
+// not shared between instances.
+func TestUnreachableRedisIsAnError(t *testing.T) {
+	// Port 1 is reserved and never listening.
+	opts := RedisOptions{Addr: "127.0.0.1:1"}
+
+	if _, err := (Cache{Redis: &opts}).Setup(); err == nil {
+		t.Error("Cache.Setup must not fall back to memory when Redis is configured but unreachable")
+	}
+	if _, err := (Queue{Redis: &RedisQueue{RedisOptions: opts}}).Setup(); err == nil {
+		t.Error("Queue.Setup must not fall back to memory when Redis is configured but unreachable")
+	}
+}
+
+func TestRedisOptionsNeedsAnAddress(t *testing.T) {
+	if _, err := (RedisOptions{}).GetRedisOptions(); err == nil {
+		t.Error("a redis section with neither url nor addr must be rejected")
+	}
+}
+
+func TestURLWinsOverFields(t *testing.T) {
+	o, err := RedisOptions{
+		URL:  "redis://localhost:6380/3",
+		Addr: "127.0.0.1:9999",
+	}.GetRedisOptions()
+	if err != nil {
+		t.Fatalf("GetRedisOptions: %v", err)
+	}
+	if o.Addr != "localhost:6380" || o.DB != 3 {
+		t.Errorf("url must win, got addr %q db %d", o.Addr, o.DB)
+	}
+}
+
+// With a reachable server, a redis section selects Redis for both.
+func TestRedisSectionSelectsRedis(t *testing.T) {
+	url := os.Getenv("REDIS_URL")
+	if url == "" {
+		t.Skip("REDIS_URL is not set; skipping the Redis selection test")
+	}
+
+	// The bridge reports the backend's own identity, so this can assert what
+	// was selected rather than only what was not.
+	c, err := (Cache{Redis: &RedisOptions{URL: url}}).Setup()
+	if err != nil {
+		t.Fatalf("Cache.Setup: %v", err)
+	}
+	if c.String() != "redis" {
+		t.Errorf("cache backend: got %q, want redis", c.String())
+	}
+
+	q, err := (Queue{Redis: &RedisQueue{RedisOptions: RedisOptions{URL: url}}}).Setup()
+	if err != nil {
+		t.Fatalf("Queue.Setup: %v", err)
+	}
+	defer q.Shutdown()
+	if q.String() != "redis" {
+		t.Errorf("queue backend: got %q, want redis", q.String())
+	}
+}
+
+// Cache and queue are configured separately but normally name one server, and
+// opening a pool for each doubles the connections a managed Redis sees.
+func TestOneServerYieldsOneClient(t *testing.T) {
+	url := os.Getenv("REDIS_URL")
+	if url == "" {
+		t.Skip("REDIS_URL is not set; skipping the shared client test")
+	}
+
+	first, err := (RedisOptions{URL: url}).Client(context.Background())
+	if err != nil {
+		t.Fatalf("first connect: %v", err)
+	}
+	second, err := (RedisOptions{URL: url}).Client(context.Background())
+	if err != nil {
+		t.Fatalf("second connect: %v", err)
+	}
+	if first != second {
+		t.Error("two configs naming one server must share a client")
+	}
+}

--- a/sdk/config/backend_test.go
+++ b/sdk/config/backend_test.go
@@ -2,9 +2,12 @@ package config
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"os"
 	"testing"
+
+	goredis "github.com/redis/go-redis/v9"
 )
 
 // The default must stay in memory. A deployment that never mentions Redis has
@@ -153,5 +156,37 @@ func TestOneServerYieldsOneClient(t *testing.T) {
 	}
 	if first != second {
 		t.Error("two configs naming one server must share a client")
+	}
+}
+
+// Sharing must not extend across credentials or transport: a config with the
+// wrong password reusing a working client would make the mistake invisible.
+func TestClientsAreNotSharedAcrossIdentities(t *testing.T) {
+	base := &goredis.Options{Network: "tcp", Addr: "localhost:6379", Username: "app", DB: 0}
+
+	withPassword := *base
+	withPassword.Password = "secret"
+
+	otherDB := *base
+	otherDB.DB = 1
+
+	withTLS := *base
+	withTLS.TLSConfig = &tls.Config{ServerName: "cache.example.com", MinVersion: tls.VersionTLS12}
+
+	key := cacheKey(base)
+	for name, o := range map[string]*goredis.Options{
+		"password": &withPassword,
+		"db":       &otherDB,
+		"tls":      &withTLS,
+	} {
+		if cacheKey(o) == key {
+			t.Errorf("a differing %s must not reuse the same client", name)
+		}
+	}
+
+	// The same inputs still have to agree, or nothing would ever be reused.
+	again := *base
+	if cacheKey(&again) != key {
+		t.Error("identical options must produce the same key")
 	}
 }

--- a/sdk/config/backend_test.go
+++ b/sdk/config/backend_test.go
@@ -162,31 +162,32 @@ func TestOneServerYieldsOneClient(t *testing.T) {
 // Sharing must not extend across credentials or transport: a config with the
 // wrong password reusing a working client would make the mistake invisible.
 func TestClientsAreNotSharedAcrossIdentities(t *testing.T) {
-	base := &goredis.Options{Network: "tcp", Addr: "localhost:6379", Username: "app", DB: 0}
+	var cfg RedisOptions
+	base := goredis.Options{Network: "tcp", Addr: "localhost:6379", Username: "app"}
+	key := cfg.clientKey(&base)
 
-	withPassword := *base
-	withPassword.Password = "secret"
-
-	otherDB := *base
-	otherDB.DB = 1
-
-	withTLS := *base
-	withTLS.TLSConfig = &tls.Config{ServerName: "cache.example.com", MinVersion: tls.VersionTLS12}
-
-	key := cacheKey(base)
-	for name, o := range map[string]*goredis.Options{
-		"password": &withPassword,
-		"db":       &otherDB,
-		"tls":      &withTLS,
-	} {
-		if cacheKey(o) == key {
+	differs := func(name string, mutate func(*RedisOptions, *goredis.Options)) {
+		t.Helper()
+		c, o := cfg, base
+		mutate(&c, &o)
+		if c.clientKey(&o) == key {
 			t.Errorf("a differing %s must not reuse the same client", name)
 		}
 	}
 
+	differs("password", func(_ *RedisOptions, o *goredis.Options) { o.Password = "secret" })
+	differs("username", func(_ *RedisOptions, o *goredis.Options) { o.Username = "other" })
+	differs("db", func(_ *RedisOptions, o *goredis.Options) { o.DB = 1 })
+	differs("tls", func(_ *RedisOptions, o *goredis.Options) { o.TLSConfig = &tls.Config{} })
+	// The certificate files never reach goredis.Options, so a key built only
+	// from those would miss them entirely.
+	differs("ca file", func(c *RedisOptions, _ *goredis.Options) {
+		c.Tls = &Tls{Cert: "a.pem", Key: "a.key", Ca: "corp.pem"}
+	})
+
 	// The same inputs still have to agree, or nothing would ever be reused.
-	again := *base
-	if cacheKey(&again) != key {
+	same := base
+	if cfg.clientKey(&same) != key {
 		t.Error("identical options must produce the same key")
 	}
 }

--- a/sdk/config/cache.go
+++ b/sdk/config/cache.go
@@ -3,16 +3,55 @@ package config
 import (
 	"github.com/go-admin-team/go-admin-core/storage"
 	"github.com/go-admin-team/go-admin-core/storage/cache"
+	redisstore "github.com/go-admin-team/go-admin-core/storage/redis"
 )
 
+// Cache selects the cache backend.
+//
+// Leaving every field unset is a valid configuration and yields the in-memory
+// cache, so a single instance runs with nothing beside it. Redis is opt-in and
+// only for deployments that run more than one instance.
 type Cache struct {
+	Redis  *RedisOptions
 	Memory interface{}
 }
 
 // CacheConfig cache配置
 var CacheConfig = new(Cache)
 
-// Setup 构造cache 顺序 其他 > memory
+// Open builds the configured cache. Order: redis > memory.
+//
+// A redis section that cannot be reached is an error rather than a fallback:
+// falling back would hand an operator who asked for a shared cache one that is
+// not shared, and the symptom would only appear later, under load.
+func (e Cache) Open() (storage.Cache, error) {
+	if e.Redis == nil {
+		return cache.NewMemCache(), nil
+	}
+
+	client, err := e.Redis.connect()
+	if err != nil {
+		return nil, err
+	}
+	return redisstore.New(client), nil
+}
+
+// Setup 构造cache 顺序 redis > 其他 > memory
+//
+// Deprecated: use Open, which returns the current contract. This returns the
+// older AdapterCache so that existing call sites keep working; storage.Cache
+// can report a miss and takes a context, neither of which survives the bridge.
 func (e Cache) Setup() (storage.AdapterCache, error) {
-	return cache.NewMemory(), nil
+	// The memory branch stays on the older implementation. Both satisfy
+	// AdapterCache, but only this one preserves the retry and expiry behaviour
+	// that current call sites were written against.
+	if e.Redis == nil {
+		return cache.NewMemory(), nil
+	}
+
+	c, err := e.Open()
+	if err != nil {
+		return nil, err
+	}
+	return storage.LegacyAdapter(c), nil
 }

--- a/sdk/config/cache.go
+++ b/sdk/config/cache.go
@@ -36,7 +36,7 @@ func (e Cache) Open() (storage.Cache, error) {
 	return redisstore.New(client), nil
 }
 
-// Setup 构造cache 顺序 redis > 其他 > memory
+// Setup builds the cache adapter. Order: redis > memory.
 //
 // Deprecated: use Open, which returns the current contract. This returns the
 // older AdapterCache so that existing call sites keep working; storage.Cache

--- a/sdk/config/option_redis.go
+++ b/sdk/config/option_redis.go
@@ -2,12 +2,9 @@ package config
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/hex"
 	"errors"
-	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -79,11 +76,15 @@ const setupTimeout = 5 * time.Second
 // would open its own pool, doubling the connection count a managed Redis sees
 // and paying a second handshake before the process can serve anything.
 //
-// Nothing evicts from it. The interfaces these clients are handed to have no
-// shutdown of their own, so they live as long as the process either way.
+// Nothing evicts from it, because the client is handed to interfaces that have
+// no shutdown of their own and a caller may still hold it. A configuration
+// reload runs Setup again, so changing credentials adds an entry and leaves the
+// previous client open for the life of the process. That is bounded by how many
+// distinct destinations have been configured, and closing the old one would
+// break whoever still holds it.
 var clients struct {
 	sync.Mutex
-	byTarget map[string]*goredis.Client
+	byKey map[clientKey]*goredis.Client
 }
 
 // Client connects and verifies the server answers, so that a wrong address
@@ -97,11 +98,11 @@ func (e RedisOptions) Client(ctx context.Context) (*goredis.Client, error) {
 		return nil, err
 	}
 
-	target := cacheKey(o)
+	key := e.clientKey(o)
 
 	clients.Lock()
 	defer clients.Unlock()
-	if c, ok := clients.byTarget[target]; ok {
+	if c, ok := clients.byKey[key]; ok {
 		return c, nil
 	}
 
@@ -111,38 +112,57 @@ func (e RedisOptions) Client(ctx context.Context) (*goredis.Client, error) {
 		return nil, err
 	}
 
-	if clients.byTarget == nil {
-		clients.byTarget = make(map[string]*goredis.Client)
+	if clients.byKey == nil {
+		clients.byKey = make(map[clientKey]*goredis.Client)
 	}
-	clients.byTarget[target] = client
+	clients.byKey[key] = client
 	return client, nil
 }
 
-// cacheKey identifies a connection by everything that decides where a command
+// clientKey identifies a connection by everything that decides where a command
 // lands and who it is issued as.
 //
 // Credentials and transport belong in it, not just the address: sharing a
-// client across two configs that differ only in password would make the wrong
-// one appear to work, which hides the misconfiguration instead of reporting it.
-// The result is hashed so no secret is held as a map key.
-func cacheKey(o *goredis.Options) string {
-	h := sha256.New()
-	fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%d\x00", o.Network, o.Addr, o.Username, o.Password, o.DB)
+// client between two configurations that differ only in password would make
+// the wrong one appear to work, hiding the misconfiguration rather than
+// reporting it. Pool size is deliberately absent, so tuning it does not split
+// one server into two pools.
+type clientKey struct {
+	// From the resolved options, so that a url and the equivalent fields name
+	// the same connection.
+	network, addr, username, password string
+	db                                int
 
-	if o.TLSConfig == nil {
-		fmt.Fprint(h, "notls")
-		return hex.EncodeToString(h.Sum(nil))
-	}
+	// tls.Config is not comparable, so the parts that decide which peer is
+	// trusted are taken from the configuration that produced it. Certificate
+	// files are compared by path: they are read once at startup.
+	tls      bool
+	certFile string
+	keyFile  string
+	caFile   string
 
-	fmt.Fprintf(h, "tls\x00%s\x00%t\x00", o.TLSConfig.ServerName, o.TLSConfig.InsecureSkipVerify)
-	// The certificates themselves, not how many there are: two configurations
-	// presenting a different identity must not share a connection.
-	for _, cert := range o.TLSConfig.Certificates {
-		for _, der := range cert.Certificate {
-			h.Write(der)
-		}
+	// Set by ParseURL for rediss:// and by ?skip_verify.
+	serverName         string
+	insecureSkipVerify bool
+}
+
+func (e RedisOptions) clientKey(o *goredis.Options) clientKey {
+	k := clientKey{
+		network:  o.Network,
+		addr:     o.Addr,
+		username: o.Username,
+		password: o.Password,
+		db:       o.DB,
+		tls:      o.TLSConfig != nil,
 	}
-	return hex.EncodeToString(h.Sum(nil))
+	if o.TLSConfig != nil {
+		k.serverName = o.TLSConfig.ServerName
+		k.insecureSkipVerify = o.TLSConfig.InsecureSkipVerify
+	}
+	if e.Tls != nil {
+		k.certFile, k.keyFile, k.caFile = e.Tls.Cert, e.Tls.Key, e.Tls.Ca
+	}
+	return k
 }
 
 // connect dials with the boot timeout applied.

--- a/sdk/config/option_redis.go
+++ b/sdk/config/option_redis.go
@@ -1,0 +1,152 @@
+package config
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// RedisOptions describes how to reach a Redis server.
+//
+// Set URL, which understands redis:// and rediss:// and is what a managed
+// provider hands out, or fill in the individual fields. URL wins when both are
+// present.
+//
+// The json names are what the configuration file is keyed on, and they match
+// the ones this repository used before Redis support was removed, so an older
+// settings file still applies.
+type RedisOptions struct {
+	URL        string `yaml:"url" json:"url"`
+	Network    string `yaml:"network" json:"network"`
+	Addr       string `yaml:"addr" json:"addr"`
+	Username   string `yaml:"username" json:"username"`
+	Password   string `yaml:"password" json:"password"`
+	DB         int    `yaml:"db" json:"db"`
+	PoolSize   int    `yaml:"pool_size" json:"pool_size"`
+	MaxRetries int    `yaml:"max_retries" json:"max_retries"`
+	Tls        *Tls   `yaml:"tls" json:"tls"`
+}
+
+// Tls points at the certificate files for an encrypted connection.
+type Tls struct {
+	Cert string `yaml:"cert" json:"cert"`
+	Key  string `yaml:"key" json:"key"`
+	Ca   string `yaml:"ca" json:"ca"`
+}
+
+// GetRedisOptions converts the configuration into client options.
+func (e RedisOptions) GetRedisOptions() (*goredis.Options, error) {
+	if e.URL != "" {
+		return goredis.ParseURL(e.URL)
+	}
+	if e.Addr == "" {
+		return nil, errors.New("config: redis needs either url or addr")
+	}
+
+	o := &goredis.Options{
+		Network:    e.Network,
+		Addr:       e.Addr,
+		Username:   e.Username,
+		Password:   e.Password,
+		DB:         e.DB,
+		PoolSize:   e.PoolSize,
+		MaxRetries: e.MaxRetries,
+	}
+
+	var err error
+	o.TLSConfig, err = e.Tls.config()
+	if err != nil {
+		return nil, err
+	}
+	return o, nil
+}
+
+// setupTimeout bounds the connection check, so a wrong address fails the boot
+// quickly instead of hanging it.
+const setupTimeout = 5 * time.Second
+
+// clients memoises connections by destination. Cache and queue are configured
+// and built separately but normally point at one server, and without this each
+// would open its own pool, doubling the connection count a managed Redis sees
+// and paying a second handshake before the process can serve anything.
+//
+// Nothing evicts from it. The interfaces these clients are handed to have no
+// shutdown of their own, so they live as long as the process either way.
+var clients struct {
+	sync.Mutex
+	byTarget map[string]*goredis.Client
+}
+
+// Client connects and verifies the server answers, so that a wrong address
+// fails the boot rather than the first request that needs the cache.
+//
+// The returned client is shared with every other caller naming the same
+// destination, and is not closed by this package.
+func (e RedisOptions) Client(ctx context.Context) (*goredis.Client, error) {
+	o, err := e.GetRedisOptions()
+	if err != nil {
+		return nil, err
+	}
+
+	// Everything that decides which keyspace a command lands in. Two configs
+	// differing only in pool size share a client; differing in db do not.
+	target := fmt.Sprintf("%s|%s|%s|%d", o.Network, o.Addr, o.Username, o.DB)
+
+	clients.Lock()
+	defer clients.Unlock()
+	if c, ok := clients.byTarget[target]; ok {
+		return c, nil
+	}
+
+	client := goredis.NewClient(o)
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+
+	if clients.byTarget == nil {
+		clients.byTarget = make(map[string]*goredis.Client)
+	}
+	clients.byTarget[target] = client
+	return client, nil
+}
+
+// connect dials with the boot timeout applied.
+func (e RedisOptions) connect() (*goredis.Client, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), setupTimeout)
+	defer cancel()
+	return e.Client(ctx)
+}
+
+func (e *Tls) config() (*tls.Config, error) {
+	if e == nil {
+		return nil, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(e.Cert, e.Key)
+	if err != nil {
+		return nil, err
+	}
+	c := &tls.Config{Certificates: []tls.Certificate{cert}}
+
+	if e.Ca == "" {
+		return c, nil
+	}
+	ca, err := os.ReadFile(e.Ca)
+	if err != nil {
+		return nil, err
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(ca) {
+		return nil, errors.New("config: no certificate found in " + e.Ca)
+	}
+	c.RootCAs = pool
+	return c, nil
+}

--- a/sdk/config/option_redis.go
+++ b/sdk/config/option_redis.go
@@ -71,17 +71,13 @@ func (e RedisOptions) GetRedisOptions() (*goredis.Options, error) {
 // quickly instead of hanging it.
 const setupTimeout = 5 * time.Second
 
-// clients memoises connections by destination. Cache and queue are configured
-// and built separately but normally point at one server, and without this each
-// would open its own pool, doubling the connection count a managed Redis sees
-// and paying a second handshake before the process can serve anything.
+// clients memoises connections by destination, so that a cache and a queue
+// naming one server share a pool instead of opening two.
 //
-// Nothing evicts from it, because the client is handed to interfaces that have
-// no shutdown of their own and a caller may still hold it. A configuration
-// reload runs Setup again, so changing credentials adds an entry and leaves the
-// previous client open for the life of the process. That is bounded by how many
-// distinct destinations have been configured, and closing the old one would
-// break whoever still holds it.
+// Nothing evicts from it: the client is handed to interfaces with no shutdown
+// of their own, and a caller may still hold it. A configuration reload runs
+// Setup again, so changing credentials adds an entry and leaves the previous
+// client open for the life of the process.
 var clients struct {
 	sync.Mutex
 	byKey map[clientKey]*goredis.Client
@@ -128,22 +124,18 @@ func (e RedisOptions) Client(ctx context.Context) (*goredis.Client, error) {
 // reporting it. Pool size is deliberately absent, so tuning it does not split
 // one server into two pools.
 type clientKey struct {
-	// From the resolved options, so that a url and the equivalent fields name
-	// the same connection.
+	// Taken from the resolved options, so that a url and the equivalent fields
+	// name the same connection.
 	network, addr, username, password string
 	db                                int
 
-	// tls.Config is not comparable, so the parts that decide which peer is
-	// trusted are taken from the configuration that produced it. Certificate
-	// files are compared by path: they are read once at startup.
-	tls      bool
-	certFile string
-	keyFile  string
-	caFile   string
-
-	// Set by ParseURL for rediss:// and by ?skip_verify.
-	serverName         string
-	insecureSkipVerify bool
+	// tls.Config is not comparable, so the key carries the parts that decide
+	// which peer is trusted. Certificates are compared by path, which means a
+	// rotation that keeps the path will not be noticed until a restart.
+	tls                       bool
+	serverName                string
+	insecureSkipVerify        bool
+	certFile, keyFile, caFile string
 }
 
 func (e RedisOptions) clientKey(o *goredis.Options) clientKey {
@@ -159,7 +151,9 @@ func (e RedisOptions) clientKey(o *goredis.Options) clientKey {
 		k.serverName = o.TLSConfig.ServerName
 		k.insecureSkipVerify = o.TLSConfig.InsecureSkipVerify
 	}
-	if e.Tls != nil {
+	// GetRedisOptions ignores the tls section when a url is set, so folding it
+	// in there would split one destination into two for no reason.
+	if e.URL == "" && e.Tls != nil {
 		k.certFile, k.keyFile, k.caFile = e.Tls.Cert, e.Tls.Key, e.Tls.Ca
 	}
 	return k

--- a/sdk/config/option_redis.go
+++ b/sdk/config/option_redis.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -95,9 +97,7 @@ func (e RedisOptions) Client(ctx context.Context) (*goredis.Client, error) {
 		return nil, err
 	}
 
-	// Everything that decides which keyspace a command lands in. Two configs
-	// differing only in pool size share a client; differing in db do not.
-	target := fmt.Sprintf("%s|%s|%s|%d", o.Network, o.Addr, o.Username, o.DB)
+	target := cacheKey(o)
 
 	clients.Lock()
 	defer clients.Unlock()
@@ -116,6 +116,33 @@ func (e RedisOptions) Client(ctx context.Context) (*goredis.Client, error) {
 	}
 	clients.byTarget[target] = client
 	return client, nil
+}
+
+// cacheKey identifies a connection by everything that decides where a command
+// lands and who it is issued as.
+//
+// Credentials and transport belong in it, not just the address: sharing a
+// client across two configs that differ only in password would make the wrong
+// one appear to work, which hides the misconfiguration instead of reporting it.
+// The result is hashed so no secret is held as a map key.
+func cacheKey(o *goredis.Options) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "%s\x00%s\x00%s\x00%s\x00%d\x00", o.Network, o.Addr, o.Username, o.Password, o.DB)
+
+	if o.TLSConfig == nil {
+		fmt.Fprint(h, "notls")
+		return hex.EncodeToString(h.Sum(nil))
+	}
+
+	fmt.Fprintf(h, "tls\x00%s\x00%t\x00", o.TLSConfig.ServerName, o.TLSConfig.InsecureSkipVerify)
+	// The certificates themselves, not how many there are: two configurations
+	// presenting a different identity must not share a connection.
+	for _, cert := range o.TLSConfig.Certificates {
+		for _, der := range cert.Certificate {
+			h.Write(der)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // connect dials with the boot timeout applied.

--- a/sdk/config/queue.go
+++ b/sdk/config/queue.go
@@ -1,11 +1,17 @@
 package config
 
 import (
+	"time"
+
 	"github.com/go-admin-team/go-admin-core/storage"
 	"github.com/go-admin-team/go-admin-core/storage/queue"
+	redisstore "github.com/go-admin-team/go-admin-core/storage/redis"
 )
 
+// Queue selects the queue backend, on the same terms as Cache: memory unless a
+// redis section says otherwise.
 type Queue struct {
+	Redis  *RedisQueue
 	Memory *QueueMemory
 }
 
@@ -13,14 +19,76 @@ type QueueMemory struct {
 	PoolSize uint
 }
 
+// RedisQueue adds the consumer-group settings to a Redis connection.
+//
+// The json names are what a settings file is keyed on. For what each setting
+// means and what a zero value falls back to, see redisstore.QueueOptions;
+// options absent here can only be set in code.
+type RedisQueue struct {
+	RedisOptions `yaml:",inline"`
+
+	Group       string `yaml:"group" json:"group"`
+	KeyPrefix   string `yaml:"key_prefix" json:"key_prefix"`
+	MaxAttempts int    `yaml:"max_attempts" json:"max_attempts"`
+
+	// In seconds, because a settings file cannot express a time.Duration.
+	ClaimMinIdleSeconds int `yaml:"claim_min_idle_seconds" json:"claim_min_idle_seconds"`
+}
+
 var QueueConfig = new(Queue)
 
 // Empty 空设置
 func (e Queue) Empty() bool {
-	return e.Memory == nil
+	return e.Memory == nil && e.Redis == nil
 }
 
-// Setup 启用顺序  其他 > memory
+// Open builds the configured queue. Order: redis > memory.
+//
+// As with Cache.Open, an unreachable redis section is an error rather than a
+// fallback to a queue that other instances cannot see.
+func (e Queue) Open() (storage.Queue, error) {
+	if e.Redis == nil {
+		// Open is exported, so it cannot assume Empty was checked first.
+		var size int
+		if e.Memory != nil {
+			size = int(e.Memory.PoolSize)
+		}
+		return queue.NewMemQueue(size), nil
+	}
+
+	client, err := e.Redis.connect()
+	if err != nil {
+		return nil, err
+	}
+	return redisstore.NewQueue(client, redisstore.QueueOptions{
+		Group:        e.Redis.Group,
+		KeyPrefix:    e.Redis.KeyPrefix,
+		MaxAttempts:  e.Redis.MaxAttempts,
+		ClaimMinIdle: time.Duration(e.Redis.ClaimMinIdleSeconds) * time.Second,
+	}), nil
+}
+
+// Setup 启用顺序 redis > 其他 > memory
+//
+// Deprecated: use Open, which returns the current contract.
+//
+// Note that the two branches do not behave identically, because the memory one
+// stays on the older implementation: there, Register starts consuming on its
+// own and retries a failed message three times, while the bridged Redis queue
+// only consumes once Run is called. A call site that registers without running
+// works on memory and silently consumes nothing on Redis.
 func (e Queue) Setup() (storage.AdapterQueue, error) {
-	return queue.NewMemory(e.Memory.PoolSize), nil
+	if e.Redis == nil {
+		var size uint
+		if e.Memory != nil {
+			size = e.Memory.PoolSize
+		}
+		return queue.NewMemory(size), nil
+	}
+
+	q, err := e.Open()
+	if err != nil {
+		return nil, err
+	}
+	return storage.LegacyQueueAdapter(q), nil
 }

--- a/sdk/config/queue.go
+++ b/sdk/config/queue.go
@@ -68,7 +68,7 @@ func (e Queue) Open() (storage.Queue, error) {
 	}), nil
 }
 
-// Setup 启用顺序 redis > 其他 > memory
+// Setup builds the queue adapter. Order: redis > memory.
 //
 // Deprecated: use Open, which returns the current contract.
 //

--- a/storage/cache/memcache.go
+++ b/storage/cache/memcache.go
@@ -40,6 +40,10 @@ var _ storage.Cache = (*MemCache)(nil)
 
 // NewMemCache returns a cache that sweeps expired entries every
 // defaultSweepInterval. Call Close when the instance is not process-wide.
+// String identifies the backend, which is what the deprecated AdapterCache
+// interface reports through storage.LegacyAdapter.
+func (c *MemCache) String() string { return "memory" }
+
 func NewMemCache() *MemCache {
 	return NewMemCacheWithSweep(defaultSweepInterval)
 }

--- a/storage/cachetest/queuetest.go
+++ b/storage/cachetest/queuetest.go
@@ -33,6 +33,7 @@ func RunQueue(t *testing.T, newQueue QueueFactory) {
 		{"AttemptsStartAtOne", testAttemptsStartAtOne},
 		{"StartReturnsOnContextCancel", testStartReturnsOnContextCancel},
 		{"SubscribeAfterStartIsRejected", testSubscribeAfterStartIsRejected},
+		{"SubscribeErrorPrecedence", testSubscribeErrorPrecedence},
 		{"SecondStartIsRejected", testSecondStartIsRejected},
 		{"CloseIsIdempotent", testQueueCloseIsIdempotent},
 		{"PublishAfterCloseFails", testPublishAfterCloseFails},
@@ -63,6 +64,24 @@ func started(t *testing.T, q storage.Queue) func() {
 		case <-time.After(3 * time.Second):
 			t.Error("Start did not return after the context was cancelled")
 		}
+	}
+}
+
+// subscribe and publish fail the test on error. No case below is about a
+// failing Subscribe or Publish, so an error there means a broken backend
+// rather than the thing under test, and it should be reported where it
+// happens instead of surfacing later as a timeout.
+func subscribe(t *testing.T, q storage.Queue, topic string, h storage.Handler) {
+	t.Helper()
+	if err := q.Subscribe(topic, h); err != nil {
+		t.Fatalf("Subscribe(%q): %v", topic, err)
+	}
+}
+
+func publish(t *testing.T, q storage.Queue, msg storage.Message) {
+	t.Helper()
+	if err := q.Publish(context.Background(), msg); err != nil {
+		t.Fatalf("Publish to %q: %v", msg.Topic, err)
 	}
 }
 
@@ -113,20 +132,36 @@ func (c *collector) await(t *testing.T, n int) []storage.Message {
 	return out
 }
 
+// running returns a queue with "orders" subscribed and Start proven to be past
+// its guard. The awaited delivery is the barrier: without it, a Subscribe or
+// Start issued next races the one already in flight and either may win.
+func running(t *testing.T, newQueue QueueFactory) (storage.Queue, *collector) {
+	t.Helper()
+
+	q := newQueue(t)
+	t.Cleanup(func() { _ = q.Close() })
+
+	c := newCollector()
+	subscribe(t, q, "orders", c.handle)
+	// Cleanup is LIFO, so the queue stops before it is closed.
+	t.Cleanup(started(t, q))
+
+	publish(t, q, storage.Message{Topic: "orders"})
+	c.await(t, 1)
+
+	return q, c
+}
+
 func testDeliversPublishedMessage(t *testing.T, newQueue QueueFactory) {
 	q := newQueue(t)
 	defer q.Close()
 
 	c := newCollector()
-	if err := q.Subscribe("orders", c.handle); err != nil {
-		t.Fatalf("Subscribe: %v", err)
-	}
+	subscribe(t, q, "orders", c.handle)
 	stop := started(t, q)
 	defer stop()
 
-	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
+	publish(t, q, storage.Message{Topic: "orders"})
 
 	c.await(t, 1)
 }
@@ -136,11 +171,11 @@ func testPreservesValues(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	c := newCollector()
-	_ = q.Subscribe("orders", c.handle)
+	subscribe(t, q, "orders", c.handle)
 	stop := started(t, q)
 	defer stop()
 
-	_ = q.Publish(context.Background(), storage.Message{
+	publish(t, q, storage.Message{
 		Topic:  "orders",
 		Values: map[string]interface{}{"id": "42", "kind": "refund"},
 	})
@@ -156,11 +191,11 @@ func testAssignsID(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	c := newCollector()
-	_ = q.Subscribe("orders", c.handle)
+	subscribe(t, q, "orders", c.handle)
 	stop := started(t, q)
 	defer stop()
 
-	_ = q.Publish(context.Background(), storage.Message{Topic: "orders"})
+	publish(t, q, storage.Message{Topic: "orders"})
 
 	if got := c.await(t, 1)[0]; got.ID == "" {
 		t.Error("the queue must assign an ID on publish")
@@ -172,12 +207,12 @@ func testRoutesByTopic(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	a, b := newCollector(), newCollector()
-	_ = q.Subscribe("a", a.handle)
-	_ = q.Subscribe("b", b.handle)
+	subscribe(t, q, "a", a.handle)
+	subscribe(t, q, "b", b.handle)
 	stop := started(t, q)
 	defer stop()
 
-	_ = q.Publish(context.Background(), storage.Message{Topic: "b"})
+	publish(t, q, storage.Message{Topic: "b"})
 
 	b.await(t, 1)
 
@@ -224,19 +259,14 @@ func testStringValuesRoundTrip(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	c := newCollector()
-	if err := q.Subscribe("orders", c.handle); err != nil {
-		t.Fatalf("Subscribe: %v", err)
-	}
+	subscribe(t, q, "orders", c.handle)
 	stop := started(t, q)
 	defer stop()
 
-	err := q.Publish(context.Background(), storage.Message{
+	publish(t, q, storage.Message{
 		Topic:  "orders",
 		Values: map[string]interface{}{"id": "42", "note": ""},
 	})
-	if err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
 
 	got := c.await(t, 1)[0]
 	if got.Values["id"] != "42" {
@@ -254,7 +284,7 @@ func testEmptyPayloadIsDelivered(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	c := newCollector()
-	_ = q.Subscribe("orders", c.handle)
+	subscribe(t, q, "orders", c.handle)
 	stop := started(t, q)
 	defer stop()
 
@@ -271,21 +301,7 @@ func testEmptyPayloadIsDelivered(t *testing.T, newQueue QueueFactory) {
 // backend can see the subscription, while nothing reads it. Rejecting the
 // subscription is what keeps that from becoming a silent backlog.
 func testSubscribeAfterStartIsRejected(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
-
-	c := newCollector()
-	if err := q.Subscribe("orders", c.handle); err != nil {
-		t.Fatalf("Subscribe: %v", err)
-	}
-	stop := started(t, q)
-	defer stop()
-
-	// As above, a delivered message proves Start is running.
-	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
-	c.await(t, 1)
+	q, _ := running(t, newQueue)
 
 	err := q.Subscribe("late", func(context.Context, storage.Message) error { return nil })
 	if !errors.Is(err, storage.ErrQueueAlreadyStarted) {
@@ -293,25 +309,31 @@ func testSubscribeAfterStartIsRejected(t *testing.T, newQueue QueueFactory) {
 	}
 }
 
+// Two rules are broken at once here. The contract fixes which error wins, so
+// that a caller switching backend does not get a different answer — the
+// implementations disagreed on exactly this before it was pinned.
+func testSubscribeErrorPrecedence(t *testing.T, newQueue QueueFactory) {
+	q, _ := running(t, newQueue)
+
+	if err := q.Subscribe("late", nil); !errors.Is(err, storage.ErrNilHandler) {
+		t.Errorf("a nil handler on a started queue: got %v, want ErrNilHandler", err)
+	}
+
+	// Closed outranks started, because it is the terminal state and the one a
+	// caller has to act on.
+	if err := q.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	err := q.Subscribe("late", func(context.Context, storage.Message) error { return nil })
+	if !errors.Is(err, storage.ErrQueueClosed) {
+		t.Errorf("Subscribe on a started, closed queue: got %v, want ErrQueueClosed", err)
+	}
+}
+
 // Start is not restartable; a second call must say so rather than running a
 // second read loop against the same handlers.
 func testSecondStartIsRejected(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
-
-	c := newCollector()
-	if err := q.Subscribe("orders", c.handle); err != nil {
-		t.Fatalf("Subscribe: %v", err)
-	}
-	stop := started(t, q)
-	defer stop()
-
-	// A delivered message proves the first Start is past the guard. Without
-	// this, the two calls race and either one may be the one that wins.
-	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
-		t.Fatalf("Publish: %v", err)
-	}
-	c.await(t, 1)
+	q, _ := running(t, newQueue)
 
 	// Already cancelled, so an implementation that wrongly runs a second read
 	// loop fails the assertion instead of hanging the suite.
@@ -338,11 +360,11 @@ func testAttemptsStartAtOne(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	c := newCollector()
-	_ = q.Subscribe("orders", c.handle)
+	subscribe(t, q, "orders", c.handle)
 	stop := started(t, q)
 	defer stop()
 
-	_ = q.Publish(context.Background(), storage.Message{Topic: "orders"})
+	publish(t, q, storage.Message{Topic: "orders"})
 
 	if got := c.await(t, 1)[0]; got.Attempts != 1 {
 		t.Errorf("Attempts on first delivery: got %d, want 1", got.Attempts)
@@ -382,7 +404,7 @@ func testQueueCloseIsIdempotent(t *testing.T, newQueue QueueFactory) {
 
 func testPublishAfterCloseFails(t *testing.T, newQueue QueueFactory) {
 	q := newQueue(t)
-	_ = q.Subscribe("orders", func(context.Context, storage.Message) error { return nil })
+	subscribe(t, q, "orders", func(context.Context, storage.Message) error { return nil })
 	if err := q.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}

--- a/storage/cachetest/queuetest.go
+++ b/storage/cachetest/queuetest.go
@@ -23,6 +23,8 @@ func RunQueue(t *testing.T, newQueue QueueFactory) {
 	}{
 		{"DeliversPublishedMessage", testDeliversPublishedMessage},
 		{"PreservesValues", testPreservesValues},
+		{"StringValuesRoundTrip", testStringValuesRoundTrip},
+		{"EmptyPayloadIsDelivered", testEmptyPayloadIsDelivered},
 		{"AssignsID", testAssignsID},
 		{"RoutesByTopic", testRoutesByTopic},
 		{"RejectsDuplicateSubscription", testRejectsDuplicateSubscription},
@@ -30,6 +32,7 @@ func RunQueue(t *testing.T, newQueue QueueFactory) {
 		{"PublishWithoutHandlerFails", testPublishWithoutHandlerFails},
 		{"AttemptsStartAtOne", testAttemptsStartAtOne},
 		{"StartReturnsOnContextCancel", testStartReturnsOnContextCancel},
+		{"SecondStartIsRejected", testSecondStartIsRejected},
 		{"CloseIsIdempotent", testQueueCloseIsIdempotent},
 		{"PublishAfterCloseFails", testPublishAfterCloseFails},
 	}
@@ -207,8 +210,80 @@ func testRejectsNilHandler(t *testing.T, newQueue QueueFactory) {
 	q := newQueue(t)
 	defer q.Close()
 
-	if err := q.Subscribe("orders", nil); err == nil {
-		t.Error("Subscribe with a nil handler must be rejected")
+	err := q.Subscribe("orders", nil)
+	if !errors.Is(err, storage.ErrNilHandler) {
+		t.Errorf("got %v, want ErrNilHandler", err)
+	}
+}
+
+// Only strings are promised to survive; a broker-backed queue has to serialise
+// the payload and an in-process one does not.
+func testStringValuesRoundTrip(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	_ = q.Subscribe("orders", c.handle)
+	stop := started(t, q)
+	defer stop()
+
+	_ = q.Publish(context.Background(), storage.Message{
+		Topic:  "orders",
+		Values: map[string]interface{}{"id": "42", "note": ""},
+	})
+
+	got := c.await(t, 1)[0]
+	if got.Values["id"] != "42" {
+		t.Errorf("id: got %#v, want the string 42", got.Values["id"])
+	}
+	if got.Values["note"] != "" {
+		t.Errorf("an empty string is a legal value, got %#v", got.Values["note"])
+	}
+}
+
+// A message with no values is still a message, and some backends cannot store
+// an entry that carries no field at all.
+func testEmptyPayloadIsDelivered(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	_ = q.Subscribe("orders", c.handle)
+	stop := started(t, q)
+	defer stop()
+
+	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
+		t.Fatalf("Publish with no values: %v", err)
+	}
+
+	if got := c.await(t, 1)[0]; len(got.Values) != 0 {
+		t.Errorf("an empty payload must stay empty, got %#v", got.Values)
+	}
+}
+
+// Start is not restartable; a second call must say so rather than running a
+// second read loop against the same handlers.
+func testSecondStartIsRejected(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	_ = q.Subscribe("orders", c.handle)
+	stop := started(t, q)
+	defer stop()
+
+	// A delivered message proves the first Start is past the guard. Without
+	// this, the two calls race and either one may be the one that wins.
+	_ = q.Publish(context.Background(), storage.Message{Topic: "orders"})
+	c.await(t, 1)
+
+	// Already cancelled, so an implementation that wrongly runs a second read
+	// loop fails the assertion instead of hanging the suite.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := q.Start(ctx); !errors.Is(err, storage.ErrQueueAlreadyStarted) {
+		t.Errorf("second Start: got %v, want ErrQueueAlreadyStarted", err)
 	}
 }
 

--- a/storage/cachetest/queuetest.go
+++ b/storage/cachetest/queuetest.go
@@ -32,6 +32,7 @@ func RunQueue(t *testing.T, newQueue QueueFactory) {
 		{"PublishWithoutHandlerFails", testPublishWithoutHandlerFails},
 		{"AttemptsStartAtOne", testAttemptsStartAtOne},
 		{"StartReturnsOnContextCancel", testStartReturnsOnContextCancel},
+		{"SubscribeAfterStartIsRejected", testSubscribeAfterStartIsRejected},
 		{"SecondStartIsRejected", testSecondStartIsRejected},
 		{"CloseIsIdempotent", testQueueCloseIsIdempotent},
 		{"PublishAfterCloseFails", testPublishAfterCloseFails},
@@ -223,14 +224,19 @@ func testStringValuesRoundTrip(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	c := newCollector()
-	_ = q.Subscribe("orders", c.handle)
+	if err := q.Subscribe("orders", c.handle); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
 	stop := started(t, q)
 	defer stop()
 
-	_ = q.Publish(context.Background(), storage.Message{
+	err := q.Publish(context.Background(), storage.Message{
 		Topic:  "orders",
 		Values: map[string]interface{}{"id": "42", "note": ""},
 	})
+	if err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
 
 	got := c.await(t, 1)[0]
 	if got.Values["id"] != "42" {
@@ -261,6 +267,32 @@ func testEmptyPayloadIsDelivered(t *testing.T, newQueue QueueFactory) {
 	}
 }
 
+// A topic registered after Start would be accepted by Publish, because the
+// backend can see the subscription, while nothing reads it. Rejecting the
+// subscription is what keeps that from becoming a silent backlog.
+func testSubscribeAfterStartIsRejected(t *testing.T, newQueue QueueFactory) {
+	q := newQueue(t)
+	defer q.Close()
+
+	c := newCollector()
+	if err := q.Subscribe("orders", c.handle); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+	stop := started(t, q)
+	defer stop()
+
+	// As above, a delivered message proves Start is running.
+	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	c.await(t, 1)
+
+	err := q.Subscribe("late", func(context.Context, storage.Message) error { return nil })
+	if !errors.Is(err, storage.ErrQueueAlreadyStarted) {
+		t.Errorf("Subscribe after Start: got %v, want ErrQueueAlreadyStarted", err)
+	}
+}
+
 // Start is not restartable; a second call must say so rather than running a
 // second read loop against the same handlers.
 func testSecondStartIsRejected(t *testing.T, newQueue QueueFactory) {
@@ -268,13 +300,17 @@ func testSecondStartIsRejected(t *testing.T, newQueue QueueFactory) {
 	defer q.Close()
 
 	c := newCollector()
-	_ = q.Subscribe("orders", c.handle)
+	if err := q.Subscribe("orders", c.handle); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
 	stop := started(t, q)
 	defer stop()
 
 	// A delivered message proves the first Start is past the guard. Without
 	// this, the two calls race and either one may be the one that wins.
-	_ = q.Publish(context.Background(), storage.Message{Topic: "orders"})
+	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
 	c.await(t, 1)
 
 	// Already cancelled, so an implementation that wrongly runs a second read

--- a/storage/cachetest/queuetest.go
+++ b/storage/cachetest/queuetest.go
@@ -33,7 +33,8 @@ func RunQueue(t *testing.T, newQueue QueueFactory) {
 		{"AttemptsStartAtOne", testAttemptsStartAtOne},
 		{"StartReturnsOnContextCancel", testStartReturnsOnContextCancel},
 		{"SubscribeAfterStartIsRejected", testSubscribeAfterStartIsRejected},
-		{"SubscribeErrorPrecedence", testSubscribeErrorPrecedence},
+		{"BadArgumentOutranksState", testBadArgumentOutranksState},
+		{"ClosedOutranksStarted", testClosedOutranksStarted},
 		{"SecondStartIsRejected", testSecondStartIsRejected},
 		{"CloseIsIdempotent", testQueueCloseIsIdempotent},
 		{"PublishAfterCloseFails", testPublishAfterCloseFails},
@@ -67,10 +68,9 @@ func started(t *testing.T, q storage.Queue) func() {
 	}
 }
 
-// subscribe and publish fail the test on error. No case below is about a
-// failing Subscribe or Publish, so an error there means a broken backend
-// rather than the thing under test, and it should be reported where it
-// happens instead of surfacing later as a timeout.
+// subscribe and publish fail where the error happens. No case below is about
+// a failing Subscribe or Publish, so one would otherwise surface as a timeout
+// somewhere else.
 func subscribe(t *testing.T, q storage.Queue, topic string, h storage.Handler) {
 	t.Helper()
 	if err := q.Subscribe(topic, h); err != nil {
@@ -132,34 +132,38 @@ func (c *collector) await(t *testing.T, n int) []storage.Message {
 	return out
 }
 
-// running returns a queue with "orders" subscribed and Start proven to be past
-// its guard. The awaited delivery is the barrier: without it, a Subscribe or
-// Start issued next races the one already in flight and either may win.
-func running(t *testing.T, newQueue QueueFactory) (storage.Queue, *collector) {
+// subscribed returns a running queue with topic delivered to the collector. It
+// does not prove Start is past its guard; use running where that matters.
+func subscribed(t *testing.T, newQueue QueueFactory, topic string) (storage.Queue, *collector) {
 	t.Helper()
 
 	q := newQueue(t)
 	t.Cleanup(func() { _ = q.Close() })
 
 	c := newCollector()
-	subscribe(t, q, "orders", c.handle)
+	subscribe(t, q, topic, c.handle)
 	// Cleanup is LIFO, so the queue stops before it is closed.
 	t.Cleanup(started(t, q))
-
-	publish(t, q, storage.Message{Topic: "orders"})
-	c.await(t, 1)
 
 	return q, c
 }
 
-func testDeliversPublishedMessage(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
+// running additionally waits for one delivery, which is the barrier a case
+// needs before issuing a second Start or a late Subscribe: without it the two
+// race and either may win. The collector is not returned because the barrier
+// message is already in it.
+func running(t *testing.T, newQueue QueueFactory) storage.Queue {
+	t.Helper()
 
-	c := newCollector()
-	subscribe(t, q, "orders", c.handle)
-	stop := started(t, q)
-	defer stop()
+	q, c := subscribed(t, newQueue, "orders")
+	publish(t, q, storage.Message{Topic: "orders"})
+	c.await(t, 1)
+
+	return q
+}
+
+func testDeliversPublishedMessage(t *testing.T, newQueue QueueFactory) {
+	q, c := subscribed(t, newQueue, "orders")
 
 	publish(t, q, storage.Message{Topic: "orders"})
 
@@ -167,13 +171,7 @@ func testDeliversPublishedMessage(t *testing.T, newQueue QueueFactory) {
 }
 
 func testPreservesValues(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
-
-	c := newCollector()
-	subscribe(t, q, "orders", c.handle)
-	stop := started(t, q)
-	defer stop()
+	q, c := subscribed(t, newQueue, "orders")
 
 	publish(t, q, storage.Message{
 		Topic:  "orders",
@@ -187,13 +185,7 @@ func testPreservesValues(t *testing.T, newQueue QueueFactory) {
 }
 
 func testAssignsID(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
-
-	c := newCollector()
-	subscribe(t, q, "orders", c.handle)
-	stop := started(t, q)
-	defer stop()
+	q, c := subscribed(t, newQueue, "orders")
 
 	publish(t, q, storage.Message{Topic: "orders"})
 
@@ -255,13 +247,7 @@ func testRejectsNilHandler(t *testing.T, newQueue QueueFactory) {
 // Only strings are promised to survive; a broker-backed queue has to serialise
 // the payload and an in-process one does not.
 func testStringValuesRoundTrip(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
-
-	c := newCollector()
-	subscribe(t, q, "orders", c.handle)
-	stop := started(t, q)
-	defer stop()
+	q, c := subscribed(t, newQueue, "orders")
 
 	publish(t, q, storage.Message{
 		Topic:  "orders",
@@ -280,17 +266,9 @@ func testStringValuesRoundTrip(t *testing.T, newQueue QueueFactory) {
 // A message with no values is still a message, and some backends cannot store
 // an entry that carries no field at all.
 func testEmptyPayloadIsDelivered(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
+	q, c := subscribed(t, newQueue, "orders")
 
-	c := newCollector()
-	subscribe(t, q, "orders", c.handle)
-	stop := started(t, q)
-	defer stop()
-
-	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
-		t.Fatalf("Publish with no values: %v", err)
-	}
+	publish(t, q, storage.Message{Topic: "orders"})
 
 	if got := c.await(t, 1)[0]; len(got.Values) != 0 {
 		t.Errorf("an empty payload must stay empty, got %#v", got.Values)
@@ -301,7 +279,7 @@ func testEmptyPayloadIsDelivered(t *testing.T, newQueue QueueFactory) {
 // backend can see the subscription, while nothing reads it. Rejecting the
 // subscription is what keeps that from becoming a silent backlog.
 func testSubscribeAfterStartIsRejected(t *testing.T, newQueue QueueFactory) {
-	q, _ := running(t, newQueue)
+	q := running(t, newQueue)
 
 	err := q.Subscribe("late", func(context.Context, storage.Message) error { return nil })
 	if !errors.Is(err, storage.ErrQueueAlreadyStarted) {
@@ -312,18 +290,23 @@ func testSubscribeAfterStartIsRejected(t *testing.T, newQueue QueueFactory) {
 // Two rules are broken at once here. The contract fixes which error wins, so
 // that a caller switching backend does not get a different answer — the
 // implementations disagreed on exactly this before it was pinned.
-func testSubscribeErrorPrecedence(t *testing.T, newQueue QueueFactory) {
-	q, _ := running(t, newQueue)
+func testBadArgumentOutranksState(t *testing.T, newQueue QueueFactory) {
+	q := running(t, newQueue)
 
 	if err := q.Subscribe("late", nil); !errors.Is(err, storage.ErrNilHandler) {
 		t.Errorf("a nil handler on a started queue: got %v, want ErrNilHandler", err)
 	}
+}
 
-	// Closed outranks started, because it is the terminal state and the one a
-	// caller has to act on.
+// Closed outranks started: it is the terminal state, and the one a caller has
+// to act on.
+func testClosedOutranksStarted(t *testing.T, newQueue QueueFactory) {
+	q := running(t, newQueue)
+
 	if err := q.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
+
 	err := q.Subscribe("late", func(context.Context, storage.Message) error { return nil })
 	if !errors.Is(err, storage.ErrQueueClosed) {
 		t.Errorf("Subscribe on a started, closed queue: got %v, want ErrQueueClosed", err)
@@ -333,7 +316,7 @@ func testSubscribeErrorPrecedence(t *testing.T, newQueue QueueFactory) {
 // Start is not restartable; a second call must say so rather than running a
 // second read loop against the same handlers.
 func testSecondStartIsRejected(t *testing.T, newQueue QueueFactory) {
-	q, _ := running(t, newQueue)
+	q := running(t, newQueue)
 
 	// Already cancelled, so an implementation that wrongly runs a second read
 	// loop fails the assertion instead of hanging the suite.
@@ -356,13 +339,7 @@ func testPublishWithoutHandlerFails(t *testing.T, newQueue QueueFactory) {
 }
 
 func testAttemptsStartAtOne(t *testing.T, newQueue QueueFactory) {
-	q := newQueue(t)
-	defer q.Close()
-
-	c := newCollector()
-	subscribe(t, q, "orders", c.handle)
-	stop := started(t, q)
-	defer stop()
+	q, c := subscribed(t, newQueue, "orders")
 
 	publish(t, q, storage.Message{Topic: "orders"})
 

--- a/storage/legacy.go
+++ b/storage/legacy.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/spf13/cast"
@@ -28,7 +29,15 @@ type legacyAdapter struct {
 	inner Cache
 }
 
-func (l *legacyAdapter) String() string { return "legacy" }
+// String reports the backend's own identity where it has one. Operators read
+// this to tell what is actually running, so the bridge must not stand in front
+// of it.
+func (l *legacyAdapter) String() string {
+	if s, ok := l.inner.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return "legacy"
+}
 
 func (l *legacyAdapter) Get(key string) (string, error) {
 	v, err := l.inner.Get(context.Background(), key)

--- a/storage/legacy_queue.go
+++ b/storage/legacy_queue.go
@@ -1,0 +1,138 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+// LegacyQueueAdapter exposes a Queue through the older AdapterQueue interface,
+// so a backend can be selected by configuration without changing the call
+// sites that still take AdapterQueue.
+//
+// It cannot repair the older contract, only preserve it:
+//
+//   - Register returns nothing, so a rejected topic or an unreachable backend
+//     can only be logged. Subscribe reports both; use it where that matters.
+//   - ConsumerFunc takes no context, so a cancelled Start does not reach a
+//     handler that is already running.
+//   - Messager counts errors while Message counts deliveries. GetErrorCount is
+//     therefore Attempts minus one, since the first delivery has not failed.
+func LegacyQueueAdapter(q Queue) AdapterQueue {
+	return &legacyQueueAdapter{inner: q}
+}
+
+type legacyQueueAdapter struct {
+	inner Queue
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+}
+
+// String reports the backend's own identity where it has one. Operators read
+// this to tell what is actually running, so the bridge must not stand in front
+// of it.
+func (l *legacyQueueAdapter) String() string {
+	if s, ok := l.inner.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return "legacy"
+}
+
+func (l *legacyQueueAdapter) Append(message Messager) error {
+	if message == nil {
+		return errors.New("storage: nil message")
+	}
+	return l.inner.Publish(context.Background(), Message{
+		Topic:  message.GetStream(),
+		Values: message.GetValues(),
+	})
+}
+
+func (l *legacyQueueAdapter) Register(name string, f ConsumerFunc) {
+	if f == nil {
+		slog.Error("queue: ignoring a nil consumer", "topic", name)
+		return
+	}
+
+	err := l.inner.Subscribe(name, func(_ context.Context, msg Message) error {
+		return f(&legacyMessage{msg: msg})
+	})
+	if err != nil {
+		// The interface has no way to report this to the caller, which is one
+		// of the reasons it is deprecated.
+		slog.Error("queue: subscribe failed", "topic", name, "error", err)
+	}
+}
+
+func (l *legacyQueueAdapter) Run() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	l.mu.Lock()
+	if l.cancel != nil {
+		l.mu.Unlock()
+		cancel()
+		slog.Error("queue: already running")
+		return
+	}
+	l.cancel = cancel
+	l.mu.Unlock()
+
+	if err := l.inner.Start(ctx); err != nil {
+		slog.Error("queue: stopped", "error", err)
+	}
+}
+
+func (l *legacyQueueAdapter) Shutdown() {
+	l.mu.Lock()
+	cancel := l.cancel
+	l.cancel = nil
+	l.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if err := l.inner.Close(); err != nil {
+		slog.Error("queue: close failed", "error", err)
+	}
+}
+
+// legacyMessage presents a Message through the older Messager interface.
+type legacyMessage struct {
+	msg Message
+}
+
+var _ Messager = (*legacyMessage)(nil)
+
+func (m *legacyMessage) GetID() string      { return m.msg.ID }
+func (m *legacyMessage) SetID(id string)    { m.msg.ID = id }
+func (m *legacyMessage) GetStream() string  { return m.msg.Topic }
+func (m *legacyMessage) SetStream(s string) { m.msg.Topic = s }
+
+func (m *legacyMessage) GetValues() map[string]interface{} { return m.msg.Values }
+
+func (m *legacyMessage) SetValues(v map[string]interface{}) { m.msg.Values = v }
+
+func (m *legacyMessage) GetPrefix() string {
+	if m.msg.Values == nil {
+		return ""
+	}
+	prefix, _ := m.msg.Values[PrefixKey].(string)
+	return prefix
+}
+
+func (m *legacyMessage) SetPrefix(prefix string) {
+	if m.msg.Values == nil {
+		m.msg.Values = make(map[string]interface{})
+	}
+	m.msg.Values[PrefixKey] = prefix
+}
+
+// GetErrorCount reports one less than Attempts: the older interface counted
+// failures, the new one counts deliveries, and the first delivery has not
+// failed yet.
+func (m *legacyMessage) GetErrorCount() int { return m.msg.Attempts - 1 }
+
+func (m *legacyMessage) SetErrorCount(count int) { m.msg.Attempts = count + 1 }

--- a/storage/legacy_queue_test.go
+++ b/storage/legacy_queue_test.go
@@ -1,0 +1,155 @@
+package storage_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+	"github.com/go-admin-team/go-admin-core/storage/queue"
+)
+
+func newLegacyQueue(t *testing.T) storage.AdapterQueue {
+	t.Helper()
+	return storage.LegacyQueueAdapter(queue.NewMemQueue(64))
+}
+
+// The point of the adapter: a call site written against AdapterQueue keeps
+// working when the backend underneath it changes.
+func TestLegacyQueueAdapterDelivers(t *testing.T) {
+	q := newLegacyQueue(t)
+
+	got := make(chan storage.Messager, 1)
+	q.Register("orders", func(m storage.Messager) error {
+		got <- m
+		return nil
+	})
+
+	go q.Run()
+	defer q.Shutdown()
+
+	msg := &queue.Message{Stream: "orders", Values: map[string]interface{}{"id": "42"}}
+	if err := q.Append(msg); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	select {
+	case m := <-got:
+		if m.GetStream() != "orders" {
+			t.Errorf("stream: got %q, want orders", m.GetStream())
+		}
+		if m.GetValues()["id"] != "42" {
+			t.Errorf("values were not preserved: %v", m.GetValues())
+		}
+		if m.GetID() == "" {
+			t.Error("the queue must assign an ID")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the message")
+	}
+}
+
+// Append still reports an unconsumed topic, which is the one thing the older
+// interface can express.
+func TestLegacyQueueAdapterReportsUnknownTopic(t *testing.T) {
+	q := newLegacyQueue(t)
+	defer q.Shutdown()
+
+	err := q.Append(&queue.Message{Stream: "nobody-listens"})
+	if err == nil {
+		t.Error("Append to an unconsumed topic must fail rather than drop the message")
+	}
+}
+
+func TestLegacyQueueAdapterRejectsNilMessage(t *testing.T) {
+	q := newLegacyQueue(t)
+	defer q.Shutdown()
+
+	if err := q.Append(nil); err == nil {
+		t.Error("a nil message must be rejected instead of panicking")
+	}
+}
+
+// Shutdown must be safe whether or not Run was ever called, since the older
+// interface gives no way to tell.
+func TestLegacyQueueAdapterShutdownIsIdempotent(t *testing.T) {
+	q := newLegacyQueue(t)
+
+	q.Shutdown()
+	q.Shutdown()
+}
+
+// Messager counts failures, Message counts deliveries. A first delivery has not
+// failed yet, so GetErrorCount must report zero.
+func TestLegacyQueueAdapterErrorCountOffset(t *testing.T) {
+	q := newLegacyQueue(t)
+
+	got := make(chan int, 1)
+	q.Register("orders", func(m storage.Messager) error {
+		got <- m.GetErrorCount()
+		return nil
+	})
+
+	go q.Run()
+	defer q.Shutdown()
+
+	if err := q.Append(&queue.Message{Stream: "orders"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	select {
+	case n := <-got:
+		if n != 0 {
+			t.Errorf("GetErrorCount on a first delivery: got %d, want 0", n)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the message")
+	}
+}
+
+// A duplicate topic cannot be reported through Register, so the first handler
+// has to stay in place rather than being silently replaced.
+func TestLegacyQueueAdapterKeepsTheFirstHandler(t *testing.T) {
+	q := newLegacyQueue(t)
+
+	first := make(chan struct{}, 1)
+	second := make(chan struct{}, 1)
+	q.Register("orders", func(storage.Messager) error { first <- struct{}{}; return nil })
+	q.Register("orders", func(storage.Messager) error { second <- struct{}{}; return nil })
+
+	go q.Run()
+	defer q.Shutdown()
+
+	if err := q.Append(&queue.Message{Stream: "orders"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	select {
+	case <-first:
+	case <-second:
+		t.Error("the second Register must not replace the first handler")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for the message")
+	}
+}
+
+// Run blocks until the queue stops, which is what "go q.Run()" at every call
+// site relies on.
+func TestLegacyQueueAdapterRunReturnsOnShutdown(t *testing.T) {
+	q := newLegacyQueue(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		q.Run()
+	}()
+
+	// Give Run a moment to reach the read loop before stopping it.
+	time.Sleep(50 * time.Millisecond)
+	q.Shutdown()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Error("Run did not return after Shutdown")
+	}
+}

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -21,7 +21,8 @@ var (
 	// ErrNilHandler reports a subscription with nothing to deliver to.
 	ErrNilHandler = errors.New("storage: nil handler")
 
-	// ErrQueueAlreadyStarted reports a second call to Start.
+	// ErrQueueAlreadyStarted reports a second call to Start, or a Subscribe
+	// that arrived too late to take effect.
 	ErrQueueAlreadyStarted = errors.New("storage: queue already started")
 )
 
@@ -63,8 +64,11 @@ type Queue interface {
 	// ErrNoHandler is returned rather than dropping the message silently.
 	Publish(ctx context.Context, msg Message) error
 
-	// Subscribe registers the handler for a topic. It must be called before
-	// Start, and returns ErrTopicAlreadySubscribed if the topic is taken.
+	// Subscribe registers the handler for a topic. It returns
+	// ErrTopicAlreadySubscribed if the topic is taken, ErrNilHandler if there
+	// is nothing to deliver to, and ErrQueueAlreadyStarted once Start has been
+	// called: an implementation may fix its set of topics at that point, so a
+	// late subscription would accept messages that are never delivered.
 	Subscribe(topic string, h Handler) error
 
 	// Start begins consuming and blocks until ctx is done or an unrecoverable

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -21,8 +21,9 @@ var (
 	// ErrNilHandler reports a subscription with nothing to deliver to.
 	ErrNilHandler = errors.New("storage: nil handler")
 
-	// ErrQueueAlreadyStarted reports a second call to Start, or a Subscribe
-	// that arrived too late to take effect.
+	// ErrQueueAlreadyStarted reports that the queue is running. Start freezes
+	// both the run state and the set of topics, so it covers a second Start and
+	// a Subscribe that arrived too late to be read.
 	ErrQueueAlreadyStarted = errors.New("storage: queue already started")
 )
 
@@ -64,11 +65,14 @@ type Queue interface {
 	// ErrNoHandler is returned rather than dropping the message silently.
 	Publish(ctx context.Context, msg Message) error
 
-	// Subscribe registers the handler for a topic. It returns
-	// ErrTopicAlreadySubscribed if the topic is taken, ErrNilHandler if there
-	// is nothing to deliver to, and ErrQueueAlreadyStarted once Start has been
-	// called: an implementation may fix its set of topics at that point, so a
-	// late subscription would accept messages that are never delivered.
+	// Subscribe registers the handler for a topic. It must be called before
+	// Start, because an implementation may fix its set of topics there and a
+	// late subscription would then let Publish succeed with nothing reading it.
+	//
+	// Where more than one rule is broken at once the errors are reported in
+	// this order, so that every implementation answers alike: ErrNilHandler,
+	// ErrQueueClosed, ErrQueueAlreadyStarted, ErrTopicAlreadySubscribed. A
+	// closed queue is reported first because that state is terminal.
 	Subscribe(topic string, h Handler) error
 
 	// Start begins consuming and blocks until ctx is done or an unrecoverable

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -21,9 +21,8 @@ var (
 	// ErrNilHandler reports a subscription with nothing to deliver to.
 	ErrNilHandler = errors.New("storage: nil handler")
 
-	// ErrQueueAlreadyStarted reports that the queue is running. Start freezes
-	// both the run state and the set of topics, so it covers a second Start and
-	// a Subscribe that arrived too late to be read.
+	// ErrQueueAlreadyStarted reports a second call to Start, or a Subscribe
+	// that arrived too late to take effect.
 	ErrQueueAlreadyStarted = errors.New("storage: queue already started")
 )
 
@@ -69,10 +68,11 @@ type Queue interface {
 	// Start, because an implementation may fix its set of topics there and a
 	// late subscription would then let Publish succeed with nothing reading it.
 	//
-	// Where more than one rule is broken at once the errors are reported in
-	// this order, so that every implementation answers alike: ErrNilHandler,
-	// ErrQueueClosed, ErrQueueAlreadyStarted, ErrTopicAlreadySubscribed. A
-	// closed queue is reported first because that state is terminal.
+	// Where more than one rule is broken at once, every implementation has to
+	// answer alike: a bad argument outranks the queue's state, and among
+	// states the terminal one outranks the rest. So ErrNilHandler, then
+	// ErrQueueClosed, then ErrQueueAlreadyStarted, then
+	// ErrTopicAlreadySubscribed.
 	Subscribe(topic string, h Handler) error
 
 	// Start begins consuming and blocks until ctx is done or an unrecoverable

--- a/storage/queue.go
+++ b/storage/queue.go
@@ -17,6 +17,12 @@ var (
 
 	// ErrNoHandler reports a message published to a topic nobody consumes.
 	ErrNoHandler = errors.New("storage: no handler for topic")
+
+	// ErrNilHandler reports a subscription with nothing to deliver to.
+	ErrNilHandler = errors.New("storage: nil handler")
+
+	// ErrQueueAlreadyStarted reports a second call to Start.
+	ErrQueueAlreadyStarted = errors.New("storage: queue already started")
 )
 
 // Message is a queued message.
@@ -32,6 +38,13 @@ type Message struct {
 	// Topic routes the message to a handler.
 	Topic string
 
+	// Values carries the payload.
+	//
+	// Only string values are guaranteed to arrive unchanged. Everything else is
+	// undefined across implementations, because a broker-backed queue has to
+	// serialise the map and an in-process one does not: the Redis queue returns
+	// a published int as a float64, the memory queue returns the int. Use
+	// strings, or encode the payload yourself.
 	Values map[string]interface{}
 
 	// Attempts counts deliveries of this message, starting at 1. A handler can

--- a/storage/queue/memqueue.go
+++ b/storage/queue/memqueue.go
@@ -27,7 +27,6 @@ type MemQueue struct {
 	// inFlight tracks deliveries so Close can wait for them.
 	inFlight sync.WaitGroup
 
-	// started is guarded by mu, matching the Redis implementation.
 	started  bool
 	stopOnce sync.Once
 	stop     chan struct{}
@@ -53,8 +52,6 @@ func NewMemQueue(size int) *MemQueue {
 }
 
 func (q *MemQueue) Subscribe(topic string, h storage.Handler) error {
-	// The order is the contract's and matches the Redis implementation, so both
-	// backends answer alike when more than one rule is broken at once.
 	if h == nil {
 		return storage.ErrNilHandler
 	}
@@ -64,9 +61,6 @@ func (q *MemQueue) Subscribe(topic string, h storage.Handler) error {
 	if q.closed {
 		return storage.ErrQueueClosed
 	}
-	// Read under the lock rather than atomically, matching the Redis
-	// implementation, where the check and Start's topic snapshot have to be one
-	// step.
 	if q.started {
 		return storage.ErrQueueAlreadyStarted
 	}

--- a/storage/queue/memqueue.go
+++ b/storage/queue/memqueue.go
@@ -52,6 +52,13 @@ func NewMemQueue(size int) *MemQueue {
 }
 
 func (q *MemQueue) Subscribe(topic string, h storage.Handler) error {
+	// Rejected for the same reason a stream-backed queue has to reject it: the
+	// contract fixes the set of topics at Start, and an implementation that
+	// quietly accepted a late one would hide the difference.
+	if q.started.Load() {
+		return storage.ErrQueueAlreadyStarted
+	}
+
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	if q.closed {

--- a/storage/queue/memqueue.go
+++ b/storage/queue/memqueue.go
@@ -27,7 +27,8 @@ type MemQueue struct {
 	// inFlight tracks deliveries so Close can wait for them.
 	inFlight sync.WaitGroup
 
-	started  atomic.Bool
+	// started is guarded by mu, matching the Redis implementation.
+	started  bool
 	stopOnce sync.Once
 	stop     chan struct{}
 }
@@ -52,11 +53,10 @@ func NewMemQueue(size int) *MemQueue {
 }
 
 func (q *MemQueue) Subscribe(topic string, h storage.Handler) error {
-	// Rejected for the same reason a stream-backed queue has to reject it: the
-	// contract fixes the set of topics at Start, and an implementation that
-	// quietly accepted a late one would hide the difference.
-	if q.started.Load() {
-		return storage.ErrQueueAlreadyStarted
+	// The order is the contract's and matches the Redis implementation, so both
+	// backends answer alike when more than one rule is broken at once.
+	if h == nil {
+		return storage.ErrNilHandler
 	}
 
 	q.mu.Lock()
@@ -64,8 +64,11 @@ func (q *MemQueue) Subscribe(topic string, h storage.Handler) error {
 	if q.closed {
 		return storage.ErrQueueClosed
 	}
-	if h == nil {
-		return storage.ErrNilHandler
+	// Read under the lock rather than atomically, matching the Redis
+	// implementation, where the check and Start's topic snapshot have to be one
+	// step.
+	if q.started {
+		return storage.ErrQueueAlreadyStarted
 	}
 	if _, exists := q.handlers[topic]; exists {
 		return storage.ErrTopicAlreadySubscribed
@@ -107,9 +110,13 @@ func (q *MemQueue) Publish(ctx context.Context, msg storage.Message) error {
 }
 
 func (q *MemQueue) Start(ctx context.Context) error {
-	if !q.started.CompareAndSwap(false, true) {
+	q.mu.Lock()
+	if q.started {
+		q.mu.Unlock()
 		return storage.ErrQueueAlreadyStarted
 	}
+	q.started = true
+	q.mu.Unlock()
 	for {
 		select {
 		case msg := <-q.messages:

--- a/storage/queue/memqueue.go
+++ b/storage/queue/memqueue.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"context"
-	"errors"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -28,12 +27,16 @@ type MemQueue struct {
 	// inFlight tracks deliveries so Close can wait for them.
 	inFlight sync.WaitGroup
 
-	startOnce sync.Once
-	stopOnce  sync.Once
-	stop      chan struct{}
+	started  atomic.Bool
+	stopOnce sync.Once
+	stop     chan struct{}
 }
 
 var _ storage.Queue = (*MemQueue)(nil)
+
+// String identifies the backend, which is what the deprecated AdapterQueue
+// interface reports through storage.LegacyQueueAdapter.
+func (q *MemQueue) String() string { return "memory" }
 
 // NewMemQueue returns a queue buffering up to size messages. A size of zero or
 // less uses the default.
@@ -55,7 +58,7 @@ func (q *MemQueue) Subscribe(topic string, h storage.Handler) error {
 		return storage.ErrQueueClosed
 	}
 	if h == nil {
-		return errors.New("storage: nil handler")
+		return storage.ErrNilHandler
 	}
 	if _, exists := q.handlers[topic]; exists {
 		return storage.ErrTopicAlreadySubscribed
@@ -97,10 +100,8 @@ func (q *MemQueue) Publish(ctx context.Context, msg storage.Message) error {
 }
 
 func (q *MemQueue) Start(ctx context.Context) error {
-	var ran bool
-	q.startOnce.Do(func() { ran = true })
-	if !ran {
-		return errors.New("storage: queue already started")
+	if !q.started.CompareAndSwap(false, true) {
+		return storage.ErrQueueAlreadyStarted
 	}
 	for {
 		select {

--- a/storage/redis/cache.go
+++ b/storage/redis/cache.go
@@ -1,7 +1,9 @@
-// Package redis implements storage.Cache on top of Redis.
+// Package redis implements storage.Cache and storage.Queue on top of Redis.
 //
-// It lives in its own package so that importing storage/cache does not drag in
-// the Redis client. Only applications that actually use Redis pay for it.
+// It lives in its own package so that importing storage or storage/cache does
+// not drag in the Redis client. Note that sdk/config imports it unconditionally
+// in order to build whichever backend the configuration selects, so an
+// application using the SDK links the client whether or not it is configured.
 package redis
 
 import (
@@ -38,19 +40,16 @@ func New(client goredis.UniversalClient) *Cache {
 // redis://user:password@localhost:6379/0. The returned Cache owns the
 // connection and closes it.
 func Open(ctx context.Context, url string) (*Cache, error) {
-	opts, err := goredis.ParseURL(url)
+	client, err := dial(ctx, url)
 	if err != nil {
 		return nil, err
 	}
-
-	client := goredis.NewClient(opts)
-	if err := client.Ping(ctx).Err(); err != nil {
-		_ = client.Close()
-		return nil, err
-	}
-
 	return &Cache{client: client, owned: true}, nil
 }
+
+// String identifies the backend, which is what the deprecated AdapterCache
+// interface reports through storage.LegacyAdapter.
+func (c *Cache) String() string { return "redis" }
 
 // check reports whether the cache may still be used. The context is examined
 // first, so a caller that gave up is never told something else went wrong.

--- a/storage/redis/cache_test.go
+++ b/storage/redis/cache_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"testing"
-	"time"
 
 	goredis "github.com/redis/go-redis/v9"
 
@@ -25,54 +24,45 @@ func redisURL(t *testing.T) string {
 	return url
 }
 
-// The same suite that validates the in-memory implementation. Two independent
-// implementations agreeing on it is what makes the contract meaningful.
-func TestRedisConformance(t *testing.T) {
-	url := redisURL(t)
-
-	cachetest.Run(t, func(t *testing.T) storage.Cache {
-		ctx := context.Background()
-
-		c, err := redisstore.Open(ctx, url)
-		if err != nil {
-			t.Fatalf("connect to Redis: %v", err)
-		}
-
-		// Each case starts from an empty keyspace, otherwise counters and
-		// expiry assertions leak into one another.
-		opts, err := goredis.ParseURL(url)
-		if err != nil {
-			t.Fatalf("parse REDIS_URL: %v", err)
-		}
-		admin := goredis.NewClient(opts)
-		defer admin.Close()
-		if err := admin.FlushDB(ctx).Err(); err != nil {
-			t.Fatalf("flush: %v", err)
-		}
-
-		return c
-	})
-}
-
-// A caller-supplied client is shared, so Close must not shut it down.
-func TestCloseLeavesBorrowedClientUsable(t *testing.T) {
-	url := redisURL(t)
+// adminClient is a plain client for the test's own bookkeeping, closed with the
+// test that asked for it.
+func adminClient(t *testing.T, url string) *goredis.Client {
+	t.Helper()
 
 	opts, err := goredis.ParseURL(url)
 	if err != nil {
 		t.Fatalf("parse REDIS_URL: %v", err)
 	}
 	client := goredis.NewClient(opts)
-	defer client.Close()
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
 
-	c := redisstore.New(client)
-	if err := c.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
+// flush empties the keyspace so that keys, streams and consumer groups left by
+// one case cannot reach the next.
+func flush(t *testing.T, admin *goredis.Client) {
+	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if err := client.Ping(ctx).Err(); err != nil {
-		t.Errorf("a borrowed client must stay usable after Close: %v", err)
+	if err := admin.FlushDB(context.Background()).Err(); err != nil {
+		t.Fatalf("flush: %v", err)
 	}
+}
+
+// The same suite that validates the in-memory implementation. Two independent
+// implementations agreeing on it is what makes the contract meaningful.
+func TestRedisConformance(t *testing.T) {
+	url := redisURL(t)
+	admin := adminClient(t, url)
+
+	cachetest.Run(t, func(t *testing.T) storage.Cache {
+		// Each case starts from an empty keyspace, otherwise counters and
+		// expiry assertions leak into one another.
+		flush(t, admin)
+
+		c, err := redisstore.Open(context.Background(), url)
+		if err != nil {
+			t.Fatalf("connect to Redis: %v", err)
+		}
+		return c
+	})
 }

--- a/storage/redis/client.go
+++ b/storage/redis/client.go
@@ -1,0 +1,23 @@
+package redis
+
+import (
+	"context"
+
+	goredis "github.com/redis/go-redis/v9"
+)
+
+// dial connects using a Redis URL and verifies the server answers, so that a
+// bad address fails where it is configured rather than at the first command.
+func dial(ctx context.Context, url string) (*goredis.Client, error) {
+	opts, err := goredis.ParseURL(url)
+	if err != nil {
+		return nil, err
+	}
+
+	client := goredis.NewClient(opts)
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, err
+	}
+	return client, nil
+}

--- a/storage/redis/queue.go
+++ b/storage/redis/queue.go
@@ -526,8 +526,14 @@ func decodeValues(in map[string]interface{}) map[string]interface{} {
 
 	out := make(map[string]interface{}, len(in))
 	for k, v := range in {
-		// A stream field is always a string on the wire.
-		s, _ := v.(string)
+		// A stream field arrives as a string, because the client reads it with
+		// ReadString. Anything else did not come from this package, so it is
+		// passed through as it is rather than being turned into an empty one.
+		s, ok := v.(string)
+		if !ok {
+			out[k] = v
+			continue
+		}
 
 		var decoded interface{}
 		if err := json.Unmarshal([]byte(s), &decoded); err != nil {

--- a/storage/redis/queue.go
+++ b/storage/redis/queue.go
@@ -1,0 +1,531 @@
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+)
+
+const (
+	defaultGroup        = "go-admin"
+	defaultMaxAttempts  = 3
+	defaultBlock        = time.Second
+	defaultClaimMinIdle = 30 * time.Second
+	defaultBatch        = 16
+)
+
+// consumerSeq keeps the generated consumer names distinct when one process
+// builds several queues. Two consumers sharing a name would take over each
+// other's pending deliveries.
+var consumerSeq atomic.Int64
+
+// QueueOptions configures a Queue. The zero value is usable.
+type QueueOptions struct {
+	// Group is the consumer group. Every instance of one application must use
+	// the same value; a distinct group receives its own copy of every message.
+	Group string
+
+	// Consumer identifies this instance inside the group and must be unique.
+	// The default combines the hostname with the process id.
+	Consumer string
+
+	// KeyPrefix is prepended to the topic to form the stream key, so that
+	// several applications can share one Redis database.
+	KeyPrefix string
+
+	// MaxAttempts bounds redelivery. A message delivered this many times
+	// without being acknowledged is left in the pending list rather than
+	// dropped, so that it stays visible to XPENDING.
+	MaxAttempts int
+
+	// Block is how long one read waits for new messages before looping. It also
+	// bounds how long Start takes to notice a cancellation, because a blocking
+	// read is not interrupted by one.
+	Block time.Duration
+
+	// ClaimMinIdle is how long a delivery must go unacknowledged before another
+	// consumer may take it over, and also the interval between retry sweeps.
+	// Set it above the running time of the slowest handler.
+	ClaimMinIdle time.Duration
+
+	// Batch is how many messages a single read or sweep may return.
+	Batch int64
+}
+
+func (o QueueOptions) withDefaults() QueueOptions {
+	if o.Group == "" {
+		o.Group = defaultGroup
+	}
+	if o.Consumer == "" {
+		o.Consumer = defaultConsumer()
+	}
+	if o.MaxAttempts <= 0 {
+		o.MaxAttempts = defaultMaxAttempts
+	}
+	if o.Block <= 0 {
+		o.Block = defaultBlock
+	}
+	if o.ClaimMinIdle <= 0 {
+		o.ClaimMinIdle = defaultClaimMinIdle
+	}
+	if o.Batch <= 0 {
+		o.Batch = defaultBatch
+	}
+	return o
+}
+
+func defaultConsumer() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s-%d-%d", host, os.Getpid(), consumerSeq.Add(1))
+}
+
+// Queue is a storage.Queue backed by Redis streams.
+//
+// Consumer groups are what make it usable from more than one instance: every
+// instance reads under the same group, so each message is handled once, and a
+// delivery whose handler fails stays pending until it is retried here or taken
+// over by another instance. Delivery is therefore at least once; a handler must
+// tolerate seeing the same message twice.
+//
+// Topic names are expected to be a fixed, finite set. Publish caches the topics
+// it has confirmed a consumer group for, so generating topic names per user or
+// per tenant would grow that cache without bound.
+type Queue struct {
+	client goredis.UniversalClient
+	// owned reports whether Close should shut the client down. A client
+	// supplied by the caller may be shared and is left alone.
+	owned bool
+	opts  QueueOptions
+
+	mu       sync.RWMutex
+	handlers map[string]storage.Handler
+	// groups caches topics known to have a consumer group in Redis, whether it
+	// was created here or by another instance.
+	groups map[string]struct{}
+	closed bool
+
+	// inFlight tracks deliveries so Close can wait for them.
+	inFlight sync.WaitGroup
+
+	started atomic.Bool
+	// stopCtx is cancelled by Close, so a running Start unblocks even when its
+	// own context is still live.
+	stopCtx    context.Context
+	stopCancel context.CancelFunc
+}
+
+var _ storage.Queue = (*Queue)(nil)
+
+// NewQueue returns a Queue backed by client. Close does not shut client down,
+// because the caller may share it with other components.
+func NewQueue(client goredis.UniversalClient, opts QueueOptions) *Queue {
+	return newQueue(client, false, opts)
+}
+
+// OpenQueue connects using a Redis URL, for example
+// redis://user:password@localhost:6379/0. The returned Queue owns the
+// connection and closes it.
+func OpenQueue(ctx context.Context, url string, opts QueueOptions) (*Queue, error) {
+	client, err := dial(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+	return newQueue(client, true, opts), nil
+}
+
+func newQueue(client goredis.UniversalClient, owned bool, opts QueueOptions) *Queue {
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	return &Queue{
+		client:     client,
+		owned:      owned,
+		opts:       opts.withDefaults(),
+		handlers:   make(map[string]storage.Handler),
+		groups:     make(map[string]struct{}),
+		stopCtx:    stopCtx,
+		stopCancel: stopCancel,
+	}
+}
+
+// String identifies the backend, which is what the deprecated AdapterQueue
+// interface reports through storage.LegacyQueueAdapter.
+func (q *Queue) String() string { return "redis" }
+
+func (q *Queue) stream(topic string) string { return q.opts.KeyPrefix + topic }
+
+func (q *Queue) topic(stream string) string {
+	return strings.TrimPrefix(stream, q.opts.KeyPrefix)
+}
+
+func (q *Queue) Subscribe(topic string, h storage.Handler) error {
+	if h == nil {
+		return storage.ErrNilHandler
+	}
+
+	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return storage.ErrQueueClosed
+	}
+	if _, exists := q.handlers[topic]; exists {
+		q.mu.Unlock()
+		return storage.ErrTopicAlreadySubscribed
+	}
+	// The topic is claimed before the round trip so that a concurrent Subscribe
+	// loses, then given back if the group cannot be created.
+	q.handlers[topic] = h
+	q.mu.Unlock()
+
+	// The group is created here rather than in Start, so that a message
+	// published in between is kept for this subscriber instead of being lost.
+	if err := q.ensureGroup(context.Background(), topic); err != nil {
+		q.mu.Lock()
+		delete(q.handlers, topic)
+		q.mu.Unlock()
+		return err
+	}
+
+	q.mu.Lock()
+	q.groups[topic] = struct{}{}
+	q.mu.Unlock()
+	return nil
+}
+
+// ensureGroup creates the consumer group, treating an existing one as success.
+func (q *Queue) ensureGroup(ctx context.Context, topic string) error {
+	// MKSTREAM creates the stream when it is missing, and "$" starts the group
+	// at the current end so a new subscriber does not replay the whole history.
+	err := q.client.XGroupCreateMkStream(ctx, q.stream(topic), q.opts.Group, "$").Err()
+	if err != nil && !strings.Contains(err.Error(), "BUSYGROUP") {
+		return err
+	}
+	return nil
+}
+
+// groupExists asks Redis whether anyone consumes the topic.
+func (q *Queue) groupExists(ctx context.Context, topic string) (bool, error) {
+	groups, err := q.client.XInfoGroups(ctx, q.stream(topic)).Result()
+	if err != nil {
+		// A stream that was never created has no group either. Redis reports
+		// this as an ordinary error rather than a nil reply.
+		if errors.Is(err, goredis.Nil) || strings.Contains(err.Error(), "no such key") {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, g := range groups {
+		if g.Name == q.opts.Group {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (q *Queue) Publish(ctx context.Context, msg storage.Message) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	q.mu.RLock()
+	closed := q.closed
+	_, known := q.groups[msg.Topic]
+	q.mu.RUnlock()
+
+	if closed {
+		return storage.ErrQueueClosed
+	}
+	if !known {
+		// The subscriber may live in another process, so a missing local
+		// registration is not evidence that nobody consumes the topic. The
+		// answer is cached, so this costs one round trip per topic.
+		ok, err := q.groupExists(ctx, msg.Topic)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return storage.ErrNoHandler
+		}
+		q.mu.Lock()
+		q.groups[msg.Topic] = struct{}{}
+		q.mu.Unlock()
+	}
+
+	values, err := encodeValues(msg.Values)
+	if err != nil {
+		return err
+	}
+
+	// The stream assigns the ID, which is what the consumer sees on delivery.
+	return q.client.XAdd(ctx, &goredis.XAddArgs{
+		Stream: q.stream(msg.Topic),
+		Values: values,
+	}).Err()
+}
+
+func (q *Queue) Start(ctx context.Context) error {
+	if !q.started.CompareAndSwap(false, true) {
+		return storage.ErrQueueAlreadyStarted
+	}
+
+	// Registered first so that it runs last: the cancel below has to happen
+	// before this Wait, otherwise returning on a read error would block here
+	// with reclaimLoop still watching a live context.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	// Close has to unblock the read as well, so both signals feed one context.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	defer context.AfterFunc(q.stopCtx, cancel)()
+
+	topics := q.topics()
+	if len(topics) == 0 {
+		// XREADGROUP needs at least one stream, so there is nothing to do but
+		// wait for the caller to give up.
+		<-ctx.Done()
+		return nil
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		q.reclaimLoop(ctx, topics)
+	}()
+
+	// XREADGROUP takes every key first and every start ID second. One read
+	// covers every topic, so an idle queue costs one round trip per Block
+	// rather than one per topic.
+	args := make([]string, 0, len(topics)*2)
+	for _, t := range topics {
+		args = append(args, q.stream(t))
+	}
+	for range topics {
+		args = append(args, ">")
+	}
+
+	for {
+		res, err := q.client.XReadGroup(ctx, &goredis.XReadGroupArgs{
+			Group:    q.opts.Group,
+			Consumer: q.opts.Consumer,
+			Streams:  args,
+			Count:    q.opts.Batch,
+			Block:    q.opts.Block,
+		}).Result()
+		switch {
+		case errors.Is(err, goredis.Nil):
+			// The block elapsed with nothing new.
+			continue
+		case err != nil:
+			if ctx.Err() != nil {
+				// Cancellation, whether from the caller or from Close, is a
+				// clean exit rather than a failure.
+				return nil
+			}
+			return err
+		}
+
+		for _, s := range res {
+			topic := q.topic(s.Stream)
+			for _, m := range s.Messages {
+				// A message read with ">" has been delivered exactly once.
+				q.deliver(ctx, topic, m, 1)
+			}
+		}
+	}
+}
+
+func (q *Queue) topics() []string {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	out := make([]string, 0, len(q.handlers))
+	for t := range q.handlers {
+		out = append(out, t)
+	}
+	return out
+}
+
+// reclaimLoop retries deliveries that were never acknowledged, which is how a
+// message survives a handler error or the instance that held it going away.
+func (q *Queue) reclaimLoop(ctx context.Context, topics []string) {
+	t := time.NewTicker(q.opts.ClaimMinIdle)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			for _, topic := range topics {
+				q.reclaim(ctx, topic)
+			}
+		}
+	}
+}
+
+func (q *Queue) reclaim(ctx context.Context, topic string) {
+	stream := q.stream(topic)
+
+	pending, err := q.client.XPendingExt(ctx, &goredis.XPendingExtArgs{
+		Stream: stream,
+		Group:  q.opts.Group,
+		Idle:   q.opts.ClaimMinIdle,
+		Start:  "-",
+		End:    "+",
+		Count:  q.opts.Batch,
+	}).Result()
+	if err != nil {
+		// Transient; the next sweep tries again.
+		return
+	}
+
+	ids := make([]string, 0, len(pending))
+	attempts := make(map[string]int, len(pending))
+	for _, p := range pending {
+		if int(p.RetryCount) >= q.opts.MaxAttempts {
+			// Given up on, but deliberately not acknowledged: the entry stays
+			// in the pending list where XPENDING still shows it. Acknowledging
+			// here would make an unhandled message look handled.
+			continue
+		}
+		ids = append(ids, p.ID)
+		// XCLAIM increments the delivery counter, so this will be attempt n+1.
+		attempts[p.ID] = int(p.RetryCount) + 1
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	// One XCLAIM for the whole batch. An entry another consumer took first is
+	// simply absent from the result. XAUTOCLAIM would be shorter still but
+	// cannot filter on delivery count, so it would drag back the entries that
+	// have exhausted MaxAttempts.
+	claimed, err := q.client.XClaim(ctx, &goredis.XClaimArgs{
+		Stream:   stream,
+		Group:    q.opts.Group,
+		Consumer: q.opts.Consumer,
+		MinIdle:  q.opts.ClaimMinIdle,
+		Messages: ids,
+	}).Result()
+	if err != nil {
+		return
+	}
+
+	for _, m := range claimed {
+		q.deliver(ctx, topic, m, attempts[m.ID])
+	}
+}
+
+func (q *Queue) deliver(ctx context.Context, topic string, m goredis.XMessage, attempts int) {
+	q.mu.RLock()
+	h := q.handlers[topic]
+	if h == nil || q.closed {
+		q.mu.RUnlock()
+		return
+	}
+	// Registered while holding the lock Close uses to publish q.closed, so the
+	// counter can never be incremented after Close began waiting on it.
+	q.inFlight.Add(1)
+	q.mu.RUnlock()
+	defer q.inFlight.Done()
+
+	err := h(ctx, storage.Message{
+		ID:       m.ID,
+		Topic:    topic,
+		Values:   decodeValues(m.Values),
+		Attempts: attempts,
+	})
+	if err != nil {
+		// Left unacknowledged on purpose: the pending entry is what makes the
+		// retry possible, here or on another instance.
+		return
+	}
+
+	// Acknowledged outside ctx, which a shutdown may already have cancelled. A
+	// handled message that stays pending would be delivered a second time. The
+	// call is bounded by the client's own read timeout.
+	//
+	// A failed acknowledgement only costs a redelivery, which the at-least-once
+	// guarantee already allows for.
+	_ = q.client.XAck(context.WithoutCancel(ctx), q.stream(topic), q.opts.Group, m.ID).Err()
+}
+
+// Close stops accepting messages, waits for in-flight deliveries and, when it
+// owns the client, shuts it down. Nothing is drained: whatever is unhandled
+// stays pending in Redis for the next instance to pick up, which is the point
+// of using consumer groups.
+func (q *Queue) Close() error {
+	q.mu.Lock()
+	first := !q.closed
+	q.closed = true
+	q.mu.Unlock()
+
+	q.stopCancel()
+	q.inFlight.Wait()
+
+	if first && q.owned {
+		return q.client.Close()
+	}
+	return nil
+}
+
+// emptyField stands in for a message with no values. XADD rejects an entry
+// that carries no field at all, and a message whose payload is empty is still
+// a message worth delivering.
+//
+// Its value is the empty string, which json.Marshal cannot produce, so a
+// caller's own field of the same name is never mistaken for the marker.
+const emptyField = "go-admin:empty"
+
+// encodeValues renders each value as JSON, because a stream field is a string.
+func encodeValues(in map[string]interface{}) (map[string]interface{}, error) {
+	if len(in) == 0 {
+		return map[string]interface{}{emptyField: ""}, nil
+	}
+
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("storage: encode value %q: %w", k, err)
+		}
+		out[k] = string(b)
+	}
+	return out, nil
+}
+
+func decodeValues(in map[string]interface{}) map[string]interface{} {
+	if len(in) == 1 {
+		if v, ok := in[emptyField]; ok && v == "" {
+			return map[string]interface{}{}
+		}
+	}
+
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		// A stream field is always a string on the wire.
+		s, _ := v.(string)
+
+		var decoded interface{}
+		if err := json.Unmarshal([]byte(s), &decoded); err != nil {
+			// Written by something other than this package; pass it through as
+			// the string Redis returned.
+			out[k] = s
+			continue
+		}
+		out[k] = decoded
+	}
+	return out
+}

--- a/storage/redis/queue.go
+++ b/storage/redis/queue.go
@@ -120,7 +120,10 @@ type Queue struct {
 	// inFlight tracks deliveries so Close can wait for them.
 	inFlight sync.WaitGroup
 
-	started atomic.Bool
+	// started is guarded by mu, not atomic: marking the queue started and
+	// freezing its topic set have to be one step.
+	started bool
+
 	// stopCtx is cancelled by Close, so a running Start unblocks even when its
 	// own context is still live.
 	stopCtx    context.Context
@@ -174,17 +177,19 @@ func (q *Queue) Subscribe(topic string, h storage.Handler) error {
 		return storage.ErrNilHandler
 	}
 
-	// Start fixes the set of streams it reads, so a topic registered afterwards
-	// would have a consumer group — making Publish succeed — with nothing here
-	// ever reading it.
-	if q.started.Load() {
-		return storage.ErrQueueAlreadyStarted
-	}
-
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()
 		return storage.ErrQueueClosed
+	}
+	// Checked under the same lock Start uses to freeze the topic set. An atomic
+	// read here would leave the original race: this call could pass the guard,
+	// Start could then snapshot without the topic, and only afterwards would
+	// the handler be registered — a consumer group Publish accepts and nothing
+	// reads.
+	if q.started {
+		q.mu.Unlock()
+		return storage.ErrQueueAlreadyStarted
 	}
 	if _, exists := q.handlers[topic]; exists {
 		q.mu.Unlock()
@@ -282,9 +287,20 @@ func (q *Queue) Publish(ctx context.Context, msg storage.Message) error {
 }
 
 func (q *Queue) Start(ctx context.Context) error {
-	if !q.started.CompareAndSwap(false, true) {
+	// Marking the queue started and reading the topics it will serve happen
+	// under one lock, so a Subscribe cannot slip between them and register a
+	// topic this loop will never read.
+	q.mu.Lock()
+	if q.started {
+		q.mu.Unlock()
 		return storage.ErrQueueAlreadyStarted
 	}
+	q.started = true
+	topics := make([]string, 0, len(q.handlers))
+	for t := range q.handlers {
+		topics = append(topics, t)
+	}
+	q.mu.Unlock()
 
 	// Registered first so that it runs last: the cancel below has to happen
 	// before this Wait, otherwise returning on a read error would block here
@@ -297,7 +313,6 @@ func (q *Queue) Start(ctx context.Context) error {
 	defer cancel()
 	defer context.AfterFunc(q.stopCtx, cancel)()
 
-	topics := q.topics()
 	if len(topics) == 0 {
 		// XREADGROUP needs at least one stream, so there is nothing to do but
 		// wait for the caller to give up.
@@ -351,17 +366,6 @@ func (q *Queue) Start(ctx context.Context) error {
 			}
 		}
 	}
-}
-
-func (q *Queue) topics() []string {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
-
-	out := make([]string, 0, len(q.handlers))
-	for t := range q.handlers {
-		out = append(out, t)
-	}
-	return out
 }
 
 // reclaimLoop retries deliveries that were never acknowledged, which is how a

--- a/storage/redis/queue.go
+++ b/storage/redis/queue.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 	"sync"
@@ -120,8 +121,8 @@ type Queue struct {
 	// inFlight tracks deliveries so Close can wait for them.
 	inFlight sync.WaitGroup
 
-	// started is guarded by mu, not atomic: marking the queue started and
-	// freezing its topic set have to be one step.
+	// started is guarded by mu because marking the queue started and freezing
+	// its topic set have to be one step.
 	started bool
 
 	// stopCtx is cancelled by Close, so a running Start unblocks even when its
@@ -182,11 +183,6 @@ func (q *Queue) Subscribe(topic string, h storage.Handler) error {
 		q.mu.Unlock()
 		return storage.ErrQueueClosed
 	}
-	// Checked under the same lock Start uses to freeze the topic set. An atomic
-	// read here would leave the original race: this call could pass the guard,
-	// Start could then snapshot without the topic, and only afterwards would
-	// the handler be registered — a consumer group Publish accepts and nothing
-	// reads.
 	if q.started {
 		q.mu.Unlock()
 		return storage.ErrQueueAlreadyStarted
@@ -213,6 +209,25 @@ func (q *Queue) Subscribe(topic string, h storage.Handler) error {
 	q.groups[topic] = struct{}{}
 	q.mu.Unlock()
 	return nil
+}
+
+// begin marks the queue started and returns the topics it will serve. The two
+// happen under one lock, so a Subscribe cannot slip between them and register
+// a topic the read loop will never look at.
+func (q *Queue) begin() ([]string, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.started {
+		return nil, storage.ErrQueueAlreadyStarted
+	}
+	q.started = true
+
+	topics := make([]string, 0, len(q.handlers))
+	for t := range q.handlers {
+		topics = append(topics, t)
+	}
+	return topics, nil
 }
 
 // ensureGroup creates the consumer group, treating an existing one as success.
@@ -287,20 +302,10 @@ func (q *Queue) Publish(ctx context.Context, msg storage.Message) error {
 }
 
 func (q *Queue) Start(ctx context.Context) error {
-	// Marking the queue started and reading the topics it will serve happen
-	// under one lock, so a Subscribe cannot slip between them and register a
-	// topic this loop will never read.
-	q.mu.Lock()
-	if q.started {
-		q.mu.Unlock()
-		return storage.ErrQueueAlreadyStarted
+	topics, err := q.begin()
+	if err != nil {
+		return err
 	}
-	q.started = true
-	topics := make([]string, 0, len(q.handlers))
-	for t := range q.handlers {
-		topics = append(topics, t)
-	}
-	q.mu.Unlock()
 
 	// Registered first so that it runs last: the cancel below has to happen
 	// before this Wait, otherwise returning on a read error would block here
@@ -315,7 +320,11 @@ func (q *Queue) Start(ctx context.Context) error {
 
 	if len(topics) == 0 {
 		// XREADGROUP needs at least one stream, so there is nothing to do but
-		// wait for the caller to give up.
+		// wait for the caller to give up. Said out loud, because a queue that
+		// consumes nothing is almost always a wiring mistake — Subscribe has to
+		// happen before Start, and a caller that starts first gets silence.
+		slog.Warn("queue: started with no subscriptions, nothing will be consumed",
+			"group", q.opts.Group)
 		<-ctx.Done()
 		return nil
 	}
@@ -526,9 +535,6 @@ func decodeValues(in map[string]interface{}) map[string]interface{} {
 
 	out := make(map[string]interface{}, len(in))
 	for k, v := range in {
-		// A stream field arrives as a string, because the client reads it with
-		// ReadString. Anything else did not come from this package, so it is
-		// passed through as it is rather than being turned into an empty one.
 		s, ok := v.(string)
 		if !ok {
 			out[k] = v

--- a/storage/redis/queue.go
+++ b/storage/redis/queue.go
@@ -174,6 +174,13 @@ func (q *Queue) Subscribe(topic string, h storage.Handler) error {
 		return storage.ErrNilHandler
 	}
 
+	// Start fixes the set of streams it reads, so a topic registered afterwards
+	// would have a consumer group — making Publish succeed — with nothing here
+	// ever reading it.
+	if q.started.Load() {
+		return storage.ErrQueueAlreadyStarted
+	}
+
 	q.mu.Lock()
 	if q.closed {
 		q.mu.Unlock()

--- a/storage/redis/queue_internal_test.go
+++ b/storage/redis/queue_internal_test.go
@@ -1,0 +1,81 @@
+package redis
+
+import (
+	"testing"
+)
+
+// decodeValues is tested directly because one of its branches cannot be
+// reached through the public API: the client reads every stream field with
+// ReadString, so a non-string value never arrives from Redis. An end-to-end
+// test can only exercise the string cases.
+func TestDecodeValues(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "json values are decoded",
+			in:   map[string]interface{}{"id": `"42"`, "count": "7", "ok": "true"},
+			want: map[string]interface{}{"id": "42", "count": float64(7), "ok": true},
+		},
+		{
+			name: "a string that is not json is passed through",
+			in:   map[string]interface{}{"raw": "not json at all"},
+			want: map[string]interface{}{"raw": "not json at all"},
+		},
+		{
+			name: "a value that is not a string is passed through untouched",
+			in:   map[string]interface{}{"weird": 42},
+			want: map[string]interface{}{"weird": 42},
+		},
+		{
+			name: "the empty marker yields an empty payload",
+			in:   map[string]interface{}{emptyField: ""},
+			want: map[string]interface{}{},
+		},
+		{
+			name: "a caller's field of the marker's name survives",
+			in:   map[string]interface{}{emptyField: `"mine"`},
+			want: map[string]interface{}{emptyField: "mine"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeValues(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+			for k, want := range tc.want {
+				if got[k] != want {
+					t.Errorf("%q: got %#v, want %#v", k, got[k], want)
+				}
+			}
+		})
+	}
+}
+
+// Every value has to be a string on the wire, and an empty payload still needs
+// one field because XADD rejects an entry with none.
+func TestEncodeValues(t *testing.T) {
+	out, err := encodeValues(nil)
+	if err != nil {
+		t.Fatalf("encode an empty payload: %v", err)
+	}
+	if len(out) != 1 || out[emptyField] != "" {
+		t.Errorf("an empty payload must carry the marker alone, got %#v", out)
+	}
+
+	out, err = encodeValues(map[string]interface{}{"id": "42"})
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if out["id"] != `"42"` {
+		t.Errorf("values travel as JSON, got %#v", out["id"])
+	}
+
+	if _, err := encodeValues(map[string]interface{}{"ch": make(chan int)}); err == nil {
+		t.Error("a value with no JSON form must be rejected at publish time")
+	}
+}

--- a/storage/redis/queue_test.go
+++ b/storage/redis/queue_test.go
@@ -203,6 +203,53 @@ func TestReservedFieldNameIsNotSwallowed(t *testing.T) {
 	}
 }
 
+// A field written by something other than this package is not JSON, so it
+// cannot be decoded. It must reach the handler as the string Redis returned
+// rather than being dropped.
+func TestForeignFieldIsPassedThrough(t *testing.T) {
+	url := redisURL(t)
+	admin := adminClient(t, url)
+	flush(t, admin)
+
+	q, err := redisstore.OpenQueue(context.Background(), url, redisstore.QueueOptions{
+		Block: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("connect to Redis: %v", err)
+	}
+	defer q.Close()
+
+	got := make(chan storage.Message, 1)
+	if err := q.Subscribe("orders", func(_ context.Context, m storage.Message) error {
+		got <- m
+		return nil
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = q.Start(ctx) }()
+
+	// Written straight to the stream, bypassing Publish's JSON encoding.
+	err = admin.XAdd(context.Background(), &goredis.XAddArgs{
+		Stream: "orders",
+		Values: map[string]interface{}{"raw": "not json at all"},
+	}).Err()
+	if err != nil {
+		t.Fatalf("XADD: %v", err)
+	}
+
+	select {
+	case m := <-got:
+		if m.Values["raw"] != "not json at all" {
+			t.Errorf("a foreign field must survive, got %#v", m.Values["raw"])
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the message")
+	}
+}
+
 // A caller-supplied client is shared, so Close must not shut it down.
 func TestCloseLeavesBorrowedClientUsable(t *testing.T) {
 	url := redisURL(t)

--- a/storage/redis/queue_test.go
+++ b/storage/redis/queue_test.go
@@ -1,0 +1,237 @@
+package redis_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+	"github.com/go-admin-team/go-admin-core/storage/cachetest"
+	redisstore "github.com/go-admin-team/go-admin-core/storage/redis"
+)
+
+// The same suite that validates the in-memory implementation. One admin client
+// serves every case, rather than a dial per case.
+func TestRedisQueueConformance(t *testing.T) {
+	url := redisURL(t)
+	admin := adminClient(t, url)
+
+	cachetest.RunQueue(t, func(t *testing.T) storage.Queue {
+		flush(t, admin)
+
+		q, err := redisstore.OpenQueue(context.Background(), url, redisstore.QueueOptions{
+			// Short enough that a case which cancels within a few seconds does
+			// not spend most of that time inside one blocking read.
+			Block: 100 * time.Millisecond,
+		})
+		if err != nil {
+			t.Fatalf("connect to Redis: %v", err)
+		}
+		return q
+	})
+}
+
+// failing records every delivery and always reports an error, which is what
+// keeps the entry pending and therefore eligible for a retry.
+type failing struct {
+	mu       sync.Mutex
+	attempts []int
+}
+
+func (f *failing) handle(_ context.Context, m storage.Message) error {
+	f.mu.Lock()
+	f.attempts = append(f.attempts, m.Attempts)
+	f.mu.Unlock()
+	return errors.New("handler failed on purpose")
+}
+
+func (f *failing) seen() []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]int, len(f.attempts))
+	copy(out, f.attempts)
+	return out
+}
+
+// A message whose handler keeps failing must be retried up to MaxAttempts and
+// then left pending, so that it is still visible instead of silently gone.
+func TestRetriesUntilMaxAttemptsThenLeavesPending(t *testing.T) {
+	url := redisURL(t)
+	admin := adminClient(t, url)
+	flush(t, admin)
+
+	const group = "retry-test"
+	q, err := redisstore.OpenQueue(context.Background(), url, redisstore.QueueOptions{
+		Group:        group,
+		MaxAttempts:  3,
+		Block:        50 * time.Millisecond,
+		ClaimMinIdle: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("connect to Redis: %v", err)
+	}
+	defer q.Close()
+
+	f := &failing{}
+	if err := q.Subscribe("orders", f.handle); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := q.Start(ctx); err != nil {
+			t.Errorf("Start: %v", err)
+		}
+	}()
+
+	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	deadline := time.After(10 * time.Second)
+	for len(f.seen()) < 3 {
+		select {
+		case <-deadline:
+			t.Fatalf("expected 3 attempts, saw %v", f.seen())
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	// Long enough for several more sweeps, none of which may redeliver.
+	time.Sleep(time.Second)
+
+	if got := f.seen(); len(got) != 3 {
+		t.Errorf("delivery must stop at MaxAttempts, saw attempts %v", got)
+	} else {
+		for i, n := range got {
+			if n != i+1 {
+				t.Errorf("attempt %d reported Attempts = %d, want %d", i, n, i+1)
+			}
+		}
+	}
+
+	cancel()
+	<-done
+
+	pending, err := admin.XPending(context.Background(), "orders", group).Result()
+	if err != nil {
+		t.Fatalf("XPENDING: %v", err)
+	}
+	if pending.Count != 1 {
+		t.Errorf("a message that was given up on must stay pending, XPENDING reports %d", pending.Count)
+	}
+}
+
+// roundTrip publishes one message and returns it as the handler saw it.
+func roundTrip(t *testing.T, url string, values map[string]interface{}) storage.Message {
+	t.Helper()
+
+	q, err := redisstore.OpenQueue(context.Background(), url, redisstore.QueueOptions{
+		Block: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("connect to Redis: %v", err)
+	}
+	t.Cleanup(func() { _ = q.Close() })
+
+	got := make(chan storage.Message, 1)
+	if err := q.Subscribe("orders", func(_ context.Context, m storage.Message) error {
+		got <- m
+		return nil
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = q.Start(ctx) }()
+
+	if err := q.Publish(context.Background(), storage.Message{Topic: "orders", Values: values}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+
+	select {
+	case m := <-got:
+		return m
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the message")
+		return storage.Message{}
+	}
+}
+
+// Values travel as JSON, so a consumer sees the types JSON can express rather
+// than the ones the publisher put in. The contract only promises strings; this
+// records what actually happens to the rest.
+func TestValuesTravelAsJSON(t *testing.T) {
+	url := redisURL(t)
+	flush(t, adminClient(t, url))
+
+	m := roundTrip(t, url, map[string]interface{}{
+		"id":    "42",
+		"count": 7,
+		"retry": true,
+	})
+
+	if m.Values["id"] != "42" {
+		t.Errorf("a string must survive unchanged, got %#v", m.Values["id"])
+	}
+	if m.Values["count"] != float64(7) {
+		t.Errorf("a number arrives as float64, got %#v", m.Values["count"])
+	}
+	if m.Values["retry"] != true {
+		t.Errorf("a bool must survive unchanged, got %#v", m.Values["retry"])
+	}
+}
+
+// An empty payload is carried by a reserved marker field, which must not eat a
+// caller's field that happens to share its name.
+func TestReservedFieldNameIsNotSwallowed(t *testing.T) {
+	url := redisURL(t)
+	flush(t, adminClient(t, url))
+
+	m := roundTrip(t, url, map[string]interface{}{"go-admin:empty": "mine"})
+
+	if m.Values["go-admin:empty"] != "mine" {
+		t.Errorf("the caller's field was lost, got %#v", m.Values)
+	}
+}
+
+// A caller-supplied client is shared, so Close must not shut it down.
+func TestCloseLeavesBorrowedClientUsable(t *testing.T) {
+	url := redisURL(t)
+
+	cases := []struct {
+		name string
+		open func(*goredis.Client) interface{ Close() error }
+	}{
+		{"cache", func(c *goredis.Client) interface{ Close() error } {
+			return redisstore.New(c)
+		}},
+		{"queue", func(c *goredis.Client) interface{ Close() error } {
+			return redisstore.NewQueue(c, redisstore.QueueOptions{})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := adminClient(t, url)
+
+			if err := tc.open(client).Close(); err != nil {
+				t.Fatalf("Close: %v", err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := client.Ping(ctx).Err(); err != nil {
+				t.Errorf("a borrowed client must stay usable after Close: %v", err)
+			}
+		})
+	}
+}

--- a/storage/redis/queue_test.go
+++ b/storage/redis/queue_test.go
@@ -203,53 +203,6 @@ func TestReservedFieldNameIsNotSwallowed(t *testing.T) {
 	}
 }
 
-// A field written by something other than this package is not JSON, so it
-// cannot be decoded. It must reach the handler as the string Redis returned
-// rather than being dropped.
-func TestForeignFieldIsPassedThrough(t *testing.T) {
-	url := redisURL(t)
-	admin := adminClient(t, url)
-	flush(t, admin)
-
-	q, err := redisstore.OpenQueue(context.Background(), url, redisstore.QueueOptions{
-		Block: 100 * time.Millisecond,
-	})
-	if err != nil {
-		t.Fatalf("connect to Redis: %v", err)
-	}
-	defer q.Close()
-
-	got := make(chan storage.Message, 1)
-	if err := q.Subscribe("orders", func(_ context.Context, m storage.Message) error {
-		got <- m
-		return nil
-	}); err != nil {
-		t.Fatalf("Subscribe: %v", err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() { _ = q.Start(ctx) }()
-
-	// Written straight to the stream, bypassing Publish's JSON encoding.
-	err = admin.XAdd(context.Background(), &goredis.XAddArgs{
-		Stream: "orders",
-		Values: map[string]interface{}{"raw": "not json at all"},
-	}).Err()
-	if err != nil {
-		t.Fatalf("XADD: %v", err)
-	}
-
-	select {
-	case m := <-got:
-		if m.Values["raw"] != "not json at all" {
-			t.Errorf("a foreign field must survive, got %#v", m.Values["raw"])
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for the message")
-	}
-}
-
 // A caller-supplied client is shared, so Close must not shut it down.
 func TestCloseLeavesBorrowedClientUsable(t *testing.T) {
 	url := redisURL(t)


### PR DESCRIPTION
Completes the multi-instance story for `storage`. The cache half landed in #110; this is the queue half, plus the configuration that makes either of them reachable without writing code.

## Why

`Cache` and `Queue` had contracts and conformance suites, but the only queue implementation was in-process: a message published on one instance was never seen by another. `sdk/config` made the point moot anyway — `Setup()` returned the in-memory implementation unconditionally, so the Redis cache added in #110 could not be selected from a settings file at all.

## Redis is opt-in, and stays opt-in

A settings file with no `cache` or `queue` section keeps the process entirely in memory and needs nothing running beside it:

```yaml
settings:
  queue:
    memory:
      poolSize: 100
```

Add a section only when more than one instance has to share state:

```yaml
settings:
  cache:
    redis: { addr: 127.0.0.1:6379, db: 0 }
  queue:
    redis: { addr: 127.0.0.1:6379, group: go-admin, max_attempts: 3 }
```

The settings keys are the ones this repository used before Redis support was removed in 90149af, so an older file still applies. `url` is new and accepts what a managed provider hands out, including `rediss://` for TLS.

Two tests pin the default, one of them through an actual JSON decode of a settings file, because "we did not force Redis on anyone" is the kind of claim that quietly stops being true.

A `redis` section that cannot be reached is an error rather than a fallback. Falling back would hand an operator who asked for a shared cache one that is not shared, and the symptom would surface much later, under load.

## The queue implementation

Consumer groups carry the semantics: every instance reads under one group so each message is handled once, and a delivery whose handler fails stays pending until it is retried here or claimed by another instance. Delivery is at least once and the package doc says so.

A message delivered `MaxAttempts` times stops being retried but is **deliberately not acknowledged**. It stays in the pending list where `XPENDING` still shows it. Acknowledging there would make an unhandled message look handled, which is the failure mode this package exists to remove; `docs/storage` has the triage steps.

Details worth flagging for review:

- `XADD` rejects an entry with no fields, so an empty payload travels as a reserved marker field. Its value is the empty string, which `json.Marshal` cannot produce, so a caller's own field of that name is never mistaken for the marker. A test pins exactly that collision.
- `Publish` asks Redis whether a consumer group exists before reporting `ErrNoHandler`, because the subscriber may live in another process. Checking only local registration would break the producer-only deployment this PR exists to enable. The answer is cached, so it costs one round trip per topic.
- A sweep claims its whole batch in one `XCLAIM` rather than one per entry. `XAUTOCLAIM` would be shorter but cannot filter on delivery count, so it would drag back the entries that have exhausted `MaxAttempts`.
- The acknowledgement runs outside the delivery context, which a shutdown may already have cancelled. A handled message left pending gets delivered twice.

## What the conformance suite caught

The suite is why both implementations agree, and it earned its keep again:

- `XADD` refusing an empty entry only showed up because the memory implementation accepts one. Four cases failed at once.
- The doc comment on `Message.Values` claimed a published number arrives as a `float64`. That describes the Redis implementation, not the contract — the memory queue passes the `int` straight through. The contract now states what actually holds everywhere (only strings survive unchanged), and a case enforces it.

Three cases were added: `StringValuesRoundTrip`, `EmptyPayloadIsDelivered`, `SecondStartIsRejected`. Both implementations pass all fourteen.

## Adopting it

`LegacyQueueAdapter` presents a `Queue` through the deprecated `AdapterQueue`, mirroring what `LegacyAdapter` already does for the cache, so switching backend is a settings change and existing call sites keep working. Two things it cannot carry over are documented on the adapter: `Register` returns nothing, so a duplicate topic or an unreachable backend is logged rather than reported; and `ConsumerFunc` takes no context.

`Open()` is added alongside `Setup()` and returns the current contract, so new code is not locked into the deprecated interface forever.

`Setup()`'s memory branch deliberately stays on the original implementation, because its callers were written against that behaviour. The two branches therefore differ on the switch — `Register` starts consuming by itself on memory but not on Redis, and the original memory queue retries three times on its own. The deprecation note and `docs/storage` both spell this out.

## Verification

- Both conformance suites run against a real server in CI through the existing Redis service container, and skip locally unless `REDIS_URL` is set.
- `make ci` (tidy, build, vet, race, api snapshot) is green, and every commit builds on its own.
- Verified locally under `-race` against Redis 7.

## Known gap, not addressed here

`Application.memoryQueue` is hardcoded to `queue.NewMemory(10000)` and never reads configuration, so anything reaching the queue through `GetMemoryQueue` stays in-process regardless of these settings. That needs a change to `sdk/runtime` and is left for a separate PR.
