### PR TITLE
fix🐛: the Runtime hands out live maps, and holds a lock that cannot lock

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -1162,7 +1162,6 @@ func (e *Application) SetDefaultTenant(tenant string)
 func (e *Application) SetEngine(engine http.Handler)
 func (e *Application) SetHandler(routerGroup func(r *gin.RouterGroup, hand ...*gin.HandlerFunc))
 func (e *Application) SetHandlerByTenant(tenant string, routerGroup func(r *gin.RouterGroup, hand ...*gin.HandlerFunc))
-func (e *Application) SetLockerAdapter(c storage.AdapterLocker)
 func (e *Application) SetLogger(l logger.Logger)
 func (e *Application) SetMiddleware(key string, middleware interface{})
 func (e *Application) SetQueueAdapter(c storage.AdapterQueue)
@@ -1315,8 +1314,6 @@ type AdapterCache interface {
 	Decrease(key string) error
 	Expire(key string, dur time.Duration) error
 func LegacyAdapter(c Cache) AdapterCache
-type AdapterLocker interface {
-	String() string
 type AdapterQueue interface {
 	String() string
 	Append(message Messager) error

--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"github.com/gin-gonic/gin"
+	"maps"
 	"net/http"
 	"sync"
 
@@ -88,10 +89,13 @@ func (e *Application) GetDb() *gorm.DB {
 }
 
 // GetAllDb 获取所有租户的数据库 (原GetDb改名)
+// GetAllDb returns a snapshot. Handing back the map itself was a race the
+// lock could not fix: it was held across the return and released before the
+// caller read anything.
 func (e *Application) GetAllDb() map[string]*gorm.DB {
-	e.mux.Lock()
-	defer e.mux.Unlock()
-	return e.dbs
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return maps.Clone(e.dbs)
 }
 
 func (e *Application) SetBefore(f func()) {
@@ -174,7 +178,9 @@ func (e *Application) SetCasbin(enforcer *casbin.SyncedEnforcer) {
 
 // GetAllCasbin 获取所有租户的casbin (原GetCasbin改名)
 func (e *Application) GetAllCasbin() map[string]*casbin.SyncedEnforcer {
-	return e.casbins
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return maps.Clone(e.casbins)
 }
 
 // GetCasbin 获取默认租户的casbin (新增单租户快捷方法)
@@ -300,9 +306,9 @@ func (e *Application) SetCrontab(crontab *cron.Cron) {
 
 // GetAllCrontab 获取所有租户的定时任务 (原GetCrontab改名)
 func (e *Application) GetAllCrontab() map[string]*cron.Cron {
-	e.mux.Lock()
-	defer e.mux.Unlock()
-	return e.crontab
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return maps.Clone(e.crontab)
 }
 
 // GetCrontab 获取默认租户的定时任务 (新增单租户快捷方法)
@@ -329,7 +335,9 @@ func (e *Application) SetMiddleware(key string, middleware interface{}) {
 
 // GetAllMiddleware 获取所有中间件
 func (e *Application) GetAllMiddleware() map[string]interface{} {
-	return e.middlewares
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return maps.Clone(e.middlewares)
 }
 
 // GetMiddleware 获取对应的中间件
@@ -420,9 +428,9 @@ func (e *Application) SetHandlerByTenant(tenant string, routerGroup func(r *gin.
 }
 
 func (e *Application) GetAllHandler() map[string][]func(r *gin.RouterGroup, hand ...*gin.HandlerFunc) {
-	e.mux.Lock()
-	defer e.mux.Unlock()
-	return e.handler
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return maps.Clone(e.handler)
 }
 
 func (e *Application) GetHandler() []func(r *gin.RouterGroup, hand ...*gin.HandlerFunc) {

--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -28,7 +28,6 @@ type Application struct {
 	middlewares   map[string]interface{}                                          // 中间件
 	cache         storage.AdapterCache                                            // 缓存
 	queue         storage.AdapterQueue                                            // 队列
-	locker        storage.AdapterLocker                                           // 分布式锁
 	memoryQueue   storage.AdapterQueue                                            // 内存队列
 	handler       map[string][]func(r *gin.RouterGroup, hand ...*gin.HandlerFunc) // 路由处理器
 	routers       []Router                                                        // 路由表
@@ -408,11 +407,6 @@ func (e *Application) GetQueuePrefix(key string) storage.AdapterQueue {
 // GetQueue 获取默认租户的队列
 func (e *Application) GetQueue() storage.AdapterQueue {
 	return e.GetQueuePrefix(e.GetDefaultTenant())
-}
-
-// SetLockerAdapter 设置分布式锁
-func (e *Application) SetLockerAdapter(c storage.AdapterLocker) {
-	e.locker = c
 }
 
 func (e *Application) SetHandler(routerGroup func(r *gin.RouterGroup, hand ...*gin.HandlerFunc)) {

--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"maps"
 	"net/http"
+	"slices"
 	"sync"
 
 	"github.com/casbin/casbin/v3"
@@ -424,7 +425,15 @@ func (e *Application) SetHandlerByTenant(tenant string, routerGroup func(r *gin.
 func (e *Application) GetAllHandler() map[string][]func(r *gin.RouterGroup, hand ...*gin.HandlerFunc) {
 	e.mux.RLock()
 	defer e.mux.RUnlock()
-	return maps.Clone(e.handler)
+
+	// The values are slices, so cloning the map is not enough: the copies
+	// would share their arrays with the originals, and a caller appending to
+	// one writes the slot the next SetHandlerByTenant writes.
+	out := make(map[string][]func(r *gin.RouterGroup, hand ...*gin.HandlerFunc), len(e.handler))
+	for tenant, fns := range e.handler {
+		out[tenant] = slices.Clone(fns)
+	}
+	return out
 }
 
 func (e *Application) GetHandler() []func(r *gin.RouterGroup, hand ...*gin.HandlerFunc) {

--- a/sdk/runtime/caller_append_test.go
+++ b/sdk/runtime/caller_append_test.go
@@ -1,0 +1,36 @@
+package runtime
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Cloning the map is not enough when the values are slices. The hazard is not
+// the accessor racing SetHandlerByTenant — three seconds of that reports
+// nothing, because an append writes at index len, outside the window a reader
+// holds. It is a caller appending to what it was handed: that writes the same
+// slot the next SetHandlerByTenant writes, and only when the internal slice
+// has spare capacity, which is why this sets three handlers rather than four.
+func TestCallersAppendingToTheSnapshotDoNotShare(t *testing.T) {
+	e := NewConfig()
+	noop := func(r *gin.RouterGroup, hand ...*gin.HandlerFunc) {}
+	for i := 0; i < 3; i++ {
+		e.SetHandlerByTenant("t", noop)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				for _, fns := range e.GetAllHandler() {
+					_ = append(fns, noop)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/sdk/runtime/getall_test.go
+++ b/sdk/runtime/getall_test.go
@@ -1,0 +1,52 @@
+package runtime
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// The GetAll accessors hand out the map itself. Three of them take the lock
+// while doing so, which protects the return statement and nothing else: the
+// caller reads the map long after the lock is gone. The other two do not lock
+// at all. Either way a setter running alongside a caller is a data race, and
+// an iteration alongside a write is a fatal error rather than a failed test.
+func TestGetAllDbIsSafeAgainstAWriter(t *testing.T) {
+	e := NewConfig()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			e.SetDbByTenant(string(rune('a'+i%26)), &gorm.DB{})
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			for range e.GetAllDb() {
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}

--- a/storage/type.go
+++ b/storage/type.go
@@ -49,7 +49,3 @@ type Messager interface {
 }
 
 type ConsumerFunc func(Messager) error
-
-type AdapterLocker interface {
-	String() string
-}


### PR DESCRIPTION
Two findings from reading `sdk/runtime` after the v2 merge. `Runtime` is a fifty-seven method interface reached through a package-level global, touched forty-three times in the open-source consumer, so its shared state is worth being sure about.

## The GetAll accessors return the map itself

All five raced, in two different ways:

| accessor | before |
| --- | --- |
| `GetAllCasbin`, `GetAllMiddleware` | no lock at all |
| `GetAllDb`, `GetAllCrontab`, `GetAllHandler` | took the lock, returned the map anyway |

The second group is the worse half. The lock is held across the `return` and released before the caller reads anything, so it protects nothing — but a reader auditing the code sees a mutex two lines up and moves on. The scan I wrote to find the first group classified all three as safe. Only reading them line by line found it.

Reproduced in two hundred milliseconds, one goroutine setting tenants while another ranges over the result:

```
WARNING: DATA RACE
Write at 0x00c0002dce70 by goroutine 9:            <- SetDbByTenant
Previous read at 0x00c0002dce70 by goroutine 10:   <- ranging over GetAllDb
```

The consequence is not only a race report. `range` over a map while another goroutine writes is `fatal error: concurrent map iteration and map write` — not recoverable, and the consumer passes this map to a job subsystem that keeps it.

They clone under a read lock now. Every call site here and in both consumers only reads, so nothing depended on the result being live, and the three that took the *write* lock to read were holding the wrong one anyway.

## AdapterLocker cannot lock

```go
type AdapterLocker interface {
	String() string
}
```

An interface for a distributed lock, with no lock method. Thirty-four types in this module satisfy it by accident, including the logger and the error codes. The field it feeds is written once and read nowhere; there is no getter, the setter is not on the `Runtime` interface, and neither consumer calls it. A caller configuring a locker hands it over and it is dropped.

Removed rather than completed. Locking is a feature, and its shape here should be `storage.Queue`'s — a contract with a conformance suite — not a placeholder that accepts anything with a `String`. v2 is not tagged yet, which is the only reason this costs nothing today.

## Not included

Four fields are still written and read without the mutex: `engine`, `before`, `appRouters`, `routers`. All are startup registration, and I have no reproduction for them — a fix I cannot counter-prove is a fix I cannot defend, so they are noted rather than changed.

`make ci` green, `scripts/canary.sh` passes against the open-source consumer.
