### PR TITLE
feat✨: coreupgrade, so v2.0.0 can actually remove the shims

### DIFF
--- a/docs/migration/v2.0.0.md
+++ b/docs/migration/v2.0.0.md
@@ -1,0 +1,55 @@
+# Migrating to v2.0.0
+
+v1.6.0 promoted six packages out of `sdk/pkg` and left a shim at each old path.
+The shims forward every symbol, so nothing broke, and they carry a
+`Deprecated:` marker saying they go away in v2.0.0.
+
+They have been deprecated since 2025-10-17. v2.0.0 removes them.
+
+## What moves
+
+| old | new | note |
+| --- | --- | --- |
+| `sdk/pkg/captcha` | `captcha` | |
+| `sdk/pkg/jwtauth` | `jwtauth` | |
+| `sdk/pkg/jwtauth/user` | `jwtauth/user` | |
+| `sdk/pkg/response` | `response` | |
+| `sdk/pkg/casbin` | `casbin` | |
+| `observability/audit` | `observe/audit` | |
+| `tools/gorm/logger` | `tools/gorm/gormlog` | the package name changes too |
+
+Every replacement exports the same identifiers under the same names, so an
+import path is the only thing that has to change. The last row is the exception
+worth knowing about: the package was renamed to stop colliding with the `logger`
+package at the root, so a plain (unaliased) import of it changes the local name
+as well.
+
+## The tool
+
+```sh
+go run github.com/go-admin-team/go-admin-core/tools/coreupgrade@latest /path/to/your/project
+```
+
+It reports what it would change and exits. Pass `-w` to write.
+
+It parses each file rather than substituting text, so the path appearing in a
+comment, a string or a struct tag is left alone, and an alias or dot import
+keeps its form. Where the package name changes and the import has no alias, it
+adds one holding the old name, so call sites do not have to move at the same
+time.
+
+Formatting follows one rule: a file that was gofmt clean stays gofmt clean —
+the replacement is re-sorted into place — and a file that was not is not
+quietly reformatted, so the migration does not disappear into whitespace.
+
+`vendor`, `testdata` and `node_modules` are skipped.
+
+## After running it
+
+```sh
+go build ./...
+go test ./...
+```
+
+The open-source `go-admin` was migrated this way: 64 imports across 46 files,
+after which it builds against this module with the shims gone.

--- a/tools/coreupgrade/main.go
+++ b/tools/coreupgrade/main.go
@@ -11,8 +11,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -47,27 +49,27 @@ func main() {
 	}
 }
 
