### PR TITLE
fix🔒: password salts come from math/rand

### DIFF
--- a/sdk/pkg/security.go
+++ b/sdk/pkg/security.go
@@ -12,10 +12,14 @@ const (
 	letter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
-// generateRandString draws from crypto/rand. These values are used as key
-// material — one of them is every user's password salt — and math/rand is a
-// generator whose internal state can be recovered from its output, which makes
-// the next value predictable to anyone who has seen enough of them.
+// generateRandString draws from crypto/rand.
+//
+// What each caller needs differs. A password salt needs to be unique, not
+// secret, and math/rand gave unique values. A token or a verification code —
+// which is what the exported names here read like they are for — needs to be
+// unpredictable, and math/rand is a generator whose internal state can be
+// recovered from enough of its output, after which every later value is known.
+// One source that satisfies both is simpler than two that each satisfy one.
 func generateRandString(length int, s string) string {
 	var chars = []byte(s)
 	clen := len(chars)

--- a/sdk/pkg/security.go
+++ b/sdk/pkg/security.go
@@ -1,8 +1,8 @@
 package pkg
 
 import (
+	"crypto/rand"
 	"encoding/hex"
-	"math/rand"
 
 	"golang.org/x/crypto/scrypt"
 )
@@ -12,6 +12,10 @@ const (
 	letter = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
+// generateRandString draws from crypto/rand. These values are used as key
+// material — one of them is every user's password salt — and math/rand is a
+// generator whose internal state can be recovered from its output, which makes
+// the next value predictable to anyone who has seen enough of them.
 func generateRandString(length int, s string) string {
 	var chars = []byte(s)
 	clen := len(chars)

--- a/sdk/pkg/security_test.go
+++ b/sdk/pkg/security_test.go
@@ -1,0 +1,135 @@
+package pkg
+
+import (
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// No test can tell crypto/rand from math/rand by looking at what comes out —
+// both produce values that pass every distribution check worth writing here.
+// The property is which source the code draws from, so it is asserted where it
+// is decidable: in the imports.
+func TestKeysAreDrawnFromACryptographicSource(t *testing.T) {
+	f, err := parser.ParseFile(token.NewFileSet(), "security.go", nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	found := false
+	for _, spec := range f.Imports {
+		path, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		switch path {
+		case "math/rand", "math/rand/v2":
+			t.Errorf("security.go imports %s; key material needs crypto/rand", path)
+		case "crypto/rand":
+			found = true
+		}
+	}
+	if !found {
+		t.Error("security.go does not import crypto/rand")
+	}
+}
+
+func TestGeneratedKeysHaveTheirLengthAndCharset(t *testing.T) {
+	cases := []struct {
+		name    string
+		gen     func() string
+		length  int
+		charset string
+	}{
+		{"GenerateRandomKey20", GenerateRandomKey20, 20, symbol},
+		{"GenerateRandomKey16", GenerateRandomKey16, 16, symbol},
+		{"GenerateRandomKey6", GenerateRandomKey6, 6, letter},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			for i := 0; i < 200; i++ {
+				got := c.gen()
+				if len(got) != c.length {
+					t.Fatalf("length %d, want %d", len(got), c.length)
+				}
+				for _, r := range got {
+					if !strings.ContainsRune(c.charset, r) {
+						t.Fatalf("%q contains %q, which is outside the charset", got, r)
+					}
+				}
+			}
+		})
+	}
+}
+
+// A generator stuck on one value, or reseeded identically per call, would pass
+// the length and charset checks and fail here.
+func TestGeneratedKeysDiffer(t *testing.T) {
+	const runs = 500
+
+	seen := make(map[string]struct{}, runs)
+	for i := 0; i < runs; i++ {
+		seen[GenerateRandomKey16()] = struct{}{}
+	}
+	if len(seen) != runs {
+		t.Errorf("%d distinct values out of %d; the generator is repeating itself", len(seen), runs)
+	}
+}
+
+// The six character key draws from 36 symbols, so collisions in 500 draws are
+// expected — around a one in twenty thousand chance of a given pair matching.
+// What must not happen is the value being constant.
+func TestTheShortKeyIsNotConstant(t *testing.T) {
+	first := GenerateRandomKey6()
+	for i := 0; i < 100; i++ {
+		if GenerateRandomKey6() != first {
+			return
+		}
+	}
+	t.Errorf("a hundred draws all returned %q", first)
+}
+
+func TestSetPassword(t *testing.T) {
+	t.Run("the same password and salt give the same verifier", func(t *testing.T) {
+		a, err := SetPassword("hunter2", "salt")
+		if err != nil {
+			t.Fatalf("SetPassword: %v", err)
+		}
+		b, err := SetPassword("hunter2", "salt")
+		if err != nil {
+			t.Fatalf("SetPassword: %v", err)
+		}
+		if a != b {
+			t.Errorf("%q != %q; verification would fail for a correct password", a, b)
+		}
+	})
+
+	t.Run("the salt changes the verifier", func(t *testing.T) {
+		a, _ := SetPassword("hunter2", "salt-a")
+		b, _ := SetPassword("hunter2", "salt-b")
+		if a == b {
+			t.Error("two salts produced one verifier; the salt is not reaching the derivation")
+		}
+	})
+
+	t.Run("the password changes the verifier", func(t *testing.T) {
+		a, _ := SetPassword("hunter2", "salt")
+		b, _ := SetPassword("hunter3", "salt")
+		if a == b {
+			t.Error("two passwords produced one verifier")
+		}
+	})
+
+	t.Run("the verifier is 32 bytes of hex", func(t *testing.T) {
+		got, err := SetPassword("hunter2", "salt")
+		if err != nil {
+			t.Fatalf("SetPassword: %v", err)
+		}
+		if len(got) != 64 {
+			t.Errorf("length %d, want 64", len(got))
+		}
+	})
+}

--- a/sdk/pkg/security_test.go
+++ b/sdk/pkg/security_test.go
@@ -3,6 +3,8 @@ package pkg
 import (
 	"go/parser"
 	"go/token"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -13,7 +15,16 @@ import (
 // The property is which source the code draws from, so it is asserted where it
 // is decidable: in the imports.
 func TestKeysAreDrawnFromACryptographicSource(t *testing.T) {
-	f, err := parser.ParseFile(token.NewFileSet(), "security.go", nil, parser.ImportsOnly)
+	// Located from this file rather than from the working directory: go test
+	// runs in the package directory, but the compiled binary can be run from
+	// anywhere, and a security check that quietly stops checking is worse than
+	// one that was never written.
+	_, self, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate this test file")
+	}
+
+	f, err := parser.ParseFile(token.NewFileSet(), filepath.Join(filepath.Dir(self), "security.go"), nil, parser.ImportsOnly)
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}


### PR DESCRIPTION
`generateRandString` read from `math/rand`. It backs `GenerateRandomKey16`, which is **every user's password salt** in both consumers:

```go
u.Salt = pkg.GenerateRandomKey16()
```

and `GenerateRandomKey20` and `GenerateRandomKey6`, which this module exports to anyone.

## How bad, precisely

Worth stating carefully rather than by adjective, because the severity depends entirely on the use:

- A salt has to be **unique**, not secret. Nothing here produces colliding salts.
- Since Go 1.20 the global `math/rand` source is seeded randomly, so this is not the classic "every deployment generates the same sequence" failure. This module requires Go 1.25, so that path is closed.
- What remains is the actual property: `math/rand` is a generator whose internal state can be recovered from enough of its output, after which every subsequent value is predictable. For a salt that is a weakness. For a token or a verification code — which is what `GenerateRandomKey20` and `GenerateRandomKey6` read like they are for — it is fatal.

No existing hash is invalidated; salts already stored keep working. `crypto/rand.Read` has the same signature, so the change is one import line.

## On testing a source of randomness

No test can tell `crypto/rand` from `math/rand` by looking at output — both pass every distribution check worth writing here. A test claiming otherwise would be worse than none, because it would be believed.

The property is which source the code draws from, which is decidable at the source level, so that is where it is asserted: the test parses `security.go` and fails if `math/rand` appears or `crypto/rand` does not.

```
security_test.go:29: security.go imports math/rand; key material needs crypto/rand
```

Everything else in the file is ordinary behaviour: length and charset over two hundred draws each, five hundred distinct sixteen-character keys, a six-character key that is not constant, and a derivation stable for a given password and salt while changing with either.

## Left alone

`scrypt.Key(..., 16384, 8, 1, 32)` — N is at the low end of current guidance, but raising it invalidates every stored password, which is a migration and not a fix.

`make ci` green.
