### PR TITLE
docs📝: a map of the tree, for whoever arrives without the history

### DIFF
--- a/docs/architecture/map.md
+++ b/docs/architecture/map.md
@@ -40,7 +40,7 @@ symbol rather than a wrong import.
 | --- | --- | --- |
 | `make ci` | tidy, build, vet, the race detector across the whole tree with nothing excluded, and the exported API matching `api/core.txt` | anything about consumers |
 | `scripts/canary.sh DIR` | a consumer, migrated by `coreupgrade`, compiles against this tree | that it runs — only that it builds |
-| `scripts/check-language.sh origin/main` | no Chinese in added Go lines or in commit subjects | uncommitted work; it reads committed state |
+| `scripts/check-language.sh origin/main` | no Chinese in added Go lines, or anywhere in a commit message — subject and body both | uncommitted work; it reads committed state |
 
 ## Traps
 

--- a/docs/architecture/map.md
+++ b/docs/architecture/map.md
@@ -1,0 +1,64 @@
+# The map
+
+What each top-level directory is, which names collide, and what "verified"
+means here. For whoever arrives without the history.
+
+## Top level
+
+| directory | what it is |
+| --- | --- |
+| `captcha` | base64Captcha wrapper: a store and the helpers around it |
+| `casbin` | casbin v3 enforcer setup, and the logger it talks through |
+| `config` | dynamic configuration, inherited from go-micro. Fifteen packages of loader / reader / encoder / source; consumers reach only `config/source/file`, through `NewConfig`. The rest is machinery with no callers outside this tree. |
+| `errors` | error codes and the protobuf error type |
+| `jwtauth` | JWT middleware, derived from gin-jwt. `jwtauth/user` reads claims off a context. |
+| `logger` | the logging package: zap and logrus adapters, the async writer, sampling, redaction |
+| `observe/audit` | audit records |
+| `response` | gin response envelopes. `response/antd` is the shape the Ant Design front end expects. |
+| `sdk` | the application layer. `sdk/runtime` holds `Runtime`, `sdk/config` holds the settings structs, `sdk/api` and `sdk/service` are the handler and service bases, `sdk/pkg` is what remains of an older grab bag. |
+| `server` | a server manager and its listeners |
+| `storage` | cache and queue **contracts**, their memory and redis implementations, and `cachetest` — the suite any implementation has to pass |
+| `tools` | helpers that belong nowhere else, plus `coreupgrade`, the migration codemod |
+
+## Names that collide
+
+Five package names mean two different things each. The compiler will not help
+you: picking the wrong one gives `undefined: X`, which reads like a missing
+symbol rather than a wrong import.
+
+| you write | you probably meant | the other one |
+| --- | --- | --- |
+| `package config` | `sdk/config` — settings structs, `CacheConfig`, `QueueConfig` | `config` — the dynamic loader |
+| `package logger` | `logger` — the logging package | `sdk/pkg/logger` |
+| `package memory` | `config/source/memory` — a config source | `config/loader/memory` — the loader |
+| `package json` | `config/reader/json` | `config/encoder/json` |
+| `package utils` | `tools/utils` | `sdk/pkg/utils` |
+
+## What "verified" means
+
+| command | what it guarantees | what it does not |
+| --- | --- | --- |
+| `make ci` | tidy, build, vet, the race detector across the whole tree with nothing excluded, and the exported API matching `api/core.txt` | anything about consumers |
+| `scripts/canary.sh DIR` | a consumer, migrated by `coreupgrade`, compiles against this tree | that it runs — only that it builds |
+| `scripts/check-language.sh origin/main` | no Chinese in added Go lines or in commit subjects | uncommitted work; it reads committed state |
+
+## Traps
+
+**Stage before you verify.** `api-check` is `git diff --exit-code api/`, which
+compares the working tree against the index. Regenerating the snapshot and then
+running `make ci` fails on your own change until you `git add` it.
+
+**`check-language.sh` takes the base ref as an argument**, not as an
+environment variable, and it compares committed state — unstaged work is
+invisible to it.
+
+**`go build ./...` writes a `coreupgrade` binary at the repository root.** It is
+gitignored; it is still surprising.
+
+**Twenty-nine of fifty-one packages have no tests.** `storage` is the exception
+worth copying: a written contract plus `cachetest`, which every implementation
+must pass. That suite is what caught the mistakes in the redis queue.
+
+**`Runtime` has fifty-seven methods and is reached through a package-level
+global**, `sdk.Runtime`. Changes to it have effects no test in this repository
+will catch; the canary is the only thing that will.


### PR DESCRIPTION
`docs/architecture` holds five reports about work that was done. None of them answers what someone actually arrives asking: what is in each directory, which of the duplicated package names they want, and what has to pass before a change counts as finished.

## Why this and not more comments

Eleven of the twelve top-level packages have no doc comment, so `go doc` returns nothing for them. That is worth fixing too, but a per-package comment cannot say the thing that keeps costing time here, which is how the pieces relate and where the floor is.

## The part I would keep if I could keep only one section

Five package names each mean two different things:

| you write | you probably meant | the other one |
| --- | --- | --- |
| `package config` | `sdk/config` — the settings structs | `config` — the dynamic loader |
| `package logger` | `logger` | `sdk/pkg/logger` |
| `package memory` | `config/source/memory` | `config/loader/memory` |
| `package json` | `config/reader/json` | `config/encoder/json` |
| `package utils` | `tools/utils` | `sdk/pkg/utils` |

Guessing wrong gives `undefined: CacheConfig`, which reads as a missing symbol rather than a wrong import — so the search that follows looks for something that was never there.

## The traps, because each one cost a wrong diagnosis

- `api-check` is `git diff --exit-code api/`, comparing the working tree against the **index**. Regenerate the snapshot, run `make ci`, and it fails on your own change until you stage it. I read that as a broken build before I read the target.
- `check-language.sh` takes the base ref as a **positional argument**, not an environment variable, and compares **committed** state. I once reported it clean having passed the ref the wrong way.
- `go build ./...` drops a `coreupgrade` binary at the root. Gitignored now; still surprising.

## What it records without proposing to fix

Twenty-nine of fifty-one packages have no tests. `Runtime` has fifty-seven methods behind a package-level global. Both are stated as facts a reader needs, not as work items — the decision was to keep v2 to the path move and the removals.

`storage` is named as the pattern worth copying: a written contract plus `cachetest`, the suite every implementation must pass. That suite is what caught the mistakes in the redis queue rather than a reviewer.

`make ci` green.