### PR TITLE
fix🐛: three stability fixes in config, the Redis queue and tenant databases

### DIFF
--- a/config/close_test.go
+++ b/config/close_test.go
@@ -10,12 +10,14 @@ import (
 // implementation selected on the channel and then closed it, which is a check
 // followed by an act: two callers could both find it open and both close it,
 // and the second one panics.
+//
+// The value is built here rather than through NewConfig because only the exit
+// channel takes part in the race, and NewConfig starts a watcher that outlives
+// Close by a second — three thousand of those is a lot of goroutines to hold
+// open for a race that does not involve them.
 func TestCloseIsSafeUnderConcurrency(t *testing.T) {
 	for i := 0; i < 3000; i++ {
-		c, err := NewConfig()
-		if err != nil {
-			t.Fatalf("NewConfig: %v", err)
-		}
+		c := &config{exit: make(chan bool)}
 
 		var wg sync.WaitGroup
 		start := make(chan struct{})

--- a/config/close_test.go
+++ b/config/close_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"sync"
+	"testing"
+)
+
+// Close is called from more than one place — a caller's defer and the watcher
+// shutting down — so it has to survive being called twice at once. The previous
+// implementation selected on the channel and then closed it, which is a check
+// followed by an act: two callers could both find it open and both close it,
+// and the second one panics.
+func TestCloseIsSafeUnderConcurrency(t *testing.T) {
+	for i := 0; i < 3000; i++ {
+		c, err := NewConfig()
+		if err != nil {
+			t.Fatalf("NewConfig: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for j := 0; j < 32; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if err := c.Close(); err != nil {
+					t.Errorf("Close: %v", err)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+}

--- a/config/default.go
+++ b/config/default.go
@@ -15,7 +15,10 @@ import (
 
 type config struct {
 	exit chan bool
-	opts Options
+	// exitOnce guards exit: the select-then-close in Close is a check followed
+	// by an act, so two callers can both reach the close.
+	exitOnce sync.Once
+	opts     Options
 
 	sync.RWMutex
 	// the current snapshot
@@ -196,12 +199,7 @@ func (c *config) Sync() error {
 }
 
 func (c *config) Close() error {
-	select {
-	case <-c.exit:
-		return nil
-	default:
-		close(c.exit)
-	}
+	c.exitOnce.Do(func() { close(c.exit) })
 	return nil
 }
 

--- a/config/source/file/watcher.go
+++ b/config/source/file/watcher.go
@@ -1,4 +1,5 @@
-//+build !linux
+//go:build !linux
+// +build !linux
 
 package file
 

--- a/config/source/file/watcher_linux.go
+++ b/config/source/file/watcher_linux.go
@@ -1,4 +1,5 @@
-//+build linux
+//go:build linux
+// +build linux
 
 package file
 

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"log"
+	"log/slog"
+	"sort"
 
 	"github.com/go-admin-team/go-admin-core/config"
 	"github.com/go-admin-team/go-admin-core/config/source"
@@ -55,13 +57,29 @@ type Config struct {
 	Extend      interface{}           `yaml:"extend"`
 }
 
-// 多db改造
+// multiDatabase fills in the databases map for a single-database setup, where
+// the wildcard entry means "one database serves every tenant".
 func (e *Config) multiDatabase() {
 	if len(*e.Databases) == 0 {
 		*e.Databases = map[string]*Database{
 			"*": e.Database,
 		}
+		return
+	}
 
+	// The wildcard short-circuits the per-tenant lookup, so anything listed
+	// beside it is dead configuration. Said out loud, because the symptom is
+	// tenants quietly sharing one database rather than an error.
+	if _, wildcard := (*e.Databases)["*"]; wildcard && len(*e.Databases) > 1 {
+		others := make([]string, 0, len(*e.Databases)-1)
+		for name := range *e.Databases {
+			if name != "*" {
+				others = append(others, name)
+			}
+		}
+		sort.Strings(others)
+		slog.Warn("config: the wildcard database entry hides the per-tenant ones, which will never be used",
+			"ignored", others)
 	}
 }
 

--- a/sdk/config/multidatabase_test.go
+++ b/sdk/config/multidatabase_test.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// captureWarnings redirects the default logger for one test.
+func captureWarnings(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return buf
+}
+
+// A single-database configuration is expressed as the wildcard entry, which is
+// how one database comes to serve every tenant.
+func TestSingleDatabaseBecomesTheWildcard(t *testing.T) {
+	dbs := map[string]*Database{}
+	c := &Config{Database: &Database{Driver: "mysql"}, Databases: &dbs}
+
+	c.multiDatabase()
+
+	if len(dbs) != 1 || dbs["*"] == nil {
+		t.Errorf("got %#v, want a single wildcard entry", dbs)
+	}
+}
+
+// The wildcard short-circuits the per-tenant lookup, so entries listed beside it
+// never serve anyone. That is a configuration mistake with no symptom other than
+// tenants sharing a database, which is exactly the kind that has to be said out
+// loud.
+func TestWildcardBesidePerTenantEntriesWarns(t *testing.T) {
+	buf := captureWarnings(t)
+
+	dbs := map[string]*Database{
+		"*":        {Driver: "mysql"},
+		"tenant-a": {Driver: "mysql"},
+		"tenant-b": {Driver: "mysql"},
+	}
+	c := &Config{Database: &Database{}, Databases: &dbs}
+
+	c.multiDatabase()
+
+	got := buf.String()
+	if !strings.Contains(got, "wildcard") {
+		t.Errorf("the clash must be reported, got: %q", got)
+	}
+	for _, name := range []string{"tenant-a", "tenant-b"} {
+		if !strings.Contains(got, name) {
+			t.Errorf("the warning must name %q so it can be found, got: %q", name, got)
+		}
+	}
+}
+
+// Per-tenant entries on their own are the normal multi-tenant setup and must
+// stay quiet, or the warning becomes noise nobody reads.
+func TestPerTenantEntriesAloneAreSilent(t *testing.T) {
+	buf := captureWarnings(t)
+
+	dbs := map[string]*Database{"tenant-a": {Driver: "mysql"}, "tenant-b": {Driver: "mysql"}}
+	c := &Config{Database: &Database{}, Databases: &dbs}
+
+	c.multiDatabase()
+
+	if got := buf.String(); got != "" {
+		t.Errorf("a normal multi-tenant configuration must not warn, got: %q", got)
+	}
+}

--- a/storage/redis/queue.go
+++ b/storage/redis/queue.go
@@ -366,14 +366,35 @@ func (q *Queue) Start(ctx context.Context) error {
 			// The block elapsed with nothing new.
 			continue
 		case isMissingGroup(err):
+			if ctx.Err() != nil {
+				// Cancellation outranks recovery. A real client reports the
+				// cancellation itself, but this branch loops, and a looping
+				// branch that cannot be stopped is a hang waiting to happen.
+				return nil
+			}
 			// The group can be gone for two reasons: a Subscribe that has not
 			// finished creating it yet, or an operator deleting the stream
 			// while this is running. Neither is a reason to stop consuming
 			// forever, which is what returning here used to do.
+			recreated := true
 			for _, t := range topics {
-				if err := q.ensureGroup(ctx, t); err != nil && ctx.Err() == nil {
-					slog.Warn("queue: could not recreate the consumer group",
-						"topic", t, "error", err)
+				if err := q.ensureGroup(ctx, t); err != nil {
+					recreated = false
+					if ctx.Err() == nil {
+						slog.Warn("queue: could not recreate the consumer group",
+							"topic", t, "error", err)
+					}
+				}
+			}
+			if !recreated {
+				// A missing group comes back immediately and ignores Block, so
+				// a group that cannot be recreated — a read-only replica, an
+				// ACL without XGROUP — would spin this loop at full speed and
+				// fill the log. Wait out one read instead.
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(q.opts.Block):
 				}
 			}
 			continue

--- a/storage/redis/queue.go
+++ b/storage/redis/queue.go
@@ -241,6 +241,13 @@ func (q *Queue) ensureGroup(ctx context.Context, topic string) error {
 	return nil
 }
 
+// isMissingGroup reports the error Redis returns for a read against a group
+// that does not exist. It has no dedicated type in the client, so the reply is
+// matched on its prefix, which is what NOGROUP is for.
+func isMissingGroup(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), "NOGROUP")
+}
+
 // groupExists asks Redis whether anyone consumes the topic.
 func (q *Queue) groupExists(ctx context.Context, topic string) (bool, error) {
 	groups, err := q.client.XInfoGroups(ctx, q.stream(topic)).Result()
@@ -357,6 +364,18 @@ func (q *Queue) Start(ctx context.Context) error {
 		switch {
 		case errors.Is(err, goredis.Nil):
 			// The block elapsed with nothing new.
+			continue
+		case isMissingGroup(err):
+			// The group can be gone for two reasons: a Subscribe that has not
+			// finished creating it yet, or an operator deleting the stream
+			// while this is running. Neither is a reason to stop consuming
+			// forever, which is what returning here used to do.
+			for _, t := range topics {
+				if err := q.ensureGroup(ctx, t); err != nil && ctx.Err() == nil {
+					slog.Warn("queue: could not recreate the consumer group",
+						"topic", t, "error", err)
+				}
+			}
 			continue
 		case err != nil:
 			if ctx.Err() != nil {

--- a/storage/redis/queue_test.go
+++ b/storage/redis/queue_test.go
@@ -235,3 +235,73 @@ func TestCloseLeavesBorrowedClientUsable(t *testing.T) {
 		})
 	}
 }
+
+// An operator deleting the stream, or any other way the consumer group can go
+// missing, used to end the read loop for good: NOGROUP is an ordinary error, so
+// Start returned it and nothing was ever consumed again. It has to recover.
+func TestRecoversFromADeletedStream(t *testing.T) {
+	url := redisURL(t)
+	admin := adminClient(t, url)
+	flush(t, admin)
+
+	q, err := redisstore.OpenQueue(context.Background(), url, redisstore.QueueOptions{
+		Block: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("connect to Redis: %v", err)
+	}
+	defer q.Close()
+
+	got := make(chan storage.Message, 8)
+	if err := q.Subscribe("orders", func(_ context.Context, m storage.Message) error {
+		got <- m
+		return nil
+	}); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan error, 1)
+	go func() { started <- q.Start(ctx) }()
+
+	if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
+		t.Fatalf("Publish: %v", err)
+	}
+	select {
+	case <-got:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first message was never delivered")
+	}
+
+	// Take the stream away underneath the running loop.
+	if err := admin.Del(context.Background(), "orders").Err(); err != nil {
+		t.Fatalf("DEL: %v", err)
+	}
+
+	// The loop has to notice, put the group back and carry on. Publish recreates
+	// the stream through XADD; without recovery Start would already have exited.
+	deadline := time.After(10 * time.Second)
+	for {
+		if err := q.Publish(context.Background(), storage.Message{Topic: "orders"}); err != nil {
+			t.Fatalf("Publish after the stream was deleted: %v", err)
+		}
+		select {
+		case <-got:
+			select {
+			case err := <-started:
+				t.Fatalf("Start returned instead of recovering: %v", err)
+			default:
+			}
+			return
+		case err := <-started:
+			t.Fatalf("Start returned instead of recovering: %v", err)
+		case <-time.After(250 * time.Millisecond):
+		}
+		select {
+		case <-deadline:
+			t.Fatal("the queue never resumed consuming after the stream was deleted")
+		default:
+		}
+	}
+}

--- a/storage/redis/queue_test.go
+++ b/storage/redis/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -303,5 +304,75 @@ func TestRecoversFromADeletedStream(t *testing.T) {
 			t.Fatal("the queue never resumed consuming after the stream was deleted")
 		default:
 		}
+	}
+}
+
+// spinClient reports a missing group on every read, and lets the group be
+// created exactly once so that Subscribe succeeds and the recovery inside the
+// read loop does not. A real Redis reaches this state through a failover to a
+// read-only replica or an ACL that allows XREADGROUP but not XGROUP.
+type spinClient struct {
+	// Embedded rather than implemented: the read loop touches two commands and
+	// nothing else, and a nil call panicking says so loudly.
+	goredis.UniversalClient
+
+	reads  atomic.Int64
+	groups atomic.Int64
+}
+
+func (c *spinClient) XReadGroup(ctx context.Context, _ *goredis.XReadGroupArgs) *goredis.XStreamSliceCmd {
+	c.reads.Add(1)
+	cmd := goredis.NewXStreamSliceCmd(ctx)
+	cmd.SetErr(errors.New("NOGROUP No such key 'orders' or consumer group 'g'"))
+	return cmd
+}
+
+func (c *spinClient) XGroupCreateMkStream(ctx context.Context, _, _, _ string) *goredis.StatusCmd {
+	cmd := goredis.NewStatusCmd(ctx)
+	if c.groups.Add(1) > 1 {
+		cmd.SetErr(errors.New("NOPERM this user has no permissions to run the 'xgroup|create' command"))
+	}
+	return cmd
+}
+
+// A group that cannot be recreated used to cost a full core: XREADGROUP answers
+// NOGROUP without waiting out Block, so the recovery path had no pacing of its
+// own. Needs no Redis.
+func TestReadLoopPacesItselfWhenTheGroupCannotBeRecreated(t *testing.T) {
+	const block = 50 * time.Millisecond
+
+	client := &spinClient{}
+	q := redisstore.NewQueue(client, redisstore.QueueOptions{
+		Group: "g",
+		Block: block,
+		// Long enough that the reclaim sweep never runs and never reaches a
+		// command this client does not implement.
+		ClaimMinIdle: time.Minute,
+	})
+	if err := q.Subscribe("orders", func(context.Context, storage.Message) error { return nil }); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	window := 20 * block
+	ctx, cancel := context.WithTimeout(context.Background(), window)
+	defer cancel()
+
+	// Start runs on its own so that a loop which ignores the deadline fails the
+	// test rather than hanging the package until the go test timeout.
+	done := make(chan error, 1)
+	go func() { done <- q.Start(ctx) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-time.After(4 * window):
+		t.Fatalf("Start did not return %v after the context expired", 3*window)
+	}
+
+	// One read per backoff is the shape being pinned; the allowance is for a
+	// loaded machine, not for a loop that never waits.
+	if reads, limit := client.reads.Load(), int64(window/block)*3; reads > limit {
+		t.Errorf("%d reads in %v, expected at most %d: the loop is not backing off", reads, window, limit)
 	}
 }


### PR DESCRIPTION
Three defects that survive a restart and have nothing to do with each other, so they are three commits. All three are pre-existing; one of them took down a CI run on an unrelated branch during this work.

## `config.Close` could panic

```go
select {
case <-c.exit:
	return nil
default:
	close(c.exit)   // two callers can both get here
}
```

A check followed by an act. It is not theoretical — `config/source/file` died with `panic: close of closed channel` during this branch's own CI, from a defer in `TestConfig`. `sync.Once` makes it exactly once by construction.

The regression test reproduces the old behaviour at three thousand rounds of thirty-two concurrent `Close` calls. At two hundred rounds of eight it did not, which is about the pressure the failure needed to surface on its own — worth recording, because a counter-proof that passes too easily proves nothing.

## A missing consumer group stopped the queue for good

`NOGROUP` is an ordinary error as far as the client is concerned, so `Start` returned it and nothing was consumed again. Two things produce it: an operator deleting the stream while the process runs, and a `Subscribe` whose group creation has not landed yet — the handler is registered before the round trip, so `Start` can snapshot a topic a moment before its group exists.

The loop now recreates the groups it reads and carries on. The test takes the stream away underneath a running loop and requires delivery to resume; removing the recovery branch makes it fail with the `NOGROUP` error itself.

## A wildcard database entry silently hid the per-tenant ones

`GetDbByTenant` returns the wildcard entry whenever one exists, ignoring the tenant it was asked for. That is the intended single-database path — `multiDatabase` creates exactly that entry when no databases are listed — but a settings file listing the wildcard *alongside* per-tenant entries gets the same short-circuit, and those entries never serve anyone.

Nothing fails. The tenants share one database, which is the opposite of what the file says, and there is no error to go looking for. It is now reported at startup, naming what will be ignored. A normal multi-tenant configuration stays silent, which is also tested: a warning nobody can act on is a warning nobody reads.

## On the tests

Each of the three was checked by reverting the fix and confirming the test fails. That step earned its keep twice here: the first attempt at two of the counter-proofs failed to build rather than failing the assertion, because deleting the code left an import unused — a green-looking result that demonstrated nothing.

`make ci` green.
