### PR TITLE
fix🐛: wire the two features that were written but never called

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -794,6 +794,7 @@ var Runtime runtime.Runtime = runtime.NewConfig()
 var DefaultLanguage = "zh-CN"
 func GetRequestLogger(c *gin.Context) *logger.Helper
 func SetRequestLogger(c *gin.Context)
+func TranslateValidationErrors(err error, locale string) error
 type Api struct {
 	Context *gin.Context
 	Logger  *logger.Helper

--- a/api/core.txt
+++ b/api/core.txt
@@ -9,7 +9,9 @@ func SetStore(s base64Captcha.Store)
 func Verify(id, code string, clear bool) bool
 
 ## github.com/go-admin-team/go-admin-core/v2/casbin
+var ReloadInterval = time.Minute
 func Setup(db *gorm.DB, _ string) *casbin.SyncedEnforcer
+func UpdateCallback(msg string)
 type Logger struct {
 func (l *Logger) EnableLog(enable bool)
 func (l *Logger) IsEnabled() bool

--- a/casbin/mycasbin.go
+++ b/casbin/mycasbin.go
@@ -2,6 +2,7 @@ package mycasbin
 
 import (
 	"sync"
+	"time"
 
 	"github.com/casbin/casbin/v3"
 	"github.com/casbin/casbin/v3/model"
@@ -25,6 +26,15 @@ e = some(where (p.eft == allow))
 [matchers]
 m = r.sub == p.sub && (keyMatch2(r.obj, p.obj) || keyMatch(r.obj, p.obj)) && (r.act == p.act || p.act == "*")
 `
+
+// ReloadInterval is how often the shared enforcer reloads its policy from the
+// database.
+//
+// A policy written on one instance reaches the others no other way: the
+// adapter writes to the database, and every other process keeps serving what
+// it loaded at startup. Set this to zero before the first Setup to opt out —
+// a single-instance deployment gains nothing from the query.
+var ReloadInterval = time.Minute
 
 var (
 	enforcer *casbin.SyncedEnforcer
@@ -51,20 +61,29 @@ func Setup(db *gorm.DB, _ string) *casbin.SyncedEnforcer {
 			panic(err)
 		}
 
+		// Without this the policy is whatever it was at startup. updateCallback
+		// below is written for a watcher, which would make this immediate
+		// rather than periodic; polling needs no second piece of infrastructure
+		// and closes the gap today.
+		if ReloadInterval > 0 {
+			enforcer.StartAutoLoadPolicy(ReloadInterval)
+		}
+
 		// Casbin v3: 日志默认已启用，无需 EnableLog()
 	})
 
 	return enforcer
 }
 
-// registered anywhere — no SetWatcher, no SetUpdateCallback, no
-// StartAutoLoadPolicy, in this module or in any consumer. Setup loads the
-// policy once inside a sync.Once, so a permission changed on one instance is
-// invisible to every other until it restarts. Kept because deleting it would
-// take the evidence of the missing wiring with it.
+// UpdateCallback reloads the policy, for use as a watcher's update callback.
 //
-//lint:ignore U1000 This is the callback for a policy watcher that is not
-func updateCallback(msg string) {
+// Setup polls instead, which needs no broker. A deployment that already has
+// one can register a watcher against this and have the change arrive at once
+// rather than within ReloadInterval:
+//
+//	enforcer.SetWatcher(w)
+//	w.SetUpdateCallback(mycasbin.UpdateCallback)
+func UpdateCallback(msg string) {
 	l := logger.NewHelper(sdk.Runtime.GetLogger())
 	l.Infof("casbin updateCallback msg: %v", msg)
 	err := enforcer.LoadPolicy()

--- a/casbin/mycasbin_test.go
+++ b/casbin/mycasbin_test.go
@@ -1,0 +1,56 @@
+package mycasbin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// A policy written by another instance reaches this one only through a reload.
+// Setup used to load once and never again, so a permission granted on one
+// process stayed invisible to every other until it restarted.
+//
+// The write here goes straight to the table, which is what the other instance's
+// adapter would have done.
+func TestSetupReloadsPolicyWrittenElsewhere(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ReloadInterval = 50 * time.Millisecond
+	e := Setup(db, "")
+
+	const sub, obj, act = "alice", "/data", "GET"
+
+	allowed, err := e.Enforce(sub, obj, act)
+	if err != nil {
+		t.Fatalf("Enforce: %v", err)
+	}
+	if allowed {
+		t.Fatal("the policy is empty and the request was allowed")
+	}
+
+	if err := db.Exec(
+		`INSERT INTO casbin_rule (ptype, v0, v1, v2) VALUES (?, ?, ?, ?)`,
+		"p", sub, obj, act,
+	).Error; err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		allowed, err = e.Enforce(sub, obj, act)
+		if err != nil {
+			t.Fatalf("Enforce: %v", err)
+		}
+		if allowed {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Error("a policy written outside this process never arrived: the enforcer is not reloading")
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-gonic/gin v1.11.0
+	github.com/glebarez/sqlite v1.11.0
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.27.0
@@ -58,7 +59,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
-	github.com/glebarez/sqlite v1.11.0 // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect

--- a/sdk/api/api.go
+++ b/sdk/api/api.go
@@ -88,7 +88,9 @@ func (e *Api) Bind(d interface{}, bindings ...binding.Binding) *Api {
 			continue
 		}
 		if err != nil {
-			e.AddError(err)
+			// Validation failures are rendered in the language the request
+			// asked for. Everything else is passed through untouched.
+			e.AddError(TranslateValidationErrors(err, e.getAcceptLanguage()))
 			break
 		}
 		validated = true
@@ -98,7 +100,7 @@ func (e *Api) Bind(d interface{}, bindings ...binding.Binding) *Api {
 	// required would be bypassed entirely (issue #81).
 	if !validated && e.Errors == nil {
 		if err = validate(d); err != nil {
-			e.AddError(err)
+			e.AddError(TranslateValidationErrors(err, e.getAcceptLanguage()))
 		}
 	}
 	//vd.SetErrorFactory(func(failPath, msg string) error {
@@ -169,12 +171,8 @@ func (e Api) Translate(form, to interface{}) {
 	pkg.Translate(form, to)
 }
 
-// getAcceptLanguage 获取当前语言
-// reads the header, transInit builds the translator, and nothing calls either.
-// Validation errors come back in the validator's default language regardless
-// of what the client asked for.
-//
-//lint:ignore U1000 Half of a translation feature that was never wired: this
+// getAcceptLanguage reports the language the request asked for, falling back
+// to DefaultLanguage.
 func (e Api) getAcceptLanguage() string {
 	languages := language.ParseAcceptLanguage(e.Context.GetHeader("Accept-Language"), nil)
 	if len(languages) == 0 {

--- a/sdk/api/translate.go
+++ b/sdk/api/translate.go
@@ -8,7 +8,9 @@
 package api
 
 import (
-	"fmt"
+	"errors"
+	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/locales/en"
@@ -19,34 +21,74 @@ import (
 	chTranslations "github.com/go-playground/validator/v10/translations/zh"
 )
 
-// transInit local 通常取决于 http 请求头的 'Accept-Language'
-// getAcceptLanguage in api.go.
-//
-//lint:ignore U1000 The other half of the unwired translation feature; see
-func transInit(local string) (trans ut.Translator, err error) {
-	if v, ok := binding.Validator.Engine().(*validator.Validate); ok {
-		zhT := zh.New() //chinese
-		enT := en.New() //english
-		uni := ut.New(enT, zhT, enT)
+// translators are built once. transInit rebuilt them on every call and
+// registered them onto the process-wide validator each time, which is both
+// wasted work and a write to shared state from a request goroutine.
+var (
+	transOnce   sync.Once
+	translators map[string]ut.Translator
+)
 
-		var o bool
-		//register translate
-		// 注册翻译器
-		switch local {
-		case "zh", "zh-CN":
-			trans, o = uni.GetTranslator("zh")
-			if !o {
-				return nil, fmt.Errorf("uni.GetTranslator(%s) failed", "zh")
-			}
-			err = chTranslations.RegisterDefaultTranslations(v, trans)
-		default:
-			trans, o = uni.GetTranslator("en")
-			if !o {
-				return nil, fmt.Errorf("uni.GetTranslator(%s) failed", "en")
-			}
-			err = enTranslations.RegisterDefaultTranslations(v, trans)
-		}
+func buildTranslators() {
+	v, ok := binding.Validator.Engine().(*validator.Validate)
+	if !ok {
 		return
 	}
-	return
+
+	zhT, enT := zh.New(), en.New()
+	uni := ut.New(enT, zhT, enT)
+
+	translators = make(map[string]ut.Translator, 2)
+	for tag, register := range map[string]func(*validator.Validate, ut.Translator) error{
+		"zh": chTranslations.RegisterDefaultTranslations,
+		"en": enTranslations.RegisterDefaultTranslations,
+	} {
+		t, found := uni.GetTranslator(tag)
+		if !found {
+			continue
+		}
+		if err := register(v, t); err != nil {
+			continue
+		}
+		translators[tag] = t
+	}
+}
+
+// translatorFor returns the translator for a locale tag such as zh-cn, falling
+// back to English. A nil result means the process validator is not the one
+// these translations were registered against, in which case the caller keeps
+// the untranslated error rather than losing it.
+func translatorFor(locale string) ut.Translator {
+	transOnce.Do(buildTranslators)
+
+	if t, ok := translators[locale]; ok {
+		return t
+	}
+	if base, _, found := strings.Cut(locale, "-"); found {
+		if t, ok := translators[base]; ok {
+			return t
+		}
+	}
+	return translators["en"]
+}
+
+// TranslateValidationErrors renders validation failures in the language the
+// request asked for. Anything that is not a validation error is returned
+// unchanged.
+func TranslateValidationErrors(err error, locale string) error {
+	var ve validator.ValidationErrors
+	if !errors.As(err, &ve) {
+		return err
+	}
+
+	t := translatorFor(locale)
+	if t == nil {
+		return err
+	}
+
+	msgs := make([]string, 0, len(ve))
+	for _, fe := range ve {
+		msgs = append(msgs, fe.Translate(t))
+	}
+	return errors.New(strings.Join(msgs, "; "))
 }

--- a/sdk/api/translate_test.go
+++ b/sdk/api/translate_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+)
+
+type payload struct {
+	Name string `json:"name" binding:"required"`
+}
+
+// bindWith runs Bind against a request carrying the given Accept-Language and
+// an empty body, which fails the required tag.
+func bindWith(t *testing.T, header string) error {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	if header != "" {
+		req.Header.Set("Accept-Language", header)
+	}
+	c.Request = req
+
+	e := &Api{Context: c}
+	e.Bind(&payload{}, binding.JSON)
+	return e.Errors
+}
+
+// The two halves of this — reading the header and building the translator —
+// were both written and neither was called, so a validation failure came back
+// in the validator's default form whatever the client asked for.
+func TestValidationErrorsFollowAcceptLanguage(t *testing.T) {
+	zh := bindWith(t, "zh-CN")
+	if zh == nil {
+		t.Fatal("an empty body passed a required field")
+	}
+
+	en := bindWith(t, "en")
+	if en == nil {
+		t.Fatal("an empty body passed a required field")
+	}
+
+	if !hasHan(zh.Error()) {
+		t.Errorf("a zh-CN request got %q, which carries no Chinese", zh)
+	}
+	if !strings.Contains(en.Error(), "required") {
+		t.Errorf("an en request got %q, which is not the English message", en)
+	}
+	if zh.Error() == en.Error() {
+		t.Error("both languages produced the same message")
+	}
+}
+
+// The underscore form is what #126 fixed in the parser; this is the path that
+// carries it, so the two are only useful together.
+func TestUnderscoreLocaleReachesTheTranslator(t *testing.T) {
+	got := bindWith(t, "zh_CN")
+	if got == nil {
+		t.Fatal("an empty body passed a required field")
+	}
+	if !hasHan(got.Error()) {
+		t.Errorf("zh_CN got %q, which carries no Chinese", got)
+	}
+}
+
+// No header at all must still produce something a caller can read.
+func TestNoAcceptLanguageStillTranslates(t *testing.T) {
+	got := bindWith(t, "")
+	if got == nil {
+		t.Fatal("an empty body passed a required field")
+	}
+	if strings.Contains(got.Error(), "Key: ") {
+		t.Errorf("got the untranslated validator form: %q", got)
+	}
+}
+
+// hasHan reports whether s carries a Han character. Asked this way rather than
+// by comparing against a literal message: the assertion is that the reply is
+// in Chinese, not that the library words it one particular way — and the
+// literal would be Chinese in a repository that keeps its source in English.
+func hasHan(s string) bool {
+	for _, r := range s {
+		if unicode.Is(unicode.Han, r) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The two features that were written and never wired. #132 exempted them from lint and said making them live was a decision rather than a cleanup; this is that decision taken.

## A policy change reached one instance only

`Setup` loaded the policy once, inside a `sync.Once`, and nothing reloaded it. The adapter writes a permission change to the database; every other process keeps enforcing what it read at startup. Two instances then disagree about who may do what, indefinitely and silently, and the one that made the change is the only one that is right.

That matters more now than it did — the queue and cache work this release rests on was about running more than one instance.

The enforcer polls at `ReloadInterval`, a minute by default, zero to opt out. Polling rather than a watcher because a watcher needs a broker and the gap closes today without one. `updateCallback`, written for that watcher and called from nowhere, is exported as `UpdateCallback` with the two lines needed to register it.

The test opens an in-memory SQLite database, writes a policy **straight to the table** — which is what another instance's adapter would have done — and requires this process to start allowing the request:

```
mycasbin_test.go:55: a policy written outside this process never arrived: the enforcer is not reloading
```

## Validation failures ignored Accept-Language

`getAcceptLanguage` read the header, `transInit` built a zh or en translator, and `Bind` returned what the validator produced by default:

```
Key: 'payload.Name' Error:Field validation for 'Name' failed on the 'required' tag
```

to every client, whatever it asked for. That string is what the counter-proof prints once the call is taken out again.

`transInit` is gone rather than wired as it stood: it rebuilt both locales on every call and registered them onto the process-wide validator each time — wasted work, and a write to shared state from a request goroutine. Translators are built once; `TranslateValidationErrors` renders a failure into one and passes anything that is not a validation error through untouched.

This is the other end of #126. That PR fixed a parser that normalises `zh_CN` to `zh-CN`; nothing consumed the result. A test covers that form for the same reason.

## One note on the test

The Chinese assertion is `unicode.Is(unicode.Han, r)` rather than a literal message. Partly because the claim is that the reply is in Chinese, not that the library words it one particular way — and partly because the literal is Chinese, in a repository whose language gate exists to keep source in English. The gate caught it, correctly.

`make ci` green, including `make lint`.