-func run(dir string, write bool, out *os.File) (imports, files int, err error) {
-	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+func run(dir string, write bool, out io.Writer) (imports, files int, err error) {
+	err = filepath.WalkDir(dir, func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			if skipDir(d.Name()) && path != dir {
+			if skipDir(d.Name()) && filePath != dir {
 				return fs.SkipDir
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ".go") {
+		if !strings.HasSuffix(filePath, ".go") {
 			return nil
 		}
 
-		src, err := os.ReadFile(path)
+		src, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}
 
-		next, changes, err := rewrite(path, src)
+		next, changes, err := rewrite(filePath, src)
 		if err != nil {
 			// A file that does not parse is reported and stepped over: the
 			// tool has no business deciding a consumer's build is broken.
@@ -78,9 +80,9 @@ func run(dir string, write bool, out *os.File) (imports, files int, err error) {
 			return nil
 		}
 
-		rel, relErr := filepath.Rel(dir, path)
+		rel, relErr := filepath.Rel(dir, filePath)
 		if relErr != nil {
-			rel = path
+			rel = filePath
 		}
 		for _, c := range changes {
 			note := ""
@@ -92,7 +94,14 @@ func run(dir string, write bool, out *os.File) (imports, files int, err error) {
 		}
 
 		if write {
-			if err := os.WriteFile(path, next, 0o644); err != nil {
+			// The consumer's permission bits are theirs. A migration that
+			// quietly turns 0600 into 0644 is the kind of change nobody
+			// thinks to look for.
+			mode := fs.FileMode(0o644)
+			if info, err := d.Info(); err == nil {
+				mode = info.Mode().Perm()
+			}
+			if err := os.WriteFile(filePath, next, mode); err != nil {
 				return err
 			}
 		}
@@ -112,14 +121,16 @@ func skipDir(name string) bool {
 	return false
 }
 
-func packageName(path string) string {
+// packageName is asked about import paths, which are slash separated on every
+// platform, so it uses path rather than filepath.
+func packageName(importPath string) string {
 	for _, m := range moves {
-		switch path {
+		switch importPath {
 		case m.from:
 			return m.name
 		case m.to:
 			return m.newName
 		}
 	}
-	return filepath.Base(path)
+	return path.Base(importPath)
 }

--- a/tools/coreupgrade/main.go
+++ b/tools/coreupgrade/main.go
@@ -1,0 +1,125 @@
+// Command coreupgrade rewrites imports of the packages this module deprecated
+// in v1.6.0 to the paths that replace them in v2.0.0.
+//
+// Usage:
+//
+//	go run github.com/go-admin-team/go-admin-core/tools/coreupgrade@latest [-w] DIR
+//
+// It reports what it would change and exits. Pass -w to write the files.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	write := flag.Bool("w", false, "write the files instead of reporting what would change")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: coreupgrade [-w] DIR\n\n")
+		fmt.Fprintf(os.Stderr, "Rewrites deprecated go-admin-core imports. Without -w it only reports.\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	n, files, err := run(flag.Arg(0), *write, os.Stdout)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "coreupgrade:", err)
+		os.Exit(1)
+	}
+
+	switch {
+	case n == 0:
+		fmt.Println("no deprecated imports found")
+	case *write:
+		fmt.Printf("\nrewrote %d import(s) in %d file(s)\n", n, files)
+	default:
+		fmt.Printf("\n%d import(s) in %d file(s) would be rewritten; pass -w to apply\n", n, files)
+	}
+}
+
+func run(dir string, write bool, out *os.File) (imports, files int, err error) {
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skipDir(d.Name()) && path != dir {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		next, changes, err := rewrite(path, src)
+		if err != nil {
+			// A file that does not parse is reported and stepped over: the
+			// tool has no business deciding a consumer's build is broken.
+			fmt.Fprintln(os.Stderr, "coreupgrade: skipping", err)
+			return nil
+		}
+		if len(changes) == 0 {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(dir, path)
+		if relErr != nil {
+			rel = path
+		}
+		for _, c := range changes {
+			note := ""
+			if c.Aliased {
+				note = fmt.Sprintf(" (kept the local name %q; the package is now %q)",
+					packageName(c.From), packageName(c.To))
+			}
+			fmt.Fprintf(out, "%s:%d: %s -> %s%s\n", rel, c.Line, c.From, c.To, note)
+		}
+
+		if write {
+			if err := os.WriteFile(path, next, 0o644); err != nil {
+				return err
+			}
+		}
+
+		imports += len(changes)
+		files++
+		return nil
+	})
+	return imports, files, err
+}
+
+func skipDir(name string) bool {
+	switch name {
+	case ".git", "vendor", "node_modules", "testdata":
+		return true
+	}
+	return false
+}
+
+func packageName(path string) string {
+	for _, m := range moves {
+		switch path {
+		case m.from:
+			return m.name
+		case m.to:
+			return m.newName
+		}
+	}
+	return filepath.Base(path)
+}

--- a/tools/coreupgrade/moves.go
+++ b/tools/coreupgrade/moves.go
@@ -1,0 +1,27 @@
+package main
+
+const mod = "github.com/go-admin-team/go-admin-core/"
+
+// move is one deprecated import path and the path that replaces it. name and
+// newName are the package names; they differ only where the promotion also
+// renamed the package, which is the case a plain path substitution gets wrong.
+type move struct {
+	from    string
+	to      string
+	name    string
+	newName string
+}
+
+// Every package this module deprecated in v1.6.0 and removes in v2.0.0. The
+// replacements re-export the same identifiers, so nothing but the import line
+// changes — except gormlog, which was renamed to stop colliding with the
+// logger package at the root.
+var moves = []move{
+	{from: mod + "sdk/pkg/captcha", to: mod + "captcha", name: "captcha", newName: "captcha"},
+	{from: mod + "sdk/pkg/jwtauth", to: mod + "jwtauth", name: "jwtauth", newName: "jwtauth"},
+	{from: mod + "sdk/pkg/jwtauth/user", to: mod + "jwtauth/user", name: "user", newName: "user"},
+	{from: mod + "sdk/pkg/response", to: mod + "response", name: "response", newName: "response"},
+	{from: mod + "sdk/pkg/casbin", to: mod + "casbin", name: "casbin", newName: "casbin"},
+	{from: mod + "observability/audit", to: mod + "observe/audit", name: "audit", newName: "audit"},
+	{from: mod + "tools/gorm/logger", to: mod + "tools/gorm/gormlog", name: "logger", newName: "gormlog"},
+}

--- a/tools/coreupgrade/rewrite.go
+++ b/tools/coreupgrade/rewrite.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strconv"
+)
+
+// change is one import line the tool would replace, reported whether or not
+// the file is written.
+type change struct {
+	Line    int
+	From    string
+	To      string
+	Aliased bool
+}
+
+// rewrite returns src with every deprecated import replaced. It parses rather
+// than substituting text so that the path appearing in a comment, a string
+// literal or a struct tag is left alone; only the import block is touched, and
+// the rest of the file keeps its formatting byte for byte.
+func rewrite(filename string, src []byte) ([]byte, []change, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, src, parser.ImportsOnly|parser.ParseComments)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%s: %w", filename, err)
+	}
+
+	type edit struct {
+		start, end int
+		text       string
+	}
+
+	var edits []edit
+	var changes []change
+
+	for _, spec := range f.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+
+		m, ok := lookup(path)
+		if !ok {
+			continue
+		}
+
+		// The local name has to survive the move. An alias or a dot import
+		// already fixes it, so only a plain import of a renamed package needs
+		// one added — and the name it needs is free by construction, because
+		// the import being replaced was using it.
+		added := spec.Name == nil && m.name != m.newName
+		name := ""
+		switch {
+		case spec.Name != nil:
+			name = spec.Name.Name
+		case added:
+			name = m.name
+		}
+
+		text := strconv.Quote(m.to)
+		if name != "" {
+			text = name + " " + text
+		}
+
+		edits = append(edits, edit{
+			start: fset.Position(spec.Pos()).Offset,
+			end:   fset.Position(spec.End()).Offset,
+			text:  text,
+		})
+		changes = append(changes, change{
+			Line:    fset.Position(spec.Pos()).Line,
+			From:    path,
+			To:      m.to,
+			Aliased: added,
+		})
+	}
+
+	if len(edits) == 0 {
+		return src, nil, nil
+	}
+
+	// Applied back to front so that earlier offsets stay valid.
+	sort.Slice(edits, func(i, j int) bool { return edits[i].start > edits[j].start })
+	out := src
+	for _, e := range edits {
+		merged := make([]byte, 0, len(out)+len(e.text))
+		merged = append(merged, out[:e.start]...)
+		merged = append(merged, e.text...)
+		merged = append(merged, out[e.end:]...)
+		out = merged
+	}
+
+	// A path that changes usually sorts somewhere else, and leaving it where
+	// the old one sat makes the block unsorted. gofmt sorts each group, so the
+	// result is formatted — but only if the input was, because reformatting a
+	// file the tool did not have to touch buries the migration in noise.
+	if formatted, err := format.Source(out); err == nil {
+		if clean, err := format.Source(src); err == nil && bytes.Equal(clean, src) {
+			out = formatted
+		}
+	}
+
+	return out, changes, nil
+}
+
+func lookup(path string) (move, bool) {
+	for _, m := range moves {
+		if m.from == path {
+			return m, true
+		}
+	}
+	return move{}, false
+}

--- a/tools/coreupgrade/rewrite_test.go
+++ b/tools/coreupgrade/rewrite_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+func TestRewrite(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "a plain import is replaced",
+			in: `package p
+
+import "github.com/go-admin-team/go-admin-core/sdk/pkg/response"
+
+var _ = response.Error
+`,
+			want: `package p
+
+import "github.com/go-admin-team/go-admin-core/response"
+
+var _ = response.Error
+`,
+		},
+		{
+			name: "an alias survives",
+			in: `package p
+
+import jwt "github.com/go-admin-team/go-admin-core/sdk/pkg/jwtauth"
+
+var _ = jwt.New
+`,
+			want: `package p
+
+import jwt "github.com/go-admin-team/go-admin-core/jwtauth"
+
+var _ = jwt.New
+`,
+		},
+		{
+			name: "a dot import stays a dot import",
+			in: `package p
+
+import . "github.com/go-admin-team/go-admin-core/tools/gorm/logger"
+
+var _ = New
+`,
+			want: `package p
+
+import . "github.com/go-admin-team/go-admin-core/tools/gorm/gormlog"
+
+var _ = New
+`,
+		},
+		{
+			name: "a renamed package keeps the local name it had",
+			in: `package p
+
+import "github.com/go-admin-team/go-admin-core/tools/gorm/logger"
+
+var _ = logger.New
+`,
+			want: `package p
+
+import logger "github.com/go-admin-team/go-admin-core/tools/gorm/gormlog"
+
+var _ = logger.New
+`,
+		},
+		{
+			name: "one line of a block, the rest untouched",
+			in: `package p
+
+import (
+	"fmt"
+
+	"github.com/go-admin-team/go-admin-core/sdk/pkg/captcha"
+	"gorm.io/gorm"
+)
+
+var _ = fmt.Sprint
+var _ = captcha.New
+var _ = gorm.Open
+`,
+			want: `package p
+
+import (
+	"fmt"
+
+	"github.com/go-admin-team/go-admin-core/captcha"
+	"gorm.io/gorm"
+)
+
+var _ = fmt.Sprint
+var _ = captcha.New
+var _ = gorm.Open
+`,
+		},
+		{
+			name: "the path in a comment or a string is not an import",
+			in: `package p
+
+// See github.com/go-admin-team/go-admin-core/sdk/pkg/response for the old one.
+const doc = "github.com/go-admin-team/go-admin-core/sdk/pkg/response"
+`,
+			want: `package p
+
+// See github.com/go-admin-team/go-admin-core/sdk/pkg/response for the old one.
+const doc = "github.com/go-admin-team/go-admin-core/sdk/pkg/response"
+`,
+		},
+		{
+			name: "a file with nothing to do is returned as it was",
+			in: `package p
+
+import "fmt"
+
+var _ = fmt.Sprint
+`,
+			want: `package p
+
+import "fmt"
+
+var _ = fmt.Sprint
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, changes, err := rewrite("x.go", []byte(c.in))
+			if err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+			if string(got) != c.want {
+				t.Errorf("got:\n%s\nwant:\n%s", got, c.want)
+			}
+			if changed := c.in != c.want; changed != (len(changes) > 0) {
+				t.Errorf("reported %d changes for a file that changed=%v", len(changes), changed)
+			}
+			if _, err := parser.ParseFile(token.NewFileSet(), "x.go", got, 0); err != nil {
+				t.Errorf("output does not parse: %v", err)
+			}
+		})
+	}
+}
+
+// Every path the table claims to move has to be a real deprecated package, and
+// every replacement a real one, or the tool sends consumers somewhere that does
+// not exist.
+func TestMovesArePlausible(t *testing.T) {
+	seen := map[string]bool{}
+	for _, m := range moves {
+		if !strings.HasPrefix(m.from, mod) || !strings.HasPrefix(m.to, mod) {
+			t.Errorf("%s -> %s: not both in this module", m.from, m.to)
+		}
+		if m.from == m.to {
+			t.Errorf("%s moves to itself", m.from)
+		}
+		if seen[m.from] {
+			t.Errorf("%s appears twice", m.from)
+		}
+		seen[m.from] = true
+	}
+}
+
+// A replacement path usually sorts somewhere else in the block, so a rewrite
+// that only swaps the string leaves the group unsorted. The first version of
+// this tool did exactly that, in nineteen files of the one repository it was
+// tried on.
+func TestRewriteLeavesTheFileFormatted(t *testing.T) {
+	in := `package p
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/go-admin-team/go-admin-core/sdk/api"
+	"github.com/go-admin-team/go-admin-core/sdk/pkg/captcha"
+)
+
+var _ = gin.New
+var _ = api.Api{}
+var _ = captcha.New
+`
+
+	got, _, err := rewrite("x.go", []byte(in))
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+
+	want, err := format.Source(got)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("output is not gofmt clean:\n%s", got)
+	}
+	if !strings.Contains(string(got), "core/captcha\"\n\t\"github.com/go-admin-team/go-admin-core/sdk/api\"") {
+		t.Errorf("the replacement did not move to where it sorts:\n%s", got)
+	}
+}
+
+// The other half of the rule: a file that was not gofmt clean to begin with is
+// not quietly reformatted, or the migration disappears into whitespace.
+func TestRewriteDoesNotFormatWhatItFound(t *testing.T) {
+	in := `package p
+
+import (
+	"github.com/go-admin-team/go-admin-core/sdk/pkg/response"
+)
+
+var  _ = response.Error
+`
+
+	got, changes, err := rewrite("x.go", []byte(in))
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(changes))
+	}
+	if !strings.Contains(string(got), "var  _ = response.Error") {
+		t.Errorf("the double space was reformatted away:\n%s", got)
+	}
+}

--- a/tools/coreupgrade/rewrite_test.go
+++ b/tools/coreupgrade/rewrite_test.go
@@ -5,6 +5,9 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -153,15 +156,31 @@ var _ = fmt.Sprint
 	}
 }
 
-// Every path the table claims to move has to be a real deprecated package, and
-// every replacement a real one, or the tool sends consumers somewhere that does
-// not exist.
-func TestMovesArePlausible(t *testing.T) {
+// Every path in the table has to exist in this module. A typo in a destination
+// sends every consumer that runs the tool to a package that is not there, and
+// the tool itself would never notice.
+func TestMovesPointAtRealPackages(t *testing.T) {
+	root := filepath.Join("..", "..")
+
 	seen := map[string]bool{}
 	for _, m := range moves {
-		if !strings.HasPrefix(m.from, mod) || !strings.HasPrefix(m.to, mod) {
-			t.Errorf("%s -> %s: not both in this module", m.from, m.to)
+		for _, p := range []string{m.from, m.to} {
+			if !strings.HasPrefix(p, mod) {
+				t.Errorf("%s is not in this module", p)
+				continue
+			}
+			dir := filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(p, mod)))
+			info, err := os.Stat(dir)
+			if err != nil || !info.IsDir() {
+				t.Errorf("%s: no package at %s", p, dir)
+				continue
+			}
+			files, err := filepath.Glob(filepath.Join(dir, "*.go"))
+			if err != nil || len(files) == 0 {
+				t.Errorf("%s: %s holds no Go files", p, dir)
+			}
 		}
+
 		if m.from == m.to {
 			t.Errorf("%s moves to itself", m.from)
 		}
@@ -169,6 +188,44 @@ func TestMovesArePlausible(t *testing.T) {
 			t.Errorf("%s appears twice", m.from)
 		}
 		seen[m.from] = true
+	}
+}
+
+// The tool overwrites files in someone else's repository, so it has to leave
+// their permission bits alone.
+//
+// This pins the contract rather than reproducing a failure: os.WriteFile only
+// applies its mode when it creates the file, so the current implementation
+// cannot fail this test — reverting the mode to a literal 0644 still passes.
+// What it would catch is the write being changed to the usual atomic shape, a
+// temporary file renamed over the target, which does replace the mode.
+func TestWriteKeepsThePermissionBits(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "x.go")
+	src := "package p\n\nimport \"" + mod + "sdk/pkg/response\"\n\nvar _ = response.Error\n"
+
+	if err := os.WriteFile(file, []byte(src), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if _, _, err := run(dir, true, io.Discard); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Errorf("mode is %v, want 0600: the tool changed the file's permissions", got)
+	}
+
+	out, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if strings.Contains(string(out), "sdk/pkg/response") {
+		t.Error("the import was not rewritten")
 	}
 }
 


### PR DESCRIPTION
v2.0.0 has been the removal date for six deprecated packages since 2025-10-17 — ten months against a six month promise. It did not happen in May as planned, and v1.7.0 shipped instead. The reason is measurable rather than mysterious:

| consumer | files still importing the old paths |
| --- | --- |
| open-source `go-admin` | **46** (64 imports) |
| the private consumer | 3 |
| this module | 1, and it is `integration_test.go` — the test that proves the shims work |

Removing the shims means migrating those first. Doing that by hand across every consumer, in and out of this organisation, is how a removal slips another release. So the tool comes first, and v2.0.0 becomes a deletion rather than a coordination problem.

## What it does

```sh
go run github.com/go-admin-team/go-admin-core/tools/coreupgrade@latest /path/to/project   # reports
go run github.com/go-admin-team/go-admin-core/tools/coreupgrade@latest -w /path/to/project # writes
```

Reporting is the default. The first run of a migration tool on somebody else's repository should not be the destructive one.

It parses each file and edits the import specs by offset rather than substituting text, so:

- the path in a comment, a string or a struct tag is left alone
- an alias or a dot import keeps its form
- everything outside the import block keeps its bytes

`tools/gorm/logger` → `tools/gorm/gormlog` is the one move that also renames the package. An unaliased import of it would silently change the local name, so the tool adds an alias holding the old one — free by construction, since the import being replaced was using that name.

## The defect worth reporting

The first version only swapped the string, which leaves the group unsorted: a replacement almost always sorts somewhere else. Running it on `go-admin` took the repository from 35 unformatted files to 54 — nineteen files damaged by a tool whose whole job is a mechanical edit, and `go build` would never have told anyone.

The rule now is symmetric, and both halves are tested: a file that was gofmt clean stays gofmt clean, and a file that was not is not quietly reformatted, because burying a migration in whitespace makes it unreviewable.

I only noticed because I read the `gofmt -l` output instead of the label I had written above it, which said the list was empty.

## Evidence

Against a fresh clone of `go-admin`:

```
rewrote 64 import(s) in 46 file(s)
unformatted files: 35 before -> 35 after
PASS consumer          # scripts/canary.sh, i.e. it builds against this tree
```

The canary is the acceptance test here: the migrated consumer compiles against this module, which is exactly the condition v2.0.0 needs.

`make ci` green.

## What this does not do

It does not touch the multi-tenancy API (`*ByTenant`, `GetAll*`). That is a design change with no replacement designed yet, and consumers use it today — it needs a target before it needs a codemod.