### PR TITLE
fix🐛: Get had no timeout at all

### DIFF
--- a/sdk/pkg/http.go
+++ b/sdk/pkg/http.go
@@ -8,14 +8,45 @@ import (
 	"time"
 )
 
+// getTimeout bounds one Get.
+//
+// The client was built as &http.Client{}, whose zero Timeout means no bound at
+// all. DefaultTransport covers only failing to connect — a dial timeout and a
+// TLS handshake timeout — not connecting to something that then never answers,
+// and the second is what happens in production.
+//
+// Get's known caller is the cron HTTP job, which runs it on a goroutine per
+// tick. An endpoint that accepts and stops answering leaks one of those every
+// tick, without limit.
+//
+// Thirty seconds rather than the five Post uses, because the url comes from
+// whatever an operator typed into the job configuration, and such an endpoint
+// often does the work inline rather than acknowledging and returning. Five
+// would turn jobs that currently finish into failures, and the caller retries
+// three times behind a backoff, so a wrong answer here is amplified.
+//
+// This is a behaviour change for a caller that relied on waiting forever —
+// but waiting forever was never a contract, only an unset field.
+const getTimeout = 30 * time.Second
+
 // Get 发送GET请求
 // url：         请求地址
 // response：    请求返回的内容
+//
+// The body is returned as it arrived; the status code is not checked, so an
+// error page comes back as an ordinary result. That is the existing contract
+// and changing it would reach every caller.
 func Get(url string) (string, error) {
+	return get(url, getTimeout)
+}
 
-	client := &http.Client{}
+// get exists so that "there is a timeout" can be tested at all. Exercising it
+// through Get means waiting the full thirty seconds, and a test that slow gets
+// skipped — which would leave the property this fix is about unverified.
+func get(url string, timeout time.Duration) (string, error) {
 	// The header was set before this check, so a url NewRequest rejects gave
-	// the caller a nil dereference instead of the error it returns.
+	// the caller a nil dereference instead of the error it returns — on the
+	// cron goroutine, for a malformed url someone typed into a job.
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", err
@@ -23,6 +54,7 @@ func Get(url string) (string, error) {
 	req.Header.Set("Accept", "*/*")
 	req.Header.Set("Content-Type", "application/json")
 
+	client := &http.Client{Timeout: effectiveTimeout(timeout)}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
@@ -37,6 +69,20 @@ func Get(url string) (string, error) {
 	}
 
 	return string(result), nil
+}
+
+// effectiveTimeout folds anything non-positive into the production constant,
+// so no path reaches an unbounded client.
+//
+// A separate function rather than an if inside get, because that is what makes
+// the property observable: the only difference between falling back and not
+// falling back shows up after thirty seconds, so a test driving get can never
+// see it, while effectiveTimeout(0) == getTimeout is one assertion.
+func effectiveTimeout(d time.Duration) time.Duration {
+	if d <= 0 {
+		return getTimeout
+	}
+	return d
 }
 
 // Post 发送POST请求

--- a/sdk/pkg/http_test.go
+++ b/sdk/pkg/http_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // Get set the request headers before checking the error from NewRequest, so a
@@ -80,5 +81,48 @@ func TestPostSendsAndReads(t *testing.T) {
 	}
 	if string(got) != `{"ok":true}` {
 		t.Errorf("Post = %s", got)
+	}
+}
+
+// The fallback is asserted directly. Driving it through get cannot see it: an
+// unbounded client and a thirty-second one behave identically for every
+// response that arrives, and the only case that separates them takes thirty
+// seconds to reach.
+func TestEffectiveTimeoutNeverYieldsAnUnboundedClient(t *testing.T) {
+	for _, d := range []time.Duration{0, -time.Second} {
+		if got := effectiveTimeout(d); got != getTimeout {
+			t.Errorf("effectiveTimeout(%v) = %v, want %v", d, got, getTimeout)
+		}
+	}
+	if got := effectiveTimeout(time.Second); got != time.Second {
+		t.Errorf("effectiveTimeout(1s) = %v, want it left alone", got)
+	}
+}
+
+// A server that accepts and never answers is what the timeout is for. Without
+// one the request never returns and the caller's goroutine is gone for good.
+func TestGetGivesUpOnAServerThatNeverAnswers(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer func() {
+		close(block)
+		srv.Close()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := get(srv.URL, 200*time.Millisecond)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("a request to a server that never answered returned no error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the request never came back: there is no bound on it")
 	}
 }


### PR DESCRIPTION
`Get` built its client as `&http.Client{}`. A zero `Timeout` means **no bound on the request**. `DefaultTransport` covers only failing to connect — a dial timeout and a TLS handshake timeout — not connecting to something that then never answers, which is the case production actually produces.

`Get`'s known caller is the cron HTTP job: one goroutine per tick. An endpoint that accepts and stops answering leaks one of those every tick, without limit, and the process never gets them back.

## How it was missed

This fix existed on a branch that never merged. **The private consumer pins that commit directly**, so it has been running with the bound while v2 shipped without it — and #131 fixed the nil dereference and the swallowed read error *in the same function* without noticing the missing one.

Two independent fixes to one function, neither aware of the other. Worth saying out loud: the branch was never merged and nothing pointed at it.

## Thirty seconds, not Post's five

The url is whatever an operator typed into a job configuration, and endpoints reached that way often do the work inline rather than acknowledging and returning. Five seconds would turn jobs that currently finish into failures — and the caller retries three times behind a backoff, so a wrong answer here is multiplied rather than absorbed.

This does change behaviour for a caller relying on waiting forever. Waiting forever was never a contract; it was an unset field.

## Testing a timeout

`get(url, timeout)` is unexported and exists only so the property can be reached: driving it through `Get` means waiting the full thirty seconds, and a test that slow gets skipped — leaving the thing this fixes unverified.

`effectiveTimeout` is a separate function for the same reason. The difference between falling back to thirty seconds and not falling back shows up only *after* thirty seconds, so no test driving `get` can observe it, while `effectiveTimeout(0) == getTimeout` is one assertion.

Both counter-proved separately:

| removed | result |
| --- | --- |
| the fallback | `effectiveTimeout(0s) = 0s, want 30s` |
| the timeout | `the request never came back: there is no bound on it` |

`make ci` green.
