### PR TITLE
fix🐛: a file helper that returns closed files, and two that exit the process

### DIFF
--- a/sdk/pkg/utils/file.go
+++ b/sdk/pkg/utils/file.go
@@ -2,8 +2,8 @@ package utils
 
 import (
 	"errors"
+	"io"
 	"io/ioutil"
-	"log"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -62,9 +62,11 @@ func MkDir(src string) error {
 }
 
 // Open 打开文件
+//
+// The caller owns the file and closes it. Closing it here — which a deferred
+// call did — handed back a file that was already closed.
 func Open(name string, flag int, perm os.FileMode) (*os.File, error) {
 	f, err := os.OpenFile(name, flag, perm)
-	defer f.Close()
 	if err != nil {
 		return nil, err
 	}
@@ -75,27 +77,26 @@ func Open(name string, flag int, perm os.FileMode) (*os.File, error) {
 // GetImgType 获取Img文件类型
 func GetImgType(p string) (string, error) {
 	file, err := os.Open(p)
-	defer file.Close()
 	if err != nil {
-		log.Println(err)
-		os.Exit(1)
+		return "", err
 	}
+	defer file.Close()
 
 	buff := make([]byte, 512)
 
-	_, err = file.Read(buff)
-
-	if err != nil {
-		log.Println(err)
-		os.Exit(1)
+	// DetectContentType is given what was actually read: a file shorter than
+	// the buffer used to be padded with zeroes and detected as those.
+	n, err := file.Read(buff)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
 	}
 
-	filetype := http.DetectContentType(buff)
+	filetype := http.DetectContentType(buff[:n])
 
 	ext := imgext.Get()
 
 	for i := 0; i < len(ext); i++ {
-		if strings.Contains(ext[i], filetype[6:len(filetype)]) {
+		if strings.Contains(ext[i], filetype[6:]) {
 			return filetype, nil
 		}
 	}
@@ -106,21 +107,19 @@ func GetImgType(p string) (string, error) {
 // GetType 获取文件类型
 func GetType(p string) (string, error) {
 	file, err := os.Open(p)
-	defer file.Close()
 	if err != nil {
-		log.Println(err)
-		os.Exit(1)
+		return "", err
 	}
+	defer file.Close()
 
 	buff := make([]byte, 512)
 
-	_, err = file.Read(buff)
-
-	if err != nil {
-		log.Println(err)
+	n, err := file.Read(buff)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return "", err
 	}
 
-	filetype := http.DetectContentType(buff)
+	filetype := http.DetectContentType(buff[:n])
 
 	//ext := GetExt(p)
 	//var list = strings.Split(filetype, "/")

--- a/sdk/pkg/utils/file_test.go
+++ b/sdk/pkg/utils/file_test.go
@@ -1,15 +1,110 @@
 package utils
 
 import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
-// TestIsNotExistMkDir 测试IsNotExistMkDir函数
-func TestIsNotExistMkDir(t *testing.T) {
-	err := IsNotExistMkDir("../../pkg/aaa")
+// A 1x1 PNG, which is enough for http.DetectContentType and short enough to
+// prove the detector is given what was read rather than a padded buffer.
+const onePixelPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+
+func writePNG(t *testing.T, dir string) string {
+	t.Helper()
+
+	raw, err := base64.StdEncoding.DecodeString(onePixelPNG)
 	if err != nil {
-		t.Error(err)
-	} else {
-		t.Log("done")
+		t.Fatalf("decode: %v", err)
 	}
+	p := filepath.Join(dir, "pixel.png")
+	if err := os.WriteFile(p, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// Open deferred a Close on the file it was about to return, so every caller
+// received one that was already closed.
+func TestOpenReturnsAFileTheCallerCanUse(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f")
+
+	f, err := Open(p, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString("still open"); err != nil {
+		t.Fatalf("writing to the returned file: %v", err)
+	}
+}
+
+func TestOpenReportsAMissingFile(t *testing.T) {
+	f, err := Open(filepath.Join(t.TempDir(), "absent"), os.O_RDONLY, 0o600)
+	if err == nil {
+		_ = f.Close()
+		t.Fatal("Open on an absent file returned no error")
+	}
+	if f != nil {
+		t.Error("Open returned both an error and a file")
+	}
+}
+
+// Both detectors called os.Exit on a file they could not open, which ends the
+// caller's process rather than the call. A test cannot catch that from inside
+// — the binary simply stops — so a run against the old code fails outright,
+// which is the observation.
+func TestDetectorsReportAMissingFileInsteadOfExiting(t *testing.T) {
+	absent := filepath.Join(t.TempDir(), "absent")
+
+	if _, err := GetType(absent); err == nil {
+		t.Error("GetType on an absent file returned no error")
+	}
+	if _, err := GetImgType(absent); err == nil {
+		t.Error("GetImgType on an absent file returned no error")
+	}
+}
+
+func TestGetTypeAndGetImgType(t *testing.T) {
+	dir := t.TempDir()
+	png := writePNG(t, dir)
+
+	t.Run("a png is detected as one", func(t *testing.T) {
+		got, err := GetImgType(png)
+		if err != nil {
+			t.Fatalf("GetImgType: %v", err)
+		}
+		if got != "image/png" {
+			t.Errorf("GetImgType = %q, want image/png", got)
+		}
+	})
+
+	t.Run("a short text file is not padded into something else", func(t *testing.T) {
+		p := filepath.Join(dir, "short.txt")
+		if err := os.WriteFile(p, []byte("hello"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		got, err := GetType(p)
+		if err != nil {
+			t.Fatalf("GetType: %v", err)
+		}
+		if !strings.HasPrefix(got, "text/plain") {
+			t.Errorf("GetType = %q, want text/plain", got)
+		}
+	})
+
+	t.Run("a text file is not an image", func(t *testing.T) {
+		p := filepath.Join(dir, "note.txt")
+		if err := os.WriteFile(p, []byte("not an image"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		if _, err := GetImgType(p); err == nil {
+			t.Error("GetImgType accepted a text file")
+		}
+	})
 }


### PR DESCRIPTION
Three defects in `sdk/pkg/utils/file.go`, all exported, none reachable from this module or either consumer.

## Open handed back a closed file

```go
func Open(name string, flag int, perm os.FileMode) (*os.File, error) {
	f, err := os.OpenFile(name, flag, perm)
	defer f.Close()
	if err != nil {
		return nil, err
	}
	return f, nil
}
```

The deferred call runs as the function returns, so the caller receives a file that is already closed. Restoring it fails the new test with the defect stated in one line:

```
file_test.go:41: writing to the returned file: ... file already closed
```

Worth noting what that implies: **this function cannot have had a working caller.** Anyone who used it hit the failure on their first read or write. Removing it would have broken nobody, and fixing it breaks nobody either.

## Two detectors called os.Exit on a missing file

```go
file, err := os.Open(p)
defer file.Close()
if err != nil {
	log.Println(err)
	os.Exit(1)
}
```

In a library, for a path that does not exist, ending the caller's process. Both functions already return an `error`; they return it now.

This one cannot be caught from inside a test — the binary stops — so against the old code the run ends rather than reporting. That is its own observation, and it is why the test exists.

## Both detectors read a padded buffer

`http.DetectContentType` was given all 512 bytes regardless of how many were read, so a file shorter than the buffer was detected together with the zeroes behind it. They pass `buff[:n]` now.

The test that pins it is five bytes of text: it only comes back as `text/plain` because the detector sees five bytes rather than five followed by five hundred and seven zeroes.

## Where these came from

staticcheck, as SA5001 — reported for as long as the file has existed. `make lint` is not part of `make ci`, which is the same reason #126 and #128 sat unnoticed.

`make ci` green.
