### PR TITLE
fix🐛: let Close reach a watch loop that never started

### DIFF
--- a/config/default.go
+++ b/config/default.go
@@ -128,13 +128,18 @@ func (c *config) run() {
 		w, err := c.opts.Loader.Watch()
 		if err != nil {
 			log.Errorf("failed to start watcher: %v", err)
-			time.Sleep(time.Second)
+			// The exit check at the bottom sits past the point this jumps
+			// back from, so without racing it here a loader that cannot be
+			// watched keeps this goroutine retrying after Close.
+			select {
+			case <-c.exit:
+				return
+			case <-time.After(time.Second):
+			}
 			continue
 		}
 
 		done := make(chan bool)
-		// close done channel when exit
-		defer close(done)
 
 		// the stop watch func 停止监控函数
 		go func() {
@@ -149,9 +154,18 @@ func (c *config) run() {
 		if err := watch(w); err != nil {
 			// 记录错误日志
 			log.Errorf("watch error: %v", err)
-			// do something better
-			time.Sleep(time.Second)
+			select {
+			case <-c.exit:
+				close(done)
+				return
+			case <-time.After(time.Second):
+			}
 		}
+
+		// Closed per iteration rather than deferred: a defer inside this loop
+		// only runs when run returns, so every iteration left its stop-watch
+		// goroutine alive until then.
+		close(done)
 
 		// if the config is closed exit 检查是否退出
 		select {

--- a/config/run_test.go
+++ b/config/run_test.go
@@ -11,12 +11,19 @@ import (
 )
 
 // unwatchableLoader loads normally and refuses to be watched, which is the
-// state run's retry loop was written for.
+// state run's retry loop was written for. It reports each attempt so the test
+// can wait for the loop to be where it needs it rather than guessing at a
+// duration.
 type unwatchableLoader struct {
 	loader.Loader
+	tried chan struct{}
 }
 
 func (l *unwatchableLoader) Watch(...string) (loader.Watcher, error) {
+	select {
+	case l.tried <- struct{}{}:
+	default:
+	}
 	return nil, errors.New("cannot watch")
 }
 
@@ -26,13 +33,18 @@ func (l *unwatchableLoader) Watch(...string) (loader.Watcher, error) {
 func TestCloseStopsARunThatCannotWatch(t *testing.T) {
 	before := runtime.NumGoroutine()
 
-	c, err := NewConfig(WithLoader(&unwatchableLoader{Loader: memory.NewLoader()}))
+	l := &unwatchableLoader{Loader: memory.NewLoader(), tried: make(chan struct{}, 1)}
+	c, err := NewConfig(WithLoader(l))
 	if err != nil {
 		t.Fatalf("NewConfig: %v", err)
 	}
 
-	// Let run reach the retry rather than racing its first iteration.
-	time.Sleep(50 * time.Millisecond)
+	// Close has to arrive while run is in the retry, not before it gets there.
+	select {
+	case <-l.tried:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run never attempted a watch")
+	}
 
 	if err := c.Close(); err != nil {
 		t.Fatalf("Close: %v", err)

--- a/config/run_test.go
+++ b/config/run_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/config/loader"
+	"github.com/go-admin-team/go-admin-core/config/loader/memory"
+)
+
+// unwatchableLoader loads normally and refuses to be watched, which is the
+// state run's retry loop was written for.
+type unwatchableLoader struct {
+	loader.Loader
+}
+
+func (l *unwatchableLoader) Watch(...string) (loader.Watcher, error) {
+	return nil, errors.New("cannot watch")
+}
+
+// The exit check in run sits below the point the retry jumps back from, so a
+// loader that cannot be watched used to keep the goroutine retrying once a
+// second for the life of the process, closed or not.
+func TestCloseStopsARunThatCannotWatch(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	c, err := NewConfig(WithLoader(&unwatchableLoader{Loader: memory.NewLoader()}))
+	if err != nil {
+		t.Fatalf("NewConfig: %v", err)
+	}
+
+	// Let run reach the retry rather than racing its first iteration.
+	time.Sleep(50 * time.Millisecond)
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if n := runtime.NumGoroutine(); n > before {
+		t.Errorf("goroutine count %d did not return to %d: run is still retrying", n, before)
+	}
+}


### PR DESCRIPTION
Found by looking rather than by accident. #118 fixed a retry loop in the memory loader that could not be stopped; the comment there said the shape had turned up four times and deserved a deliberate pass instead of waiting for the next one. This is what the pass found.

## The same defect, one layer up

```go
for {
    w, err := c.opts.Loader.Watch()
    if err != nil {
        log.Errorf("failed to start watcher: %v", err)
        time.Sleep(time.Second)
        continue          // <- jumps above the exit check
    }
    ...
    select {
    case <-c.exit:        // <- only reached once a watch succeeded
        return
    default:
    }
}
```

A loader that cannot be watched keeps this goroutine retrying once a second for the life of the process, whether or not `Close` has been called. Both sleeps race the exit channel now.

The stop-watch goroutine was also released by a `defer` inside the loop, so it ran when `run` returned rather than when the iteration ended — every iteration left one behind. It is closed per iteration.

## What the scan covered

Two shapes across this repository and both consumers: a `select` with a `default` that closes a shared channel, and a bare `time.Sleep` inside a `for` with no cancellation in scope.

| hit | verdict |
| --- | --- |
| `logger/async.go:299` | not it — a per-call done channel, not shared state |
| `sdk/pkg/file.go:117` | not it — the loop checks `ctx.Err()` at the top |
| `config/default.go:127` | **this** |

The consumers came back clean.

## Counter-proof

`WithLoader` takes a loader that loads normally and fails every `Watch`. Restoring the old retry:

```
run_test.go:46: goroutine count 3 did not return to 2: run is still retrying
```

## On the count

That is three instances of select-then-close and two of a loop with no exit, all in the config stack inherited wholesale from go-micro. None was introduced by recent work; each surfaced while looking at something else nearby. The scan is cheap enough to keep — worth a linter rule if the shape appears again.

`make ci` green, race target covering the whole tree now that #118 has landed.