### PR TITLE
chore🔧: clear the lint backlog, and the defects it was hiding

### DIFF
--- a/config/reader/json/json.go
+++ b/config/reader/json/json.go
@@ -11,8 +11,6 @@ import (
 	"github.com/go-admin-team/go-admin-core/v2/config/source"
 )
 
-const readerTyp = "json"
-
 type jsonReader struct {
 	opts reader.Options
 	json encoder.Encoder

--- a/config/source/env/env_test.go
+++ b/config/source/env/env_test.go
@@ -138,11 +138,3 @@ func containsKey(m map[string]interface{}, s string) bool {
 	}
 	return false
 }
-
-func getKeys(m map[string]interface{}) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}

--- a/sdk/api/request_logger.go
+++ b/sdk/api/request_logger.go
@@ -10,8 +10,6 @@ import (
 	"github.com/go-admin-team/go-admin-core/v2/sdk/pkg"
 )
 
-type loggerKey struct{}
-
 // GetRequestLogger 获取上下文提供的日志
 func GetRequestLogger(c *gin.Context) *logger.Helper {
 	var log *logger.Helper

--- a/sdk/runtime/queue.go
+++ b/sdk/runtime/queue.go
@@ -41,11 +41,17 @@ func (e *Queue) Register(name string, f storage.ConsumerFunc) {
 
 // Append 增加数据到生产者
 func (e *Queue) Append(message storage.Messager) error {
+	// The map has to go back through SetValues. Writing into what GetValues
+	// returned worked only while the message already had one: when it did not,
+	// the prefix went into a map that was attached to nothing and the message
+	// was published without its tenant.
 	values := message.GetValues()
 	if values == nil {
 		values = make(map[string]interface{})
 	}
 	values[storage.PrefixKey] = e.prefix
+	message.SetValues(values)
+
 	return e.queue.Append(message)
 }
 

--- a/sdk/runtime/queue.go
+++ b/sdk/runtime/queue.go
@@ -41,16 +41,12 @@ func (e *Queue) Register(name string, f storage.ConsumerFunc) {
 
 // Append 增加数据到生产者
 func (e *Queue) Append(message storage.Messager) error {
-	// The map has to go back through SetValues. Writing into what GetValues
-	// returned worked only while the message already had one: when it did not,
-	// the prefix went into a map that was attached to nothing and the message
-	// was published without its tenant.
-	values := message.GetValues()
-	if values == nil {
-		values = make(map[string]interface{})
-	}
-	values[storage.PrefixKey] = e.prefix
-	message.SetValues(values)
+	// SetPrefix rather than reaching into the values map: it creates the map
+	// when there is none — which is where the prefix used to be lost — and it
+	// does the whole thing under the message's own lock, where a read through
+	// GetValues followed by a write through SetValues is three separate
+	// acquisitions with the modification sitting outside all of them.
+	message.SetPrefix(e.prefix)
 
 	return e.queue.Append(message)
 }

--- a/sdk/runtime/queue_append_test.go
+++ b/sdk/runtime/queue_append_test.go
@@ -1,0 +1,48 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/storage/queue"
+)
+
+// Append tags the message with the queue's prefix so that a consumer can tell
+// which tenant it came from. It read the values map, created one when it was
+// nil, wrote the prefix into that, and then published the message — which
+// still had no values. A message published without values lost its tenant.
+func TestAppendTagsAMessageThatHasNoValues(t *testing.T) {
+	q := NewQueue("tenant-a", queue.NewMemory(10))
+
+	m := &queue.Message{}
+	if m.GetValues() != nil {
+		t.Fatal("this test needs a message with no values")
+	}
+
+	if err := q.Append(m); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	if got := m.GetPrefix(); got != "tenant-a" {
+		t.Errorf("prefix is %q, want tenant-a: the tag never reached the message", got)
+	}
+}
+
+// The ordinary case, so that a fix cannot work by ignoring what was there.
+func TestAppendKeepsExistingValues(t *testing.T) {
+	q := NewQueue("tenant-b", queue.NewMemory(10))
+
+	m := &queue.Message{}
+	m.SetValues(map[string]interface{}{"id": "7"})
+
+	if err := q.Append(m); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	values := m.GetValues()
+	if values["id"] != "7" {
+		t.Errorf("id is %v, want 7", values["id"])
+	}
+	if got := m.GetPrefix(); got != "tenant-b" {
+		t.Errorf("prefix is %q, want tenant-b", got)
+	}
+}

--- a/sdk/runtime/queue_test.go
+++ b/sdk/runtime/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/go-admin-team/go-admin-core/v2/storage"
 	"github.com/go-admin-team/go-admin-core/v2/storage/queue"
 	"testing"
+	"time"
 )
 
 func TestNewMemoryQueue(t *testing.T) {
@@ -36,14 +37,35 @@ func TestNewMemoryQueue(t *testing.T) {
 	}
 }
 
+// Register forwards to the backing adapter, so what this checks is that a
+// consumer registered through the wrapper receives what is published through
+// it. The test was a stub — two type declarations and no body — which reads as
+// coverage from the outside.
 func TestQueue_Register(t *testing.T) {
-	type fields struct {
-		prefix string
-		queue  storage.AdapterQueue
-	}
-	type args struct {
-		name string
-		f    storage.ConsumerFunc
+	q := NewQueue("tenant", queue.NewMemory(10))
+
+	got := make(chan storage.Messager, 1)
+	q.Register("orders", func(m storage.Messager) error {
+		got <- m
+		return nil
+	})
+
+	m := &queue.Message{}
+	m.SetValues(map[string]interface{}{"id": "1"})
+	m.SetStream("orders")
+	if err := q.Append(m); err != nil {
+		t.Fatalf("Append: %v", err)
 	}
 
+	go q.Run()
+	t.Cleanup(func() { q.Shutdown() })
+
+	select {
+	case received := <-got:
+		if received.GetPrefix() != "tenant" {
+			t.Errorf("prefix is %q, want tenant", received.GetPrefix())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the registered consumer never received the message")
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -25,7 +25,6 @@ type Server struct {
 	internalCancel         context.CancelFunc
 	internalProceduresStop chan struct{}
 	shutdownCtx            context.Context
-	shutdownCancel         context.CancelFunc
 	logger                 *logger.Helper
 	opts                   options
 }

--- a/storage/cache/memory.go
+++ b/storage/cache/memory.go
@@ -114,9 +114,6 @@ func (*Memory) String() string {
 	return "memory"
 }
 
-func (m *Memory) connect() {
-}
-
 func (m *Memory) Get(key string) (string, error) {
 	item, err := m.getItem(key)
 	if err != nil || item == nil {

--- a/tools/gorm/gormlog/logger.go
+++ b/tools/gorm/gormlog/logger.go
@@ -130,24 +130,6 @@ func (l gormLogger) Trace(ctx context.Context, begin time.Time, fc func() (strin
 	}
 }
 
-type traceRecorder struct {
-	logger.Interface
-	BeginAt      time.Time
-	SQL          string
-	RowsAffected int64
-	Err          error
-}
-
-func (l traceRecorder) New() *traceRecorder {
-	return &traceRecorder{Interface: l.Interface, BeginAt: time.Now()}
-}
-
-func (l *traceRecorder) Trace(ctx context.Context, begin time.Time, fc func() (string, int64), err error) {
-	l.BeginAt = begin
-	l.SQL, l.RowsAffected = fc()
-	l.Err = err
-}
-
 func New(config logger.Config) logger.Interface {
 	var (
 		infoStr      = "%s\n[info] "


### PR DESCRIPTION
The lint backlog, and two defects it was hiding.

## The stub test

```go
func TestQueue_Register(t *testing.T) {
	type fields struct { ... }
	type args struct { ... }

}
```

Two type declarations and no body. staticcheck reported the types as unused, which is the only reason it surfaced — from the outside a test with a name and no assertions reads as coverage.

Writing the real one found this:

```go
values := message.GetValues()
if values == nil {
	values = make(map[string]interface{})
}
values[storage.PrefixKey] = e.prefix
return e.queue.Append(message)      // message still has no values
```

`Append` tags a message with the queue's prefix so a consumer can tell which tenant it came from. When the message arrived without values, the prefix went into a map attached to nothing, and the message was published without its tenant — silently, with `GetPrefix()` returning empty. It worked at all only because callers usually set values first.

```
queue_append_test.go:26: prefix is "", want tenant-a: the tag never reached the message
```

The ordinary case is tested beside it, so that a fix which discarded existing values would still fail.

## What was deleted

Eight symbols nothing reaches: a const, a test helper, a context key type left from a move to string keys, an empty method, a struct field shadowed by a local of the same name, and a gorm trace recorder with its two methods.

## What was not, and why

Three symbols staticcheck calls unused are the working half of a feature that was never wired:

| symbol | what it would do |
| --- | --- |
| `casbin.updateCallback` | reload the policy when a watcher fires |
| `sdk/api.getAcceptLanguage` | read and parse `Accept-Language` |
| `sdk/api.transInit` | build the zh/en translator for validation errors |

Deleting them removes the evidence that someone meant to build these. They are left in place; making them live is a decision, not a cleanup.

**The casbin one is worth its own look.** `Setup` loads the policy once inside a `sync.Once`, there is no `SetWatcher`, no `SetUpdateCallback` and no `StartAutoLoadPolicy` anywhere — in this module or in either consumer — and `updateCallback` exists to be a watcher's callback. So a permission changed on one instance is invisible to every other until it restarts. The code picked `SyncedEnforcer`, the variant that exists for auto-loading, which says the intent was there.

That matters more now than it used to: the queue and cache work this release rests on was about running more than one instance.

## Count

71 findings before, 57 after. The rest is style plus 26 `SA1019` deprecation warnings, most of them the compatibility layer referring to what it is compatible with — those need an explicit exemption rather than a change, which is the step before `make lint` can join `make ci`.

`make ci` green.
