### PR TITLE
fix🐛: make the configured queue reachable

### DIFF
--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -386,10 +386,7 @@ func (e *Application) queueAdapter() storage.AdapterQueue {
 
 // GetQueueAdapter 获取队列适配器
 func (e *Application) GetQueueAdapter() storage.AdapterQueue {
-	// GetDefaultTenant takes the lock, so it has to be called before
-	// queueAdapter does: sync.RWMutex is not reentrant.
-	tenant := e.GetDefaultTenant()
-	return NewQueue(tenant, e.queueAdapter())
+	return NewQueue(e.GetDefaultTenant(), e.queueAdapter())
 }
 
 // GetQueuePrefix 获取标记的queue

--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -341,6 +341,8 @@ func (e *Application) GetMiddleware(key string) interface{} {
 
 // SetCacheAdapter 设置缓存
 func (e *Application) SetCacheAdapter(c storage.AdapterCache) {
+	e.mux.Lock()
+	defer e.mux.Unlock()
 	e.cache = c
 }
 
@@ -351,22 +353,51 @@ func (e *Application) GetCacheAdapter() storage.AdapterCache {
 
 // GetCacheAdapterPrefix 获取prefix标记的cache
 func (e *Application) GetCacheAdapterPrefix(prefix string) storage.AdapterCache {
-	return NewCache(prefix, e.cache, "")
+	e.mux.RLock()
+	cache := e.cache
+	e.mux.RUnlock()
+	return NewCache(prefix, cache, "")
 }
 
 // SetQueueAdapter 设置队列适配器
+//
+// Reloading the configuration calls this again while requests are in flight,
+// so the field is guarded.
 func (e *Application) SetQueueAdapter(c storage.AdapterQueue) {
+	e.mux.Lock()
+	defer e.mux.Unlock()
 	e.queue = c
+}
+
+// queueAdapter returns the configured queue, falling back to the process-wide
+// memory queue.
+//
+// The fallback has to be that one shared instance rather than a fresh queue:
+// a producer and a consumer that both asked for "the queue" would otherwise be
+// handed different ones, and every message would be dropped in silence.
+func (e *Application) queueAdapter() storage.AdapterQueue {
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	if e.queue != nil {
+		return e.queue
+	}
+	return e.memoryQueue
 }
 
 // GetQueueAdapter 获取队列适配器
 func (e *Application) GetQueueAdapter() storage.AdapterQueue {
-	return NewQueue(e.GetDefaultTenant(), e.queue)
+	// GetDefaultTenant takes the lock, so it has to be called before
+	// queueAdapter does: sync.RWMutex is not reentrant.
+	tenant := e.GetDefaultTenant()
+	return NewQueue(tenant, e.queueAdapter())
 }
 
 // GetQueuePrefix 获取标记的queue
+//
+// This is the queue the configuration selected. Prefer it over GetMemoryQueue,
+// which ignores configuration and never leaves the process.
 func (e *Application) GetQueuePrefix(key string) storage.AdapterQueue {
-	return NewQueue(key, e.queue)
+	return NewQueue(key, e.queueAdapter())
 }
 
 // GetQueue 获取默认租户的队列
@@ -418,6 +449,11 @@ func (e *Application) GetStreamMessage(id, stream string, value map[string]inter
 	return message, nil
 }
 
+// GetMemoryQueue returns the in-process queue.
+//
+// Deprecated: use GetQueuePrefix. This always returns the in-process queue,
+// whatever the configuration selected, so messages published through it are
+// invisible to every other instance.
 func (e *Application) GetMemoryQueue(prefix string) storage.AdapterQueue {
 	return NewQueue(prefix, e.memoryQueue)
 }

--- a/sdk/runtime/queue.go
+++ b/sdk/runtime/queue.go
@@ -1,14 +1,22 @@
 package runtime
 
 import (
+	"log/slog"
+
 	"github.com/go-admin-team/go-admin-core/storage"
 	"github.com/go-admin-team/go-admin-core/storage/queue"
 )
 
 // NewQueue 创建对应上下文队列
+//
+// A nil q yields a fresh in-process queue, which is almost never what a caller
+// wants: two calls produce two unconnected queues, so a consumer registered on
+// one never sees what is published to the other. Application.GetQueuePrefix
+// passes a shared queue for exactly this reason.
 func NewQueue(prefix string, q storage.AdapterQueue) storage.AdapterQueue {
-	// 如果传入 nil，创建默认的内存队列
 	if q == nil {
+		slog.Warn("runtime: queue created without a backing adapter; it is connected to nothing else",
+			"prefix", prefix)
 		q = queue.NewMemory(100)
 	}
 	return &Queue{

--- a/sdk/runtime/queue.go
+++ b/sdk/runtime/queue.go
@@ -10,12 +10,12 @@ import (
 // NewQueue 创建对应上下文队列
 //
 // A nil q yields a fresh in-process queue, which is almost never what a caller
-// wants: two calls produce two unconnected queues, so a consumer registered on
-// one never sees what is published to the other. Application.GetQueuePrefix
-// passes a shared queue for exactly this reason.
+// wants: it works, but it is private to the returned handle, so a consumer
+// registered through one call never sees what another publishes.
+// Application.GetQueuePrefix passes a shared queue for exactly this reason.
 func NewQueue(prefix string, q storage.AdapterQueue) storage.AdapterQueue {
 	if q == nil {
-		slog.Warn("runtime: queue created without a backing adapter; it is connected to nothing else",
+		slog.Warn("runtime: queue created without a backing adapter; it is private to this handle and is not the configured backend",
 			"prefix", prefix)
 		q = queue.NewMemory(100)
 	}

--- a/sdk/runtime/queue_adapter_test.go
+++ b/sdk/runtime/queue_adapter_test.go
@@ -33,21 +33,36 @@ func TestQueuePrefixIsSharedWithoutConfiguration(t *testing.T) {
 	}
 }
 
+// fakeQueue is distinguishable from the fallback, which the real memory queue
+// is not: both report "memory", so asserting on that would pass whether or not
+// the configured adapter was used.
+type fakeQueue struct{ storage.AdapterQueue }
+
+func (fakeQueue) String() string { return "fake" }
+
 // The configured adapter is what the queue getters must hand out, otherwise
 // selecting Redis in the settings file changes nothing.
 func TestConfiguredAdapterIsUsed(t *testing.T) {
 	app := NewConfig()
-
-	configured := queue.NewMemory(16)
-	app.SetQueueAdapter(configured)
+	app.SetQueueAdapter(fakeQueue{})
 
 	for name, q := range map[string]storage.AdapterQueue{
 		"GetQueuePrefix":  app.GetQueuePrefix("x"),
 		"GetQueueAdapter": app.GetQueueAdapter(),
 	} {
-		if q.String() != configured.String() {
+		if q.String() != "fake" {
 			t.Errorf("%s: got %q, want the configured adapter", name, q.String())
 		}
+	}
+}
+
+// Without configuration the getters fall back, and the fallback has to be the
+// in-process queue rather than an error or a nil.
+func TestFallbackIsTheMemoryQueue(t *testing.T) {
+	app := NewConfig()
+
+	if got := app.GetQueuePrefix("x").String(); got != "memory" {
+		t.Errorf("got %q, want memory", got)
 	}
 }
 

--- a/sdk/runtime/queue_adapter_test.go
+++ b/sdk/runtime/queue_adapter_test.go
@@ -1,0 +1,81 @@
+package runtime
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/storage"
+	"github.com/go-admin-team/go-admin-core/storage/queue"
+)
+
+// Two callers asking for the queue have to reach the same one. When they did
+// not, a consumer registered through one and a message published through the
+// other went to unconnected queues and every message was lost in silence.
+func TestQueuePrefixIsSharedWithoutConfiguration(t *testing.T) {
+	app := NewConfig()
+
+	got := make(chan storage.Messager, 1)
+	app.GetQueuePrefix("consumer").Register("orders", func(m storage.Messager) error {
+		got <- m
+		return nil
+	})
+
+	producer := app.GetQueuePrefix("producer")
+	if err := producer.Append(&queue.Message{Stream: "orders"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	select {
+	case <-got:
+	case <-time.After(3 * time.Second):
+		t.Fatal("a message published through one handle never reached a consumer registered through another")
+	}
+}
+
+// The configured adapter is what the queue getters must hand out, otherwise
+// selecting Redis in the settings file changes nothing.
+func TestConfiguredAdapterIsUsed(t *testing.T) {
+	app := NewConfig()
+
+	configured := queue.NewMemory(16)
+	app.SetQueueAdapter(configured)
+
+	for name, q := range map[string]storage.AdapterQueue{
+		"GetQueuePrefix":  app.GetQueuePrefix("x"),
+		"GetQueueAdapter": app.GetQueueAdapter(),
+	} {
+		if q.String() != configured.String() {
+			t.Errorf("%s: got %q, want the configured adapter", name, q.String())
+		}
+	}
+}
+
+// Reloading the configuration replaces the adapter while requests are in
+// flight, so the field is read and written concurrently.
+func TestAdapterSwapIsRaceFree(t *testing.T) {
+	app := NewConfig()
+
+	const rounds = 2000
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			app.SetQueueAdapter(queue.NewMemory(8))
+			app.SetCacheAdapter(nil)
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			_ = app.GetQueuePrefix("x")
+			_ = app.GetCacheAdapterPrefix("x")
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Selecting a queue backend in the settings file changed nothing. This is the last piece of #112 — that PR made a Redis queue selectable, this one makes the selection reach the code that publishes.

## What was wrong

The adapter built from configuration is stored through `SetQueueAdapter`, but the getter call sites actually use is `GetMemoryQueue`, which returns a queue hardcoded at construction:

```go
memoryQueue: queue.NewMemory(10000),   // application.go
```

So a process configured with `queue.redis` still ran its login-log, operate-log and api-check queues entirely in process, and a second instance saw none of it.

`GetQueuePrefix` already returned the configured adapter, so it looks like the answer. It was not usable as one:

```go
func NewQueue(prefix string, q storage.AdapterQueue) storage.AdapterQueue {
	if q == nil {
		q = queue.NewMemory(100)   // a fresh queue, every call
	}
```

With no queue configured, two calls produced two unconnected queues. A consumer registered through one handle and a message published through another went to different queues, and the message was dropped without a word — the failure mode this whole line of work exists to remove.

## What changed

- The fallback is the one shared memory queue rather than a fresh one. `TestQueuePrefixIsSharedWithoutConfiguration` registers through one handle and publishes through another; reverting the fallback makes it fail, so it is not a test that passes for free.
- `queue` and `cache` are now read and written under the lock every other field on `Application` already uses. Reloading the configuration calls `Setup` again, so the swap happens while requests are in flight; that is a data race, and `TestAdapterSwapIsRaceFree` puts it under the detector.
- `GetMemoryQueue` is deprecated rather than changed. Its name promises the in-process queue, and silently making it configuration-dependent would be worse than leaving it honest.
- `NewQueue` still accepts nil for compatibility but logs when it happens, because a queue connected to nothing else is not a state anyone picks deliberately.

## Not included

Call sites move separately. `go-admin` has four uses of `GetMemoryQueue` that should become `GetQueuePrefix`; that is a change in another repository, and its current checkout does not build against `main` for reasons that predate this branch.

## Verification

`make ci` green. Downstream canary against `go-admin` reports the same six pre-existing drift errors as `main` — no new breakage, since `GetMemoryQueue` keeps its signature and behaviour.
