### PR TITLE
feat✨: coreupgrade carries imports across the major version too

### DIFF
--- a/docs/migration/v2.0.0.md
+++ b/docs/migration/v2.0.0.md
@@ -24,13 +24,23 @@ worth knowing about: the package was renamed to stop colliding with the `logger`
 package at the root, so a plain (unaliased) import of it changes the local name
 as well.
 
+## The module path changes too
+
+Go requires the major version in the import path from v2 on, so the module
+becomes `github.com/go-admin-team/go-admin-core/v2` and **every** import of it
+changes, not only the ones in the table above. That is why the two happen
+together: one pass over a consumer rather than two.
+
 ## The tool
 
 ```sh
 go run github.com/go-admin-team/go-admin-core/tools/coreupgrade@latest /path/to/your/project
 ```
 
-It reports what it would change and exits. Pass `-w` to write.
+It reports what it would change and exits. Pass `-w` to write, and `-v2` to
+carry every import of this module onto the v2 path at the same time.
+
+Run `go mod tidy` afterwards: the require line follows the imports.
 
 It parses each file rather than substituting text, so the path appearing in a
 comment, a string or a struct tag is left alone, and an alias or dot import
@@ -52,4 +62,6 @@ go test ./...
 ```
 
 The open-source `go-admin` was migrated this way: 64 imports across 46 files,
-after which it builds against this module with the shims gone.
+after which it builds against this module with the shims gone. With `-v2` the
+same repository is 210 imports across 95 files, which is the shape of the
+whole upgrade rather than just the deprecated part of it.

--- a/tools/coreupgrade/main.go
+++ b/tools/coreupgrade/main.go
@@ -21,9 +21,12 @@ import (
 
 func main() {
 	write := flag.Bool("w", false, "write the files instead of reporting what would change")
+	major := flag.Bool("v2", false, "also move every import of this module onto its v2 path")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: coreupgrade [-w] DIR\n\n")
+		fmt.Fprintf(os.Stderr, "usage: coreupgrade [-w] [-v2] DIR\n\n")
 		fmt.Fprintf(os.Stderr, "Rewrites deprecated go-admin-core imports. Without -w it only reports.\n")
+		fmt.Fprintf(os.Stderr, "With -v2 it also moves every import of this module onto the v2 path,\n")
+		fmt.Fprintf(os.Stderr, "which Go requires from that major version on. Run go mod tidy after.\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -33,7 +36,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	n, files, err := run(flag.Arg(0), *write, os.Stdout)
+	n, files, err := run(flag.Arg(0), *write, *major, os.Stdout)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "coreupgrade:", err)
 		os.Exit(1)
@@ -49,7 +52,7 @@ func main() {
 	}
 }
 
-func run(dir string, write bool, out io.Writer) (imports, files int, err error) {
+func run(dir string, write, toMajor bool, out io.Writer) (imports, files int, err error) {
 	err = filepath.WalkDir(dir, func(filePath string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -69,7 +72,7 @@ func run(dir string, write bool, out io.Writer) (imports, files int, err error) 
 			return err
 		}
 
-		next, changes, err := rewrite(filePath, src)
+		next, changes, err := rewrite(filePath, src, toMajor)
 		if err != nil {
 			// A file that does not parse is reported and stepped over: the
 			// tool has no business deciding a consumer's build is broken.

--- a/tools/coreupgrade/moves.go
+++ b/tools/coreupgrade/moves.go
@@ -25,3 +25,8 @@ var moves = []move{
 	{from: mod + "observability/audit", to: mod + "observe/audit", name: "audit", newName: "audit"},
 	{from: mod + "tools/gorm/logger", to: mod + "tools/gorm/gormlog", name: "logger", newName: "gormlog"},
 }
+
+// majorPath is where this module lives once it carries a major version. Go
+// requires the suffix from v2 on, so every import of this module changes, not
+// only the ones that also moved.
+const majorPath = mod + "v2"

--- a/tools/coreupgrade/rewrite.go
+++ b/tools/coreupgrade/rewrite.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // change is one import line the tool would replace, reported whether or not
@@ -23,7 +24,7 @@ type change struct {
 // than substituting text so that the path appearing in a comment, a string
 // literal or a struct tag is left alone; only the import block is touched, and
 // the rest of the file keeps its formatting byte for byte.
-func rewrite(filename string, src []byte) ([]byte, []change, error) {
+func rewrite(filename string, src []byte, toMajor bool) ([]byte, []change, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, filename, src, parser.ImportsOnly|parser.ParseComments)
 	if err != nil {
@@ -44,7 +45,7 @@ func rewrite(filename string, src []byte) ([]byte, []change, error) {
 			continue
 		}
 
-		m, ok := lookup(path)
+		to, m, ok := target(path, toMajor)
 		if !ok {
 			continue
 		}
@@ -62,7 +63,7 @@ func rewrite(filename string, src []byte) ([]byte, []change, error) {
 			name = m.name
 		}
 
-		text := strconv.Quote(m.to)
+		text := strconv.Quote(to)
 		if name != "" {
 			text = name + " " + text
 		}
@@ -75,7 +76,7 @@ func rewrite(filename string, src []byte) ([]byte, []change, error) {
 		changes = append(changes, change{
 			Line:    fset.Position(spec.Pos()).Line,
 			From:    path,
-			To:      m.to,
+			To:      to,
 			Aliased: added,
 		})
 	}
@@ -106,6 +107,39 @@ func rewrite(filename string, src []byte) ([]byte, []change, error) {
 	}
 
 	return out, changes, nil
+}
+
+// target returns the path that replaces importPath. The two rules compose in
+// one direction only: a package is moved first and then carried across the
+// major version, so sdk/pkg/response becomes response becomes v2/response.
+func target(importPath string, toMajor bool) (string, move, bool) {
+	m, moved := lookup(importPath)
+
+	out := importPath
+	if moved {
+		out = m.to
+	}
+	if toMajor {
+		if major, ok := withMajor(out); ok {
+			out = major
+		}
+	}
+	return out, m, out != importPath
+}
+
+// withMajor puts a path of this module on its major version. A path already
+// there is left alone, and so is a module whose path merely starts with the
+// same characters — go-admin-core-extra is not this module.
+func withMajor(importPath string) (string, bool) {
+	switch {
+	case importPath == majorPath || strings.HasPrefix(importPath, majorPath+"/"):
+		return "", false
+	case importPath == strings.TrimSuffix(mod, "/"):
+		return majorPath, true
+	case strings.HasPrefix(importPath, mod):
+		return majorPath + "/" + strings.TrimPrefix(importPath, mod), true
+	}
+	return "", false
 }
 
 func lookup(path string) (move, bool) {

--- a/tools/coreupgrade/rewrite_test.go
+++ b/tools/coreupgrade/rewrite_test.go
@@ -139,7 +139,7 @@ var _ = fmt.Sprint
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got, changes, err := rewrite("x.go", []byte(c.in))
+			got, changes, err := rewrite("x.go", []byte(c.in), false)
 			if err != nil {
 				t.Fatalf("rewrite: %v", err)
 			}
@@ -208,7 +208,7 @@ func TestWriteKeepsThePermissionBits(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
-	if _, _, err := run(dir, true, io.Discard); err != nil {
+	if _, _, err := run(dir, true, false, io.Discard); err != nil {
 		t.Fatalf("run: %v", err)
 	}
 
@@ -247,7 +247,7 @@ var _ = api.Api{}
 var _ = captcha.New
 `
 
