### PR TITLE
fix🐛: the locale tag normalisation replaced nothing

### DIFF
--- a/tools/language/parser.go
+++ b/tools/language/parser.go
@@ -54,7 +54,11 @@ func ParseAcceptLanguage(languages string, supportedLanguages []string) []string
 
 	for i, rawPreferredLanguage := range preferredLanguages {
 		// Format strings.
-		preferredLanguage := strings.Replace(strings.ToLower(strings.TrimSpace(rawPreferredLanguage)), "_", "-", 0)
+		// Both forms of a locale tag arrive here, and only the hyphen one can
+		// match a supported tag. Replace was asked for zero replacements, so
+		// the underscore form was passed through untouched and matched
+		// nothing.
+		preferredLanguage := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(rawPreferredLanguage)), "_", "-")
 
 		if preferredLanguage == "" {
 			continue

--- a/tools/language/parser_test.go
+++ b/tools/language/parser_test.go
@@ -1,0 +1,56 @@
+package language
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A browser may send either form of a locale tag, and the parser normalises
+// the underscore one so that it can match a supported tag. The normalisation
+// asked strings.Replace for zero replacements, so it never happened and the
+// underscore form matched nothing.
+func TestParseAcceptLanguageNormalisesUnderscores(t *testing.T) {
+	cases := []struct {
+		name      string
+		header    string
+		supported []string
+		want      []string
+	}{
+		{
+			name:      "an underscore tag matches its hyphen form",
+			header:    "zh_CN",
+			supported: []string{"zh-cn"},
+			want:      []string{"zh-cn"},
+		},
+		{
+			name:      "the hyphen form still matches",
+			header:    "zh-CN",
+			supported: []string{"zh-cn"},
+			want:      []string{"zh-cn"},
+		},
+		{
+			name:      "quality still orders the result",
+			header:    "en;q=0.8,zh_CN;q=0.9",
+			supported: []string{"zh-cn", "en"},
+			want:      []string{"zh-cn", "en"},
+		},
+		{
+			name:      "an unsupported tag is dropped",
+			header:    "de_DE",
+			supported: []string{"zh-cn"},
+			want:      []string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ParseAcceptLanguage(c.header, c.supported)
+			if len(got) == 0 && len(c.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("ParseAcceptLanguage(%q, %v) = %v, want %v", c.header, c.supported, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
tools/language/parser.go:57:108: calling strings.Replace with n == 0
    will return no results, did you mean -1? (SA1018)
```

staticcheck has been saying this for as long as the file has existed. `make lint` is not part of `make ci`, so nobody saw it.

## What it does

```go
preferredLanguage := strings.Replace(..., "_", "-", 0)
```

Zero replacements means none. The line is there to turn `zh_CN` into `zh-CN` so it can match a supported tag, and it never did. A client sending the underscore form — which browsers and HTTP clients do — is silently dropped and gets the fallback language, with nothing anywhere to explain why.

## The test came first

It fails on exactly the two underscore cases and passes the two hyphen ones, which is what identified the defect. The lint message says a call is suspicious; the test says what breaks.

```
--- FAIL: an_underscore_tag_matches_its_hyphen_form
--- PASS: the_hyphen_form_still_matches
--- FAIL: quality_still_orders_the_result
--- PASS: an_unsupported_tag_is_dropped
```

## The wider point

`make lint` reports **68 findings** and is not in `make ci`. Most are style or dead code, but this one is a behavioural bug that a linter had already found and nobody was reading. Wiring lint into CI means fixing or explicitly accepting the other 67 first, which is its own piece of work — worth doing, but not smuggled into this fix.

`make ci` green.
