### PR TITLE
fix🐛: complete the deprecated jwtauth shim

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -1063,12 +1063,56 @@ type Logger = newcasbin.Logger
 func NewWithSeconds() *cron.Cron
 
 ## github.com/go-admin-team/go-admin-core/sdk/pkg/jwtauth
+const JwtPayloadKey = newjwtauth.JwtPayloadKey
+var (
+	ErrEmptyAuthHeader = newjwtauth.ErrEmptyAuthHeader
+	ErrEmptyCookieToken = newjwtauth.ErrEmptyCookieToken
+	ErrEmptyParamToken = newjwtauth.ErrEmptyParamToken
+	ErrEmptyQueryToken = newjwtauth.ErrEmptyQueryToken
+	ErrExpiredToken = newjwtauth.ErrExpiredToken
+	ErrFailedAuthentication = newjwtauth.ErrFailedAuthentication
+	ErrFailedTokenCreation = newjwtauth.ErrFailedTokenCreation
+	ErrForbidden = newjwtauth.ErrForbidden
+	ErrInvalidAuthHeader = newjwtauth.ErrInvalidAuthHeader
+	ErrInvalidClaims = newjwtauth.ErrInvalidClaims
+	ErrInvalidPrivKey = newjwtauth.ErrInvalidPrivKey
+	ErrInvalidPubKey = newjwtauth.ErrInvalidPubKey
+	ErrInvalidSigningAlgorithm = newjwtauth.ErrInvalidSigningAlgorithm
+	ErrInvalidVerificationode = newjwtauth.ErrInvalidVerificationode
+	ErrMissingAuthenticatorFunc = newjwtauth.ErrMissingAuthenticatorFunc
+	ErrMissingExpField = newjwtauth.ErrMissingExpField
+	ErrMissingLoginValues = newjwtauth.ErrMissingLoginValues
+	ErrMissingOrigIatField = newjwtauth.ErrMissingOrigIatField
+	ErrMissingSecretKey = newjwtauth.ErrMissingSecretKey
+	ErrNoPrivKeyFile = newjwtauth.ErrNoPrivKeyFile
+	ErrNoPubKeyFile = newjwtauth.ErrNoPubKeyFile
+	ErrWrongFormatOfExp = newjwtauth.ErrWrongFormatOfExp
+	DataScopeKey = newjwtauth.DataScopeKey
+	DeptId = newjwtauth.DeptId
+	DeptName = newjwtauth.DeptName
+	IdentityKey = newjwtauth.IdentityKey
+	NiceKey = newjwtauth.NiceKey
+	RKey = newjwtauth.RKey
+	RoleIdKey = newjwtauth.RoleIdKey
+	RoleKey = newjwtauth.RoleKey
+	RoleNameKey = newjwtauth.RoleNameKey
 func GetToken(c *gin.Context) string
 type GinJWTMiddleware = newjwtauth.GinJWTMiddleware
 func New(m *GinJWTMiddleware) (*GinJWTMiddleware, error)
 type MapClaims = newjwtauth.MapClaims
 func ExtractClaims(c *gin.Context) MapClaims
 func ExtractClaimsFromToken(token *jwt.Token) MapClaims
+
+## github.com/go-admin-team/go-admin-core/sdk/pkg/jwtauth/user
+func ExtractClaims(c *gin.Context) jwtauth.MapClaims
+func Get(c *gin.Context, key string) interface{}
+func GetDeptId(c *gin.Context) int
+func GetDeptName(c *gin.Context) string
+func GetRoleId(c *gin.Context) int
+func GetRoleName(c *gin.Context) string
+func GetUserId(c *gin.Context) int
+func GetUserIdStr(c *gin.Context) string
+func GetUserName(c *gin.Context) string
 
 ## github.com/go-admin-team/go-admin-core/sdk/pkg/logger
 func SetupLogger(opts ...logger.Option) logger.Logger

--- a/sdk/pkg/jwtauth/deprecated.go
+++ b/sdk/pkg/jwtauth/deprecated.go
@@ -1,16 +1,17 @@
-// Package jwtauth 已弃用
+// Package jwtauth forwards to the package of the same name at the top level.
 //
-// Deprecated: 请使用 github.com/go-admin-team/go-admin-core/jwtauth 替代。
-// 本包将在 v2.0.0 版本中移除。
+// Deprecated: use github.com/go-admin-team/go-admin-core/jwtauth. This package
+// will be removed in v2.0.0.
 //
-// 迁移指南:
-//   旧导入: import "github.com/go-admin-team/go-admin-core/sdk/pkg/jwtauth"
-//   新导入: import "github.com/go-admin-team/go-admin-core/jwtauth"
+// To migrate, change the import:
+//
+//	old: import "github.com/go-admin-team/go-admin-core/sdk/pkg/jwtauth"
+//	new: import "github.com/go-admin-team/go-admin-core/jwtauth"
 package jwtauth
 
 import (
-	newjwtauth "github.com/go-admin-team/go-admin-core/jwtauth"
 	"github.com/gin-gonic/gin"
+	newjwtauth "github.com/go-admin-team/go-admin-core/jwtauth"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -39,3 +40,76 @@ func ExtractClaimsFromToken(token *jwt.Token) MapClaims {
 func GetToken(c *gin.Context) string {
 	return newjwtauth.GetToken(c)
 }
+
+// The identifiers below are forwarded so that this package is a complete
+// stand-in. Only some of them were, which is worse than none: the package
+// compiled far enough to look like a working compatibility layer and then
+// failed on whatever it had left out.
+var (
+	// Deprecated: use jwtauth.ErrEmptyAuthHeader.
+	ErrEmptyAuthHeader = newjwtauth.ErrEmptyAuthHeader
+	// Deprecated: use jwtauth.ErrEmptyCookieToken.
+	ErrEmptyCookieToken = newjwtauth.ErrEmptyCookieToken
+	// Deprecated: use jwtauth.ErrEmptyParamToken.
+	ErrEmptyParamToken = newjwtauth.ErrEmptyParamToken
+	// Deprecated: use jwtauth.ErrEmptyQueryToken.
+	ErrEmptyQueryToken = newjwtauth.ErrEmptyQueryToken
+	// Deprecated: use jwtauth.ErrExpiredToken.
+	ErrExpiredToken = newjwtauth.ErrExpiredToken
+	// Deprecated: use jwtauth.ErrFailedAuthentication.
+	ErrFailedAuthentication = newjwtauth.ErrFailedAuthentication
+	// Deprecated: use jwtauth.ErrFailedTokenCreation.
+	ErrFailedTokenCreation = newjwtauth.ErrFailedTokenCreation
+	// Deprecated: use jwtauth.ErrForbidden.
+	ErrForbidden = newjwtauth.ErrForbidden
+	// Deprecated: use jwtauth.ErrInvalidAuthHeader.
+	ErrInvalidAuthHeader = newjwtauth.ErrInvalidAuthHeader
+	// Deprecated: use jwtauth.ErrInvalidClaims.
+	ErrInvalidClaims = newjwtauth.ErrInvalidClaims
+	// Deprecated: use jwtauth.ErrInvalidPrivKey.
+	ErrInvalidPrivKey = newjwtauth.ErrInvalidPrivKey
+	// Deprecated: use jwtauth.ErrInvalidPubKey.
+	ErrInvalidPubKey = newjwtauth.ErrInvalidPubKey
+	// Deprecated: use jwtauth.ErrInvalidSigningAlgorithm.
+	ErrInvalidSigningAlgorithm = newjwtauth.ErrInvalidSigningAlgorithm
+	// Deprecated: use jwtauth.ErrInvalidVerificationode.
+	ErrInvalidVerificationode = newjwtauth.ErrInvalidVerificationode
+	// Deprecated: use jwtauth.ErrMissingAuthenticatorFunc.
+	ErrMissingAuthenticatorFunc = newjwtauth.ErrMissingAuthenticatorFunc
+	// Deprecated: use jwtauth.ErrMissingExpField.
+	ErrMissingExpField = newjwtauth.ErrMissingExpField
+	// Deprecated: use jwtauth.ErrMissingLoginValues.
+	ErrMissingLoginValues = newjwtauth.ErrMissingLoginValues
+	// Deprecated: use jwtauth.ErrMissingOrigIatField.
+	ErrMissingOrigIatField = newjwtauth.ErrMissingOrigIatField
+	// Deprecated: use jwtauth.ErrMissingSecretKey.
+	ErrMissingSecretKey = newjwtauth.ErrMissingSecretKey
+	// Deprecated: use jwtauth.ErrNoPrivKeyFile.
+	ErrNoPrivKeyFile = newjwtauth.ErrNoPrivKeyFile
+	// Deprecated: use jwtauth.ErrNoPubKeyFile.
+	ErrNoPubKeyFile = newjwtauth.ErrNoPubKeyFile
+	// Deprecated: use jwtauth.ErrWrongFormatOfExp.
+	ErrWrongFormatOfExp = newjwtauth.ErrWrongFormatOfExp
+
+	// Deprecated: use jwtauth.DataScopeKey.
+	DataScopeKey = newjwtauth.DataScopeKey
+	// Deprecated: use jwtauth.DeptId.
+	DeptId = newjwtauth.DeptId
+	// Deprecated: use jwtauth.DeptName.
+	DeptName = newjwtauth.DeptName
+	// Deprecated: use jwtauth.IdentityKey.
+	IdentityKey = newjwtauth.IdentityKey
+	// Deprecated: use jwtauth.NiceKey.
+	NiceKey = newjwtauth.NiceKey
+	// Deprecated: use jwtauth.RKey.
+	RKey = newjwtauth.RKey
+	// Deprecated: use jwtauth.RoleIdKey.
+	RoleIdKey = newjwtauth.RoleIdKey
+	// Deprecated: use jwtauth.RoleKey.
+	RoleKey = newjwtauth.RoleKey
+	// Deprecated: use jwtauth.RoleNameKey.
+	RoleNameKey = newjwtauth.RoleNameKey
+)
+
+// Deprecated: use jwtauth.JwtPayloadKey.
+const JwtPayloadKey = newjwtauth.JwtPayloadKey

--- a/sdk/pkg/jwtauth/user/deprecated.go
+++ b/sdk/pkg/jwtauth/user/deprecated.go
@@ -1,0 +1,46 @@
+// Package user forwards to jwtauth/user.
+//
+// Deprecated: use github.com/go-admin-team/go-admin-core/jwtauth/user. This
+// package exists so that the move does not break importers; it will be removed
+// in v2.0.0.
+//
+// The parent package kept a forwarding shim when it moved, but this one did
+// not, so the package simply vanished. That is a load error rather than a type
+// error, which stops the compiler before it reports anything else — an
+// importer upgrading to a current release saw one confusing message instead of
+// the list of things actually left to change.
+package user
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/go-admin-team/go-admin-core/jwtauth"
+	newuser "github.com/go-admin-team/go-admin-core/jwtauth/user"
+)
+
+// Deprecated: use jwtauth/user.ExtractClaims.
+func ExtractClaims(c *gin.Context) jwtauth.MapClaims { return newuser.ExtractClaims(c) }
+
+// Deprecated: use jwtauth/user.Get.
+func Get(c *gin.Context, key string) interface{} { return newuser.Get(c, key) }
+
+// Deprecated: use jwtauth/user.GetUserId.
+func GetUserId(c *gin.Context) int { return newuser.GetUserId(c) }
+
+// Deprecated: use jwtauth/user.GetUserIdStr.
+func GetUserIdStr(c *gin.Context) string { return newuser.GetUserIdStr(c) }
+
+// Deprecated: use jwtauth/user.GetUserName.
+func GetUserName(c *gin.Context) string { return newuser.GetUserName(c) }
+
+// Deprecated: use jwtauth/user.GetRoleName.
+func GetRoleName(c *gin.Context) string { return newuser.GetRoleName(c) }
+
+// Deprecated: use jwtauth/user.GetRoleId.
+func GetRoleId(c *gin.Context) int { return newuser.GetRoleId(c) }
+
+// Deprecated: use jwtauth/user.GetDeptId.
+func GetDeptId(c *gin.Context) int { return newuser.GetDeptId(c) }
+
+// Deprecated: use jwtauth/user.GetDeptName.
+func GetDeptName(c *gin.Context) string { return newuser.GetDeptName(c) }

--- a/sdk/pkg/jwtauth/user/deprecated_test.go
+++ b/sdk/pkg/jwtauth/user/deprecated_test.go
@@ -1,6 +1,7 @@
 package user_test
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -12,10 +13,30 @@ import (
 )
 
 // withClaims builds a context carrying the payload the accessors read.
+//
+// The request matters: an accessor whose claim is absent logs the method and
+// path, so a context without one panics on a nil dereference rather than
+// returning the zero value the caller expects.
 func withClaims(claims jwtauth.MapClaims) *gin.Context {
+	gin.SetMode(gin.TestMode)
+
 	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
 	c.Set(jwtauth.JwtPayloadKey, claims)
 	return c
+}
+
+// An absent claim is a normal condition — the accessors warn and return a zero
+// value — so it must not take the process down.
+func TestAbsentClaimReturnsZero(t *testing.T) {
+	c := withClaims(jwtauth.MapClaims{})
+
+	if got := olduser.GetDeptName(c); got != "" {
+		t.Errorf("GetDeptName with no claim: got %#v, want an empty string", got)
+	}
+	if got := olduser.GetUserId(c); got != 0 {
+		t.Errorf("GetUserId with no claim: got %#v, want 0", got)
+	}
 }
 
 // Every accessor has to return what the package it forwards to returns. A shim

--- a/sdk/pkg/jwtauth/user/deprecated_test.go
+++ b/sdk/pkg/jwtauth/user/deprecated_test.go
@@ -1,0 +1,82 @@
+package user_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/go-admin-team/go-admin-core/jwtauth"
+	newuser "github.com/go-admin-team/go-admin-core/jwtauth/user"
+	olduser "github.com/go-admin-team/go-admin-core/sdk/pkg/jwtauth/user"
+)
+
+// withClaims builds a context carrying the payload the accessors read.
+func withClaims(claims jwtauth.MapClaims) *gin.Context {
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Set(jwtauth.JwtPayloadKey, claims)
+	return c
+}
+
+// Every accessor has to return what the package it forwards to returns. A shim
+// that compiles but reads a different key would be worse than no shim at all,
+// because the importer would see plausible zero values instead of an error.
+func TestForwardsToTheCurrentPackage(t *testing.T) {
+	claims := jwtauth.MapClaims{
+		"identity": float64(7),
+		"nice":     "seven",
+		"nickname": "tester",
+		"rolekey":  "admin",
+		"roleid":   float64(3),
+		"deptid":   float64(11),
+		"deptkey":  "ops",
+	}
+
+	cases := []struct {
+		name string
+		old  func(*gin.Context) interface{}
+		want func(*gin.Context) interface{}
+	}{
+		{"GetUserId",
+			func(c *gin.Context) interface{} { return olduser.GetUserId(c) },
+			func(c *gin.Context) interface{} { return newuser.GetUserId(c) }},
+		{"GetUserIdStr",
+			func(c *gin.Context) interface{} { return olduser.GetUserIdStr(c) },
+			func(c *gin.Context) interface{} { return newuser.GetUserIdStr(c) }},
+		{"GetUserName",
+			func(c *gin.Context) interface{} { return olduser.GetUserName(c) },
+			func(c *gin.Context) interface{} { return newuser.GetUserName(c) }},
+		{"GetRoleName",
+			func(c *gin.Context) interface{} { return olduser.GetRoleName(c) },
+			func(c *gin.Context) interface{} { return newuser.GetRoleName(c) }},
+		{"GetRoleId",
+			func(c *gin.Context) interface{} { return olduser.GetRoleId(c) },
+			func(c *gin.Context) interface{} { return newuser.GetRoleId(c) }},
+		{"GetDeptId",
+			func(c *gin.Context) interface{} { return olduser.GetDeptId(c) },
+			func(c *gin.Context) interface{} { return newuser.GetDeptId(c) }},
+		{"GetDeptName",
+			func(c *gin.Context) interface{} { return olduser.GetDeptName(c) },
+			func(c *gin.Context) interface{} { return newuser.GetDeptName(c) }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, want := tc.old(withClaims(claims)), tc.want(withClaims(claims))
+			if got != want {
+				t.Errorf("got %#v, want %#v", got, want)
+			}
+			// A zero value on both sides would make the comparison meaningless.
+			if got == nil || got == "" || got == 0 {
+				t.Errorf("the fixture does not exercise this accessor: got %#v", got)
+			}
+		})
+	}
+
+	if got := olduser.ExtractClaims(withClaims(claims)); len(got) != len(claims) {
+		t.Errorf("ExtractClaims: got %d claims, want %d", len(got), len(claims))
+	}
+	if got := olduser.Get(withClaims(claims), "nickname"); got != "tester" {
+		t.Errorf("Get: got %#v, want tester", got)
+	}
+}


