### PR TITLE
fix🐛: a break that left the select, not the loop

### DIFF
--- a/sdk/pkg/ws/ws.go
+++ b/sdk/pkg/ws/ws.go
@@ -99,8 +99,12 @@ func (c *Client) Write(cxt context.Context) {
 			if err != nil {
 				log.Printf("client [%s] writemessage err: %s", c.Id, err)
 			}
-		case _ = <-c.Context.Done():
-			break
+		case <-c.Context.Done():
+			// break here leaves the select, not the loop. What ended the
+			// loop was the check at the top, which watches the parameter —
+			// so this exit worked only while the caller passed the client's
+			// own context, which the signature does not require.
+			return
 		}
 	}
 }

--- a/sdk/pkg/ws/ws_test.go
+++ b/sdk/pkg/ws/ws_test.go
@@ -22,6 +22,8 @@ func dialedClient(t *testing.T) *Client {
 		if err != nil {
 			return
 		}
+		defer conn.Close()
+
 		// Hold the connection open; the test drives the other end.
 		for {
 			if _, _, err := conn.ReadMessage(); err != nil {

--- a/sdk/pkg/ws/ws_test.go
+++ b/sdk/pkg/ws/ws_test.go
@@ -1,0 +1,78 @@
+package ws
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// dialedClient gives back a Client wired to a real connection, because Write
+// closes the socket on its way out and a nil one panics there.
+func dialedClient(t *testing.T) *Client {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Hold the connection open; the test drives the other end.
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	return &Client{
+		Id:         "test",
+		Group:      "test",
+		Context:    ctx,
+		CancelFunc: cancel,
+		Socket:     conn,
+		Message:    make(chan []byte, 1),
+	}
+}
+
+// Write takes a context as a parameter and also reads c.Context, and it used to
+// depend on those being the same value: the select's break left the select
+// rather than the loop, so the only thing that ended it was the check at the
+// top of the loop, which watches the parameter. Cancelling the client's own
+// context then spun the goroutine at full speed instead of ending it.
+//
+// The one call site in this module passes the same context to both, which is
+// why nothing has been observed. The signature does not require it.
+func TestWriteEndsWhenTheClientContextIsCancelled(t *testing.T) {
+	c := dialedClient(t)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Deliberately not c.Context: the caller's context outlives the client.
+		c.Write(context.Background())
+	}()
+
+	c.CancelFunc()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write did not return after the client context was cancelled")
+	}
+}


### PR DESCRIPTION
```go
case _ = <-c.Context.Done():
    break
}
```

`break` inside a `select` leaves the select, not the loop around it. staticcheck has been reporting it as SA4011; `make lint` is not part of `make ci`, so nobody was reading it.

## Why nothing has been observed

What actually ends this loop is the check at the top:

```go
for {
    if cxt.Err() != nil {
        break        // this one works
    }
    select { ... }
}
```

That watches `cxt`, the **parameter**. The select watches `c.Context`, the **client's**. The single call site in this module passes the same value to both:

```go
go client.Write(ctx)   // and client.Context is that same ctx
```

so the loop exits and the defect is invisible. The signature does not require that, and `Write` is exported. A caller whose own context outlives the client — the natural thing to pass, a server context — gets a goroutine spinning at full speed on a closed `Done` channel instead of a goroutine that stops.

`return` matches the other exit in the same select and does not depend on the two contexts being the same value.

## The test

The package had no tests. This one dials a real connection through `httptest` — `Write` closes the socket on its way out, so a nil one panics there — then passes a context that is deliberately *not* the client's and cancels the client. Against the old code:

```
ws_test.go:76: Write did not return after the client context was cancelled
FAIL (2.00s)
```

## Third of its kind

This is the same shape as `config.run`'s retry (#119) and the memory loader's (#118): a loop whose exit depends on something other than the signal that is supposed to end it. All three were in different subsystems and none was found by the same means.

`make ci` green.