-	got, _, err := rewrite("x.go", []byte(in))
+	got, _, err := rewrite("x.go", []byte(in), false)
 	if err != nil {
 		t.Fatalf("rewrite: %v", err)
 	}
@@ -276,7 +276,7 @@ import (
 var  _ = response.Error
 `
 
-	got, changes, err := rewrite("x.go", []byte(in))
+	got, changes, err := rewrite("x.go", []byte(in), false)
 	if err != nil {
 		t.Fatalf("rewrite: %v", err)
 	}
@@ -285,5 +285,120 @@ var  _ = response.Error
 	}
 	if !strings.Contains(string(got), "var  _ = response.Error") {
 		t.Errorf("the double space was reformatted away:\n%s", got)
+	}
+}
+
+// Go requires the major version in the path from v2 on, so -v2 touches every
+// import of this module, not only the ones that also moved.
+func TestTargetWithMajor(t *testing.T) {
+	const bare = "github.com/go-admin-team/go-admin-core"
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "an ordinary package gains the version",
+			in:   bare + "/sdk/runtime",
+			want: bare + "/v2/sdk/runtime",
+		},
+		{
+			name: "the module root gains it too",
+			in:   bare,
+			want: bare + "/v2",
+		},
+		{
+			name: "a moved package is moved first, then carried across",
+			in:   bare + "/sdk/pkg/response",
+			want: bare + "/v2/response",
+		},
+		{
+			name: "a path already on v2 is left alone",
+			in:   bare + "/v2/sdk/runtime",
+			want: bare + "/v2/sdk/runtime",
+		},
+		{
+			name: "another module that starts the same way is not this one",
+			in:   bare + "-extra/sdk/runtime",
+			want: bare + "-extra/sdk/runtime",
+		},
+		{
+			name: "someone else's module is untouched",
+			in:   "gorm.io/gorm",
+			want: "gorm.io/gorm",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, _, changed := target(c.in, true)
+			if got != c.want {
+				t.Errorf("target(%q) = %q, want %q", c.in, got, c.want)
+			}
+			if want := c.in != c.want; changed != want {
+				t.Errorf("changed = %v, want %v", changed, want)
+			}
+		})
+	}
+}
+
+// Without the flag nothing gains a version, which is what a consumer staying
+// on v1 has to be able to rely on.
+func TestTargetWithoutMajorLeavesTheVersionAlone(t *testing.T) {
+	for _, in := range []string{
+		"github.com/go-admin-team/go-admin-core/sdk/runtime",
+		"github.com/go-admin-team/go-admin-core",
+	} {
+		got, _, changed := target(in, false)
+		if changed || got != in {
+			t.Errorf("target(%q, false) = %q, changed=%v; want it untouched", in, got, changed)
+		}
+	}
+
+	// A deprecated path still moves, it just does not gain a version.
+	got, _, changed := target("github.com/go-admin-team/go-admin-core/sdk/pkg/response", false)
+	if !changed || got != "github.com/go-admin-team/go-admin-core/response" {
+		t.Errorf("got %q changed=%v, want the v1 destination", got, changed)
+	}
+}
+
+// The whole point of -v2 is one pass rather than two, so a file mixing moved
+// and unmoved imports has to come out consistent.
+func TestRewriteWithMajorAcrossOneFile(t *testing.T) {
+	in := `package p
+
+import (
+	"github.com/go-admin-team/go-admin-core/sdk/pkg/response"
+	"github.com/go-admin-team/go-admin-core/sdk/runtime"
+	"gorm.io/gorm"
+)
+
+var _ = response.Error
+var _ = runtime.Runtime
+var _ = gorm.Open
+`
+	want := `package p
+
+import (
+	"github.com/go-admin-team/go-admin-core/v2/response"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
+	"gorm.io/gorm"
+)
+
+var _ = response.Error
+var _ = runtime.Runtime
+var _ = gorm.Open
+`
+
+	got, changes, err := rewrite("x.go", []byte(in), true)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("got:\n%s\nwant:\n%s", got, want)
+	}
+	if len(changes) != 2 {
+		t.Errorf("changes = %d, want 2", len(changes))
 	}
 }


### PR DESCRIPTION
The plan of record says v2.0.0 removes the deprecated packages. It cannot, as written: Go requires the major version in the import path from v2 on, so the module has to become `github.com/go-admin-team/go-admin-core/v2`. Tagging `v2.0.0` on the current path produces a module `go get` refuses. `docs/migration/v1.6.0-plan.md` never mentions this, which may be part of why the May date came and went.

That changes the shape of the migration rather than the plan: **every** import of this module moves, not only the seven deprecated ones. A consumer told to do those two things separately does the work twice.

## What the flag does

```sh
coreupgrade -w -v2 /path/to/project   # both rules, one pass
go mod tidy                            # the require line follows the imports
```

The rules compose in one direction: a package moves first and is then carried across, so `sdk/pkg/response` → `response` → `v2/response`. Without `-v2` nothing gains a version, which is what a consumer staying on v1 relies on.

## The two guards, both counter-proved

| removed | what the tool produces |
| --- | --- |
| the already-on-v2 check | `go-admin-core/v2/v2/sdk/runtime` |
| the trailing slash in the module prefix | `go-admin-core/v2/github.com/go-admin-team/go-admin-core-extra/sdk/runtime` |

The second is the one worth having a test for: `go-admin-core-extra` is a different module that happens to start with the same characters, and a prefix check without the separator swallows it.

## The size of the thing

| repository | deprecated paths only | with `-v2` |
| --- | --- | --- |
| open-source `go-admin` | 64 imports / 46 files | **210 / 95** |
| this module (internal imports) | — | **178 / 98** |
| the private consumer | 3 / 3 | **406 / 238** |

Mechanical, but not small — which is the argument for the tool rather than against the version.

## What this does not decide

Whether to go to `/v2` at all. The alternatives are tagging `v2.0.0` without the suffix, which yields a module nobody can `go get`, and removing the shims in a v1 minor, which breaks `go get -u` for everyone with no signal. This PR only makes the first option cheap; it changes nothing until someone runs it with the flag.

`make ci` green.