### PR TITLE
ci🔧: build the open-source consumer in CI, and retire the issue it tracked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,23 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: go-admin-team/go-admin
-          ref: master
           path: consumer
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            consumer/go.sum
 
       - name: Build the consumer against this tree
+        # setup-go pins GOTOOLCHAIN=local, which fails outright when either
+        # module asks for a newer Go than the one it installed — the consumer
+        # was a minor ahead the first time this job ran. Letting the toolchain
+        # resolve is what a consumer's own build does anyway.
+        env:
+          GOTOOLCHAIN: auto
         run: scripts/canary.sh "${{ github.workspace }}/consumer"
 
   vuln:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,30 @@ jobs:
       - name: Test with race detector
         run: make test-race
 
+  canary:
+    name: canary / go-admin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The consumer is built from its own default branch, against this tree.
+      # A written compatibility promise stops nobody; this is the check that
+      # fails when a change here breaks the open-source consumer. When the
+      # consumer's own branch is broken, the fix belongs in that repository.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: go-admin-team/go-admin
+          ref: master
+          path: consumer
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build the consumer against this tree
+        run: scripts/canary.sh "${{ github.workspace }}/consumer"
+
   vuln:
     name: govulncheck
     runs-on: ubuntu-latest

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -32,43 +32,7 @@ production code path reaches it today.
 the four-layer `loader`/`reader`/`encoder`/`secrets` stack has no users. This
 race disappears with that work rather than being patched in place.
 
-## 2. The open-source go-admin does not build against this tree
-
-**Excluded from:** the canary run — it is expected to fail until the version
-unification work lands.
-
-**Reproduce:**
-
-```sh
-scripts/canary.sh /path/to/go-admin
-```
-
-**Status** (measured 2026-08-17): every consumer already on the merged-module
-layout builds clean. The open-source `go-admin`, still pinned to `v1.5.3-rc`,
-does not.
-
-**Why it fails** — four independent causes, in the order the compiler reports
-them:
-
-1. It still requires the separate `go-admin-core/sdk` module, which no longer
-   exists after the module merge.
-2. `captcha.NewCacheStore` moved when `sdk/pkg/captcha` was promoted to a
-   top-level package.
-3. `GetCasbinKey` and `GetCrontabKey` were renamed to `GetCasbinByTenant` and
-   `GetCrontabByTenant`.
-4. `SetCrontab(string, *cron.Cron)` became `SetCrontab(*cron.Cron)` — a
-   same-name, different-signature change.
-
-Beyond these, the consumer pins `casbin/v2` while this module is on
-`casbin/v3`. `Runtime` exposes `*casbin.SyncedEnforcer` directly, and across a
-major version that is a different type, so no deprecation shim can bridge it.
-
-**Plan:** this is a planned breaking upgrade, not a regression. It needs a
-codemod shipped alongside it. Note that cause 4 is the dangerous class: the
-obvious fix is to drop the first argument, which lands on a method that used to
-deadlock on call until it was repaired.
-
-## 3. Integration tests require a live MySQL
+## 2. Integration tests require a live MySQL
 
 **Excluded from:** every target, via `testing.Short()` guards in the tests
 themselves.


### PR DESCRIPTION
The compatibility promise to consumers has been a document. `scripts/canary.sh` implements the check, but nothing ran it, and the drift it was written to catch accumulated anyway — four separate breakages against the open-source `go-admin`, all recorded in `docs/known-issues.md` after the fact rather than caught on the way in.

Both halves of that are now resolved.

## The check runs

A `canary / go-admin` job checks the consumer out at its default branch and builds it against this tree, through a throw-away `go.work` that never touches the consumer's `go.mod`.

It catches what this repository's own build cannot. Renaming `GetCasbinByTenant` and repairing the callers inside this module keeps `go build ./...` green here:

```
core build: exit=0
FAIL consumer
    # go-admin/common/global
    common/global/casbin.go:12:24: sdk.Runtime.GetCasbinByTenant undefined
```

That is the shape of every entry in the retired issue: a change that is locally consistent and remotely fatal.

The cost is that a consumer branch broken on its own turns this job red for reasons that do not belong here. Worth it — the alternative has been to find out at upgrade time, four causes deep.

## The issue it tracked is gone

`known-issues.md` #2 said the open-source `go-admin` does not build against this tree. It does now: the module merge, the promoted `captcha` package, the renamed tenant methods, the `SetCrontab` signature and `casbin/v3` are all taken. Verified against a fresh clone of `master`, not a local working copy.

```
PASS consumer
```

`make ci` green.