### PR TITLE
fix🐛: the memory loader's watcher races and stop panics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 GO ?= go
 
 # Integration tests that need a live MySQL are guarded by testing.Short(),
-# so every target below runs with -short. See docs/known-issues.md for the
-# tests excluded from the race target.
-RACE_SKIP ?= TestConfigWatcherDirtyOverrite
+# so every target below runs with -short. Nothing is excluded from the race
+# target; anything that has to be would belong in docs/known-issues.md.
 
 .PHONY: all build vet test test-race lint vuln tidy api-snapshot api-check ci
 
@@ -19,7 +18,7 @@ test:
 	$(GO) test -short ./...
 
 test-race:
-	$(GO) test -short -race -timeout 600s -skip '$(RACE_SKIP)' ./...
+	$(GO) test -short -race -timeout 600s ./...
 
 lint:
 	$(GO) run honnef.co/go/tools/cmd/staticcheck@latest ./...

--- a/config/loader/memory/memory.go
+++ b/config/loader/memory/memory.go
@@ -38,12 +38,13 @@ type updateValue struct {
 }
 
 type watcher struct {
-	exit    chan bool
-	path    []string
-	value   reader.Value
-	reader  reader.Reader
-	version string
-	updates chan updateValue
+	exit     chan bool
+	exitOnce sync.Once
+	path     []string
+	value    reader.Value
+	reader   reader.Reader
+	version  string
+	updates  chan updateValue
 }
 
 func (m *memory) watch(idx int, s source.Source) {
@@ -155,9 +156,8 @@ func (m *memory) reload() error {
 }
 
 func (m *memory) update() {
-	watchers := make([]*watcher, 0, m.watchers.Len())
-
 	m.RLock()
+	watchers := make([]*watcher, 0, m.watchers.Len())
 	for e := m.watchers.Front(); e != nil; e = e.Next() {
 		watchers = append(watchers, e.Value.(*watcher))
 	}
@@ -167,12 +167,12 @@ func (m *memory) update() {
 	m.RUnlock()
 
 	for _, w := range watchers {
-		if w.version >= snap.Version {
-			continue
-		}
-
+		// A watcher's version belongs to whoever calls Next, so it cannot be
+		// consulted from here. Next applies the same filter one step later,
+		// which is why this only ever skipped work rather than deciding
+		// anything.
 		uv := updateValue{
-			version: m.snap.Version,
+			version: snap.Version,
 			value:   vals.Get(w.path...),
 		}
 
@@ -413,13 +413,11 @@ func (w *watcher) Next() (*loader.Snapshot, error) {
 }
 
 func (w *watcher) Stop() error {
-	select {
-	case <-w.exit:
-	default:
-		close(w.exit)
-		close(w.updates)
-	}
-
+	// Selecting on the channel and then closing it is a check followed by an
+	// act: two callers can both find it open. Next returns on exit alone, so
+	// the updates channel is left for the collector rather than closed —
+	// closing it raced with the send in update and panicked the sender.
+	w.exitOnce.Do(func() { close(w.exit) })
 	return nil
 }
 

--- a/config/loader/memory/memory.go
+++ b/config/loader/memory/memory.go
@@ -16,8 +16,9 @@ import (
 )
 
 type memory struct {
-	exit chan bool
-	opts loader.Options
+	exit     chan bool
+	exitOnce sync.Once
+	opts     loader.Options
 
 	sync.RWMutex
 	// the current snapshot
@@ -86,7 +87,15 @@ func (m *memory) watch(idx int, s source.Source) {
 		// watch the source
 		w, err := s.Watch()
 		if err != nil {
-			time.Sleep(time.Second)
+			// The exit check at the bottom is only reached once a watch has
+			// been established, so without this a source that cannot be
+			// watched keeps this goroutine retrying for the life of the
+			// process, Close or no Close.
+			select {
+			case <-m.exit:
+				return
+			case <-time.After(time.Second):
+			}
 			continue
 		}
 
@@ -256,12 +265,7 @@ func (m *memory) Sync() error {
 }
 
 func (m *memory) Close() error {
-	select {
-	case <-m.exit:
-		return nil
-	default:
-		close(m.exit)
-	}
+	m.exitOnce.Do(func() { close(m.exit) })
 	return nil
 }
 

--- a/config/loader/memory/watcher_test.go
+++ b/config/loader/memory/watcher_test.go
@@ -1,0 +1,97 @@
+package memory
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/config/source"
+)
+
+func loadedMemory(t *testing.T) *memory {
+	t.Helper()
+
+	m := NewLoader().(*memory)
+	if err := m.Load(&testSource{data: []byte(`{"a":1}`)}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	return m
+}
+
+// Stop is reachable from two places at once — the caller's own defer and the
+// config shutting its watcher down — and it used to select on the exit channel
+// before closing it, so both callers could find it open.
+func TestWatcherStopIsSafeUnderConcurrency(t *testing.T) {
+	m := loadedMemory(t)
+
+	for i := 0; i < 500; i++ {
+		w, err := m.Watch("a")
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for j := 0; j < 16; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if err := w.Stop(); err != nil {
+					t.Errorf("Stop: %v", err)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+}
+
+// Stop also closed the updates channel, which update sends on. A watcher is
+// removed from the list asynchronously, so a stop landing during a config
+// change left the sender writing to a closed channel.
+func TestStopDuringUpdateDoesNotPanic(t *testing.T) {
+	m := loadedMemory(t)
+
+	for i := 0; i < 500; i++ {
+		w, err := m.Watch("a")
+		if err != nil {
+			t.Fatalf("Watch: %v", err)
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		start := make(chan struct{})
+		go func() {
+			defer wg.Done()
+			<-start
+			m.update()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = w.Stop()
+		}()
+		close(start)
+		wg.Wait()
+	}
+}
+
+type testSource struct {
+	data []byte
+}
+
+func (s *testSource) Read() (*source.ChangeSet, error) {
+	cs := &source.ChangeSet{
+		Data:   s.data,
+		Format: "json",
+		Source: "test",
+	}
+	cs.Checksum = cs.Sum()
+	return cs, nil
+}
+
+func (s *testSource) Write(*source.ChangeSet) error { return nil }
+func (s *testSource) Watch() (source.Watcher, error) {
+	return nil, source.ErrWatcherStopped
+}
+func (s *testSource) String() string { return "test" }

--- a/config/loader/memory/watcher_test.go
+++ b/config/loader/memory/watcher_test.go
@@ -1,8 +1,10 @@
 package memory
 
 import (
+	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-admin-team/go-admin-core/config/source"
 )
@@ -14,6 +16,9 @@ func loadedMemory(t *testing.T) *memory {
 	if err := m.Load(&testSource{data: []byte(`{"a":1}`)}); err != nil {
 		t.Fatalf("Load: %v", err)
 	}
+	// Load starts a watch goroutine per source. Without this it outlives the
+	// test and keeps running while the rest of the package reports failures.
+	t.Cleanup(func() { _ = m.Close() })
 	return m
 }
 
@@ -77,7 +82,8 @@ func TestStopDuringUpdateDoesNotPanic(t *testing.T) {
 }
 
 type testSource struct {
-	data []byte
+	data        []byte
+	unwatchable bool
 }
 
 func (s *testSource) Read() (*source.ChangeSet, error) {
@@ -91,7 +97,76 @@ func (s *testSource) Read() (*source.ChangeSet, error) {
 }
 
 func (s *testSource) Write(*source.ChangeSet) error { return nil }
+
 func (s *testSource) Watch() (source.Watcher, error) {
+	if s.unwatchable {
+		return nil, source.ErrWatcherStopped
+	}
+	return &testWatcher{stop: make(chan struct{})}, nil
+}
+
+func (s *testSource) String() string { return "test" }
+
+// testWatcher reports nothing and blocks until it is stopped, which is what a
+// quiet source looks like to the loader.
+type testWatcher struct {
+	stop chan struct{}
+	once sync.Once
+}
+
+func (w *testWatcher) Next() (*source.ChangeSet, error) {
+	<-w.stop
 	return nil, source.ErrWatcherStopped
 }
-func (s *testSource) String() string { return "test" }
+
+func (w *testWatcher) Stop() error {
+	w.once.Do(func() { close(w.stop) })
+	return nil
+}
+
+// A source that cannot be watched used to keep the loader'"'"'s goroutine retrying
+// once a second forever: the exit check sat past the point the retry jumped
+// back from, so Close could not reach it.
+func TestCloseStopsAWatchThatCannotStart(t *testing.T) {
+	m := NewLoader().(*memory)
+	if err := m.Load(&testSource{data: []byte(`{"a":1}`), unwatchable: true}); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	before := runtime.NumGoroutine()
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// The goroutine is in a one second sleep at worst, so give it two.
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() >= before && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n := runtime.NumGoroutine(); n >= before {
+		t.Errorf("goroutine count %d did not fall below %d: the watch is still retrying", n, before)
+	}
+}
+
+// Close carried the same select-then-close as the watcher, and the loader is
+// closed both by its owner and by whatever is shutting the process down.
+func TestLoaderCloseIsSafeUnderConcurrency(t *testing.T) {
+	for i := 0; i < 500; i++ {
+		m := NewLoader().(*memory)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for j := 0; j < 16; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				if err := m.Close(); err != nil {
+					t.Errorf("Close: %v", err)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+	}
+}

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -4,35 +4,7 @@ Issues that CI deliberately tolerates. Each entry states why it is excluded,
 how to reproduce it, and when it is expected to be resolved. Nothing may be
 added here without a reproduction command.
 
-## 1. Data race in `config/loader/memory`
-
-**Excluded from:** `make test-race` (via `RACE_SKIP`)
-
-**Reproduce:**
-
-```sh
-go test -race ./config/ -run TestConfigWatcherDirtyOverrite
-```
-
-**What happens:** `(*watcher).Next` writes a field that `(*memory).update`
-reads concurrently, with no synchronisation between them.
-
-```
-Write at 0x... by goroutine 9:
-  config/loader/memory.(*watcher).Next()   memory.go:404
-Previous read at 0x... by goroutine 8:
-  config/loader/memory.(*memory).update()
-```
-
-**Impact:** limited to the dynamic config watcher. All consumers only use
-`config/source/file` and none of them subscribe to change events, so no
-production code path reaches it today.
-
-**Plan:** the `config` package is scheduled to be reduced to a thin loader —
-the four-layer `loader`/`reader`/`encoder`/`secrets` stack has no users. This
-race disappears with that work rather than being patched in place.
-
-## 2. Integration tests require a live MySQL
+## 1. Integration tests require a live MySQL
 
 **Excluded from:** every target, via `testing.Short()` guards in the tests
 themselves.


### PR DESCRIPTION
The race target has been skipping `TestConfigWatcherDirtyOverrite` since the exclusion mechanism was added. The plan of record was that the race would disappear when `config` is reduced to a thin loader. That refactor has not happened, the code is reachable today through the config watcher, and looking at the twenty lines the detector points to turned up two more defects next to it.

## What `update` was reading

```go
watchers := make([]*watcher, 0, m.watchers.Len())   // before the lock
m.RLock()
...
snap := m.snap
m.RUnlock()

for _, w := range watchers {
    if w.version >= snap.Version {                  // owned by Next
        continue
    }
    uv := updateValue{version: m.snap.Version, ...} // after the lock
```

Three reads with no claim to what they touch. `w.version` is the one the detector reports, and it is a `string` — a torn read there is two words that never went together.

The check it guarded only ever skipped work. `Next` already drops an update whose version it has seen, so removing the read costs a few sends that were being dropped anyway, and needs no new lock.

## What `Stop` was closing

```go
select {
case <-w.exit:
default:
    close(w.exit)
    close(w.updates)
}
```

The same select-then-close that `config.Close` carried until #116 — two callers can both find the channel open. And closing `w.updates` races the send in `update`: a watcher leaves the list from a goroutine that waits on `exit`, so a stop landing during a config change leaves the sender writing to a closed channel.

`Next` returns on `exit` alone, so the updates channel is not closed at all now.

## Counter-proofs

Each fix was checked by putting the old code back, separately:

| restored | result |
| --- | --- |
| `update` | `WARNING: DATA RACE` ×2 |
| `Stop` select-then-close | `panic: close of closed channel` |
| `close(w.updates)` alone | `panic: send on closed channel` |

The third needed the first two fixes left in place, otherwise the earlier panic aborts the run before the interesting one.

## The exclusion is gone

`RACE_SKIP` and the `known-issues.md` entry describing it are both removed. `make test-race` now covers the whole tree, and `TestConfigWatcherDirtyOverrite` passes under `-race` at `-count=5`.

`make ci` green.