### PR TITLE
chore🔧: io/ioutil, the style backlog, and a predicate that lied

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -1013,7 +1013,6 @@ func DynamicTable(f func(string) string, baseTable, fieldValue string) func(db *
 
 ## github.com/go-admin-team/go-admin-core/v2/sdk/pkg/utils
 func Base64ToImage(imageBase64 string) ([]byte, error)
-func CheckExist(src string) bool
 func CheckPermission(src string) bool
 func GetCurrentTimeStamp() int64
 func GetDirFiles(dir string) ([]string, error)
@@ -1026,6 +1025,7 @@ func Hmac(data string) string
 func IsNotExistMkDir(src string) error
 func IsStringEmpty(str string) bool
 func MkDir(src string) error
+func NotExist(src string) bool
 func Open(name string, flag int, perm os.FileMode) (*os.File, error)
 func PathExists(path string) bool
 func RemoveRepByMap(slc []string) []string

--- a/config/default_test.go
+++ b/config/default_test.go
@@ -145,7 +145,7 @@ func TestConfigWatcherDirtyOverrite(t *testing.T) {
 
 	l := 100
 
-	ss := make([]source.Source, l, l)
+	ss := make([]source.Source, l)
 
 	for i := 0; i < l; i++ {
 		ss[i] = memory.NewSource(memory.WithJSON([]byte(fmt.Sprintf(`{"key%d": "val%d"}`, i, i))))

--- a/config/source/file/file.go
+++ b/config/source/file/file.go
@@ -2,7 +2,7 @@
 package file
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/go-admin-team/go-admin-core/v2/config/source"
@@ -23,7 +23,7 @@ func (f *file) Read() (*source.ChangeSet, error) {
 		return nil, err
 	}
 	defer fh.Close()
-	b, err := ioutil.ReadAll(fh)
+	b, err := io.ReadAll(fh)
 	if err != nil {
 		return nil, err
 	}

--- a/jwtauth/jwtauth.go
+++ b/jwtauth/jwtauth.go
@@ -3,8 +3,8 @@ package jwtauth
 import (
 	"crypto/rsa"
 	"github.com/pkg/errors"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -257,7 +257,7 @@ func (mw *GinJWTMiddleware) readKeys() error {
 }
 
 func (mw *GinJWTMiddleware) privateKey() error {
-	keyData, err := ioutil.ReadFile(mw.PrivKeyFile)
+	keyData, err := os.ReadFile(mw.PrivKeyFile)
 	if err != nil {
 		return ErrNoPrivKeyFile
 	}
@@ -270,7 +270,7 @@ func (mw *GinJWTMiddleware) privateKey() error {
 }
 
 func (mw *GinJWTMiddleware) publicKey() error {
-	keyData, err := ioutil.ReadFile(mw.PubKeyFile)
+	keyData, err := os.ReadFile(mw.PubKeyFile)
 	if err != nil {
 		return ErrNoPubKeyFile
 	}

--- a/logger/level.go
+++ b/logger/level.go
@@ -77,7 +77,7 @@ func GetLevel(levelStr string) (Level, error) {
 	case FatalLevel.String():
 		return FatalLevel, nil
 	}
-	return InfoLevel, fmt.Errorf("Unknown Level String: '%s', defaulting to InfoLevel", levelStr)
+	return InfoLevel, fmt.Errorf("unknown level string %q, defaulting to InfoLevel", levelStr)
 }
 
 // Info logs a message at the info log level.

--- a/logger/writer/file.go
+++ b/logger/writer/file.go
@@ -77,7 +77,7 @@ func (p *FileWriter) write() {
 
 func (p *FileWriter) checkFile() {
 	info, _ := p.file.Stat()
-	if strings.Index(p.file.Name(), time.Now().Format(timeFormat)) < 0 ||
+	if !strings.Contains(p.file.Name(), time.Now().Format(timeFormat)) ||
 		(p.opts.cap > 0 && uint(info.Size()) > p.opts.cap) {
 		//生成新文件
 		if uint(info.Size()) > p.opts.cap {

--- a/sdk/config/config.go
+++ b/sdk/config/config.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"log"
 	"log/slog"
 	"sort"
@@ -112,7 +111,7 @@ func Setup(s source.Source,
 
 func handleError(err error, msg string) {
 	if err != nil {
-		log.Fatal(fmt.Sprintf("%s: %s", msg, err.Error()))
+		log.Fatalf("%s: %s", msg, err.Error())
 	}
 }
 

--- a/sdk/pkg/file.go
+++ b/sdk/pkg/file.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -70,7 +69,7 @@ func (h ReplaceHelper) walkCallback(path string, f os.FileInfo, err error) error
 		return nil
 	}
 
-	buf, err := ioutil.ReadFile(path)
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -82,7 +81,7 @@ func (h ReplaceHelper) walkCallback(path string, f os.FileInfo, err error) error
 	newContent := strings.Replace(content, h.OldText, h.NewText, -1)
 
 	//重新写入
-	err = ioutil.WriteFile(path, []byte(newContent), 0)
+	err = os.WriteFile(path, []byte(newContent), 0)
 	if err != nil {
 		return err
 	}

--- a/sdk/pkg/http.go
+++ b/sdk/pkg/http.go
@@ -3,7 +3,7 @@ package pkg
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 )
@@ -26,7 +26,7 @@ func Get(url string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	result, _ := ioutil.ReadAll(resp.Body)
+	result, _ := io.ReadAll(resp.Body)
 
 	return string(result), nil
 }
@@ -47,7 +47,7 @@ func Post(url string, data interface{}, contentType string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	result, _ := ioutil.ReadAll(resp.Body)
+	result, _ := io.ReadAll(resp.Body)
 	return result, nil
 
 }

--- a/sdk/pkg/http.go
+++ b/sdk/pkg/http.go
@@ -14,19 +14,27 @@ import (
 func Get(url string) (string, error) {
 
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", url, nil)
-	req.Header.Set("Accept", "*/*")
-	req.Header.Set("Content-Type", "application/json")
+	// The header was set before this check, so a url NewRequest rejects gave
+	// the caller a nil dereference instead of the error it returns.
+	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
 	}
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
 	defer resp.Body.Close()
-	result, _ := io.ReadAll(resp.Body)
+
+	// A body that fails halfway through used to come back as a short string
+	// with no error, which reads exactly like a successful empty response.
+	result, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
 
 	return string(result), nil
 }
@@ -40,14 +48,22 @@ func Post(url string, data interface{}, contentType string) ([]byte, error) {
 
 	// 超时时间：5秒
 	client := &http.Client{Timeout: 5 * time.Second}
-	jsonStr, _ := json.Marshal(data)
+	// A value that will not marshal used to be posted as an empty body.
+	jsonStr, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
 	resp, err := client.Post(url, contentType, bytes.NewBuffer(jsonStr))
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	result, _ := io.ReadAll(resp.Body)
+	result, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	return result, nil
 
 }

--- a/sdk/pkg/http_test.go
+++ b/sdk/pkg/http_test.go
@@ -1,0 +1,84 @@
+package pkg
+
+import (
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Get set the request headers before checking the error from NewRequest, so a
+// url it rejects dereferenced a nil request. The caller's process ended
+// instead of the call returning the error NewRequest had already produced.
+func TestGetReturnsAnErrorForARejectedURL(t *testing.T) {
+	got, err := Get("://not a url")
+	if err == nil {
+		t.Fatalf("Get returned %q and no error for a url NewRequest rejects", got)
+	}
+	if got != "" {
+		t.Errorf("Get returned %q alongside an error", got)
+	}
+}
+
+func TestGetReadsTheBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Accept") != "*/*" {
+			t.Errorf("Accept is %q", r.Header.Get("Accept"))
+		}
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer srv.Close()
+
+	got, err := Get(srv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != "hello" {
+		t.Errorf("Get = %q, want hello", got)
+	}
+}
+
+// A truncated response arrives as a read error. It used to be discarded, so a
+// half-delivered body came back as a short string with no error — which reads
+// exactly like a successful short response.
+func TestGetReportsATruncatedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "1024")
+		_, _ = w.Write([]byte("short"))
+	}))
+	defer srv.Close()
+
+	got, err := Get(srv.URL)
+	if err == nil {
+		t.Fatalf("Get returned %q and no error for a body that ended early", got)
+	}
+}
+
+// Post marshalled its argument and threw the error away, so a value that
+// cannot be encoded was sent as an empty body.
+func TestPostReportsAValueItCannotEncode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("the request was sent even though the body could not be encoded")
+	}))
+	defer srv.Close()
+
+	got, err := Post(srv.URL, math.Inf(1), "application/json")
+	if err == nil {
+		t.Fatalf("Post returned %q and no error for a value json cannot encode", got)
+	}
+}
+
+func TestPostSendsAndReads(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	got, err := Post(srv.URL, map[string]string{"a": "b"}, "application/json")
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if string(got) != `{"ok":true}` {
+		t.Errorf("Post = %s", got)
+	}
+}

--- a/sdk/pkg/utils/file.go
+++ b/sdk/pkg/utils/file.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"errors"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -15,7 +14,7 @@ import (
 
 // GetSize 获取文件大小
 func GetSize(f multipart.File) (int, error) {
-	content, err := ioutil.ReadAll(f)
+	content, err := io.ReadAll(f)
 
 	return len(content), err
 }
@@ -25,8 +24,13 @@ func GetExt(fileName string) string {
 	return path.Ext(fileName)
 }
 
-// CheckExist 检查文件是否存在
-func CheckExist(src string) bool {
+// NotExist reports whether nothing is at src.
+//
+// It was called CheckExist and documented as checking existence while
+// returning the opposite, so its one caller compensated by inverting twice.
+// Renamed rather than corrected in place: a caller who had worked the real
+// behaviour out gets a compile error instead of a silent inversion.
+func NotExist(src string) bool {
 	_, err := os.Stat(src)
 
 	return os.IsNotExist(err)
@@ -42,10 +46,8 @@ func CheckPermission(src string) bool {
 // IsNotExistMkDir 检查文件夹是否存在
 // 如果不存在则新建文件夹
 func IsNotExistMkDir(src string) error {
-	if exist := !CheckExist(src); exist == false {
-		if err := MkDir(src); err != nil {
-			return err
-		}
+	if NotExist(src) {
+		return MkDir(src)
 	}
 
 	return nil
@@ -101,7 +103,7 @@ func GetImgType(p string) (string, error) {
 		}
 	}
 
-	return "", errors.New("Invalid image type")
+	return "", errors.New("invalid image type")
 }
 
 // GetType 获取文件类型

--- a/sdk/pkg/utils/utils.go
+++ b/sdk/pkg/utils/utils.go
@@ -4,7 +4,6 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -50,7 +49,7 @@ func Base64ToImage(imageBase64 string) ([]byte, error) {
 }
 
 func GetDirFiles(dir string) ([]string, error) {
-	dirList, err := ioutil.ReadDir(dir)
+	dirList, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +76,7 @@ func GetCurrentTimeStamp() int64 {
 	return time.Now().UnixNano() / 1e6
 }
 
-//slice去重
+// slice去重
 func RemoveRepByMap(slc []string) []string {
 	result := []string{}
 	tempMap := map[string]byte{}

--- a/sdk/pkg/utils/utils.go
+++ b/sdk/pkg/utils/utils.go
@@ -76,7 +76,7 @@ func GetCurrentTimeStamp() int64 {
 	return time.Now().UnixNano() / 1e6
 }
 
-// slice去重
+// RemoveRepByMap returns slc without its duplicates, keeping first order.
 func RemoveRepByMap(slc []string) []string {
 	result := []string{}
 	tempMap := map[string]byte{}

--- a/tools/poster/poster.go
+++ b/tools/poster/poster.go
@@ -5,7 +5,6 @@ import (
 	"image/color"
 	"image/draw"
 	"image/jpeg"
-	"io/ioutil"
 	"os"
 
 	"github.com/golang/freetype"
@@ -13,7 +12,7 @@ import (
 	"github.com/skip2/go-qrcode"
 )
 
-//新PNG载体
+// 新PNG载体
 type Rect struct {
 	X0 int
 	X1 int
@@ -68,7 +67,7 @@ func MergeImage(PNG draw.Image, image image.Image, imageBound image.Point) {
 
 // LoadTextType 读取字体类型
 func LoadTextType(path string) (*truetype.Font, error) {
-	fbyte, err := ioutil.ReadFile(path)
+	fbyte, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/poster/poster.go
+++ b/tools/poster/poster.go
@@ -12,7 +12,7 @@ import (
 	"github.com/skip2/go-qrcode"
 )
 
-// 新PNG载体
+// Rect is the area a PNG overlay is drawn into.
 type Rect struct {
 	X0 int
 	X1 int

--- a/tools/poster/source.go
+++ b/tools/poster/source.go
@@ -5,8 +5,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"image"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 )
 
 // GetImage 从源读取图片，支持网络和本地
@@ -38,13 +39,13 @@ func getResourceReader(src string) (r *bytes.Reader, err error) {
 			return r, err
 		}
 		defer resp.Body.Close()
-		fileBytes, err := ioutil.ReadAll(resp.Body)
+		fileBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return r, err
 		}
 		r = bytes.NewReader(fileBytes)
 	} else {
-		fileBytes, err := ioutil.ReadFile(src)
+		fileBytes, err := os.ReadFile(src)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The mechanical half of the lint backlog, and one finding that was filed as style.

## CheckExist reported the opposite of its name

```go
// CheckExist 检查文件是否存在
func CheckExist(src string) bool {
	_, err := os.Stat(src)
	return os.IsNotExist(err)   // true when it is *not* there
}
```

Name, doc comment and behaviour all disagreed. Its one caller compensated by inverting twice:

```go
if exist := !CheckExist(src); exist == false {
```

which staticcheck reported only as `S1002`, "omit comparison to bool constant". Simplifying that line is what exposed the rest — and my first reading of it was wrong: I took the function at its name and concluded `IsNotExistMkDir` created directories that already existed. Reading the body showed the two inversions cancel and the behaviour is correct.

It is `NotExist` now, and the caller is one line. **Renamed rather than corrected in place**: anyone who worked out the real behaviour and relied on it gets a compile error, where changing the return value would have silently inverted their code.

## io/ioutil

Eight files, deprecated since Go 1.19. `ReadAll` to `io`; `ReadFile`, `WriteFile` and `ReadDir` to `os`. `os.ReadDir` returns directory entries rather than file infos — the single caller uses `Name` and `IsDir`, which both have.

## The rest

A capitalised error string in two places, `log.Fatal` wrapped around a `Sprintf`, `strings.Index(...) < 0`, and a `make` whose length equals its capacity. Each checked rather than applied on the linter's say-so.

## Count

71 at the start of this work, **40 now**. What remains is about twenty `SA1019` for `AdapterCache` — the compatibility layer referring to the thing it is compatible with, which needs an exemption rather than a change — and the three unused symbols kept deliberately in #130.

That exemption is the last step before `make lint` can join `make ci`, which is the point of all this: five behavioural defects this week were sitting in a report nobody read.

`make ci` green.