### PR DESCRIPTION
The shim left behind when `jwtauth` moved to the top level forwards six of the package's thirty-seven exported identifiers, and the `user` sub-package got no shim at all.

## Why that is worse than no shim

A partial shim compiles far enough to look like a working compatibility layer, then fails on whatever it left out. The missing sub-package is worse still: `no required module provides package .../sdk/pkg/jwtauth/user` is a **load** error, so the compiler stops there and reports nothing else.

That is not hypothetical. Upgrading `go-admin` to a current release, the first build reported exactly one error — the missing sub-package. Fixing it revealed the next layer, and so on through four rounds. Each round looked like "almost done" and was not, because every layer was hidden behind the one before it. An importer reading that first message has no way to judge whether the upgrade is a five-minute change or a week.

## What changed

Every exported identifier now forwards: the twenty-two error values, the nine claim keys, `JwtPayloadKey`, and the nine accessors in `jwtauth/user`.

The test compares each accessor against the package it forwards to rather than against a literal, and asserts the fixture produces a non-zero value. That second part earned its keep immediately: two accessors read claim keys that do not match their names — `GetDeptName` reads `deptkey` — so a test written from the names alone would have compared an empty string against an empty string and passed. Reverting a forwarding line makes the test fail with `got 0, want 7`.

The package header is now English, per CONTRIBUTING.md. It was rewritten rather than left alone because gofmt reindented two of its lines, which made them newly added as far as the language gate is concerned, and half-translating the block would have been worse than either alternative.

## Verification

`make ci` green, including the API snapshot. With this branch in place, `go-admin` builds against current core after a set of renames that are now visible all at once rather than one per build.
