### PR TITLE
fix🐛: a claim is whatever the token said it was

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -313,6 +313,7 @@ func (mw *GinJWTMiddleware) TokenGenerator(data interface{}) (string, time.Time,
 type MapClaims map[string]interface{}
 func ExtractClaims(c *gin.Context) MapClaims
 func ExtractClaimsFromToken(token *jwt.Token) MapClaims
+func (m MapClaims) Int64(key string) (int64, bool)
 
 ## github.com/go-admin-team/go-admin-core/v2/jwtauth/user
 func ExtractClaims(c *gin.Context) jwt.MapClaims

--- a/api/core.txt
+++ b/api/core.txt
@@ -242,7 +242,7 @@ var (
 	ErrExpiredToken = errors.New("token is expired")
 	ErrEmptyAuthHeader = errors.New("auth header is empty")
 	ErrMissingExpField = errors.New("missing exp field")
-	ErrWrongFormatOfExp = errors.New("exp must be float64 format")
+	ErrWrongFormatOfExp = errors.New("exp is not a number")
 	ErrInvalidClaims = errors.New("invalid token claims")
 	ErrMissingOrigIatField = errors.New("missing orig_iat field")
 	ErrInvalidAuthHeader = errors.New("auth header is invalid")

--- a/jwtauth/claims.go
+++ b/jwtauth/claims.go
@@ -1,0 +1,36 @@
+package jwtauth
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// Int64 reads a numeric claim without asserting how it was encoded.
+//
+// A claim arrives as whatever the JSON decoder produced. A number is a float64
+// by default and a json.Number when the parser was given WithJSONNumber; a
+// caller that built the claims itself may have left an int. A bare type
+// assertion panics on every case but the one it names, over a token whose shape
+// a caller can influence.
+//
+// float64 is also why an identity above 2^53 cannot survive the trip: it has no
+// exact representation at that size, which is where snowflake ids live.
+// json.Number keeps the digits.
+func (m MapClaims) Int64(key string) (int64, bool) {
+	switch n := m[key].(type) {
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	case float64:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case string:
+		i, err := strconv.ParseInt(n, 10, 64)
+		return i, err == nil
+	default:
+		return 0, false
+	}
+}

--- a/jwtauth/claims.go
+++ b/jwtauth/claims.go
@@ -2,6 +2,7 @@ package jwtauth
 
 import (
 	"encoding/json"
+	"math"
 	"strconv"
 )
 
@@ -22,6 +23,14 @@ func (m MapClaims) Int64(key string) (int64, bool) {
 		i, err := n.Int64()
 		return i, err == nil
 	case float64:
+		// Converting a float64 that does not fit an int64 is undefined, and in
+		// practice yields MaxInt64 - so 1e300 and +Inf both read as a valid
+		// identity. A fractional value would be silently truncated, and NaN
+		// reads as zero, which several callers treat as "no user". None of
+		// those is a number this claim can hold.
+		if n != math.Trunc(n) || n < math.MinInt64 || n >= math.MaxInt64 {
+			return 0, false
+		}
 		return int64(n), true
 	case int:
 		return int64(n), true

--- a/jwtauth/claims_test.go
+++ b/jwtauth/claims_test.go
@@ -1,0 +1,41 @@
+package jwtauth
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMapClaimsInt64ReadsEveryEncodingANumberArrivesIn(t *testing.T) {
+	claims := MapClaims{
+		"decoded":  json.Number("9007199254740993"),
+		"float":    float64(1755000000),
+		"int":      7,
+		"int64":    int64(9007199254740993),
+		"string":   "42",
+		"garbage":  []string{"not a number"},
+		"unparsed": "twelve",
+	}
+
+	for key, want := range map[string]int64{
+		"decoded": 9007199254740993,
+		"float":   1755000000,
+		"int":     7,
+		"int64":   9007199254740993,
+		"string":  42,
+	} {
+		got, ok := claims.Int64(key)
+		if !ok {
+			t.Errorf("%s: not read", key)
+			continue
+		}
+		if got != want {
+			t.Errorf("%s: got %d, want %d", key, got, want)
+		}
+	}
+
+	for _, key := range []string{"garbage", "unparsed", "absent"} {
+		if _, ok := claims.Int64(key); ok {
+			t.Errorf("%s: read as a number", key)
+		}
+	}
+}

--- a/jwtauth/claims_test.go
+++ b/jwtauth/claims_test.go
@@ -2,6 +2,7 @@ package jwtauth
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 )
 
@@ -37,5 +38,28 @@ func TestMapClaimsInt64ReadsEveryEncodingANumberArrivesIn(t *testing.T) {
 		if _, ok := claims.Int64(key); ok {
 			t.Errorf("%s: read as a number", key)
 		}
+	}
+}
+
+// A float64 that is not an integer in range is not a number this claim can
+// hold. Converting one is undefined and yields MaxInt64 in practice, so 1e300
+// used to read as a valid identity; NaN used to read as zero, which several
+// callers treat as no user at all.
+func TestMapClaimsInt64RejectsFloatsThatAreNotIdentities(t *testing.T) {
+	for name, v := range map[string]float64{
+		"fractional":       3.14,
+		"nan":              math.NaN(),
+		"positive inf":     math.Inf(1),
+		"negative inf":     math.Inf(-1),
+		"far above range":  1e300,
+		"just above range": math.MaxInt64,
+	} {
+		if got, ok := (MapClaims{"identity": v}).Int64("identity"); ok {
+			t.Errorf("%s (%v) read as %d", name, v, got)
+		}
+	}
+
+	if got, ok := (MapClaims{"identity": float64(1755000000)}).Int64("identity"); !ok || got != 1755000000 {
+		t.Errorf("an ordinary integral float64 must still read: %d, %v", got, ok)
 	}
 }

--- a/jwtauth/jwtauth.go
+++ b/jwtauth/jwtauth.go
@@ -171,8 +171,8 @@ var (
 	// ErrMissingExpField missing exp field in token
 	ErrMissingExpField = errors.New("missing exp field")
 
-	// ErrWrongFormatOfExp field must be float64 format
-	ErrWrongFormatOfExp = errors.New("exp must be float64 format")
+	// ErrWrongFormatOfExp exp is present but is not a number
+	ErrWrongFormatOfExp = errors.New("exp is not a number")
 
 	// ErrInvalidClaims indicates the token claims are not of the expected type
 	ErrInvalidClaims = errors.New("invalid token claims")

--- a/jwtauth/jwtauth.go
+++ b/jwtauth/jwtauth.go
@@ -720,7 +720,7 @@ func (mw *GinJWTMiddleware) ParseToken(c *gin.Context) (*jwt.Token, error) {
 		c.Set("JWT_TOKEN", token)
 
 		return mw.Key, nil
-	})
+	}, jwt.WithJSONNumber())
 }
 
 // ParseTokenString parse jwt token string
@@ -734,7 +734,7 @@ func (mw *GinJWTMiddleware) ParseTokenString(token string) (*jwt.Token, error) {
 		}
 
 		return mw.Key, nil
-	})
+	}, jwt.WithJSONNumber())
 }
 
 func (mw *GinJWTMiddleware) unauthorized(c *gin.Context, code int, message string) {

--- a/jwtauth/jwtauth.go
+++ b/jwtauth/jwtauth.go
@@ -411,11 +411,12 @@ func (mw *GinJWTMiddleware) middlewareImpl(c *gin.Context) {
 		return
 	}
 
-	if _, ok := claims["exp"].(float64); !ok {
+	exp, ok := claims.Int64("exp")
+	if !ok {
 		mw.unauthorized(c, http.StatusBadRequest, mw.HTTPStatusMessageFunc(ErrWrongFormatOfExp, c))
 		return
 	}
-	if int64(claims["exp"].(float64)) < mw.TimeFunc().Unix() {
+	if exp < mw.TimeFunc().Unix() {
 		mw.unauthorized(c, 6401, mw.HTTPStatusMessageFunc(ErrExpiredToken, c))
 		return
 	}
@@ -598,11 +599,10 @@ func (mw *GinJWTMiddleware) CheckIfTokenExpire(c *gin.Context) (jwt.MapClaims, e
 
 	// A validly signed token minted elsewhere may carry no orig_iat. Treat it
 	// as non-refreshable instead of panicking on the type assertion.
-	rawIat, ok := claims["orig_iat"].(float64)
+	origIat, ok := MapClaims(claims).Int64("orig_iat")
 	if !ok {
 		return nil, ErrMissingOrigIatField
 	}
-	origIat := int64(rawIat)
 
 	if origIat < mw.TimeFunc().Add(-mw.MaxRefresh).Unix() {
 		return nil, ErrExpiredToken

--- a/jwtauth/middleware_exp_test.go
+++ b/jwtauth/middleware_exp_test.go
@@ -1,0 +1,41 @@
+package jwtauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Nothing covered the guarded path itself, so a change to how exp is read
+// could reject every authenticated request without a test noticing. The
+// middleware asserted float64 there; with the parser decoding numbers as
+// json.Number that assertion fails and every request is answered as a
+// malformed exp.
+func TestMiddlewareLetsAValidTokenThrough(t *testing.T) {
+	mw := newRefreshTestMiddleware(time.Now, time.Hour)
+	if err := mw.MiddlewareInit(); err != nil {
+		t.Fatalf("init the middleware: %v", err)
+	}
+	token := issueToken(t, mw, time.Now())
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	reached := false
+	r.GET("/guarded", mw.MiddlewareFunc(), func(c *gin.Context) {
+		reached = true
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/guarded", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK || !reached {
+		t.Fatalf("a valid token was turned away: status %d, handler reached %v, body %s",
+			w.Code, reached, w.Body.String())
+	}
+}

--- a/jwtauth/user/claims_test.go
+++ b/jwtauth/user/claims_test.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"encoding/json"
-	"math"
 	"net/http/httptest"
 	"testing"
 
@@ -97,5 +96,4 @@ func TestOrdinaryClaimsStillRead(t *testing.T) {
 	if got := GetDeptName(c); got != "hq" {
 		t.Errorf("GetDeptName = %q, want hq", got)
 	}
-	_ = math.MaxInt64
 }

--- a/jwtauth/user/claims_test.go
+++ b/jwtauth/user/claims_test.go
@@ -97,3 +97,24 @@ func TestOrdinaryClaimsStillRead(t *testing.T) {
 		t.Errorf("GetDeptName = %q, want hq", got)
 	}
 }
+
+// Accepting a number for a claim that has to be text would make the reading
+// depend on how the parser was configured: json.Number where UseNumber is on,
+// float64 where it is off, and only one of those was being accepted.
+func TestNumericClaimsAreNotNames(t *testing.T) {
+	for _, claims := range []jwt.MapClaims{
+		{"nice": json.Number("42"), "rolekey": json.Number("7"), "deptkey": json.Number("9")},
+		{"nice": float64(42), "rolekey": float64(7), "deptkey": float64(9)},
+	} {
+		c := contextWith(claims)
+		if got := GetUserName(c); got != "" {
+			t.Errorf("GetUserName = %q, want empty", got)
+		}
+		if got := GetRoleName(c); got != "" {
+			t.Errorf("GetRoleName = %q, want empty", got)
+		}
+		if got := GetDeptName(c); got != "" {
+			t.Errorf("GetDeptName = %q, want empty", got)
+		}
+	}
+}

--- a/jwtauth/user/claims_test.go
+++ b/jwtauth/user/claims_test.go
@@ -1,0 +1,101 @@
+package user
+
+import (
+	"encoding/json"
+	"math"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+)
+
+func contextWith(claims jwt.MapClaims) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/", nil)
+	c.Set(jwt.JwtPayloadKey, claims)
+	return c
+}
+
+// Every reader here used a bare type assertion, which panics on any type but
+// the one it named — in a request handler, over claims whose shape a caller
+// can influence. A claim that is not what was expected now reads as absent.
+func TestClaimsOfTheWrongTypeDoNotPanic(t *testing.T) {
+	c := contextWith(jwt.MapClaims{
+		"identity": "not a number at all",
+		"nice":     42.0,
+		"rolekey":  []string{"unexpected"},
+		"roleid":   map[string]int{"a": 1},
+		"deptid":   true,
+		"deptkey":  99.0,
+	})
+
+	if got := GetUserId(c); got != 0 {
+		t.Errorf("GetUserId = %d, want 0", got)
+	}
+	if got := GetUserName(c); got != "" {
+		t.Errorf("GetUserName = %q, want empty", got)
+	}
+	if got := GetRoleName(c); got != "" {
+		t.Errorf("GetRoleName = %q, want empty", got)
+	}
+	if got := GetRoleId(c); got != 0 {
+		t.Errorf("GetRoleId = %d, want 0", got)
+	}
+	if got := GetDeptId(c); got != 0 {
+		t.Errorf("GetDeptId = %d, want 0", got)
+	}
+	if got := GetDeptName(c); got != "" {
+		t.Errorf("GetDeptName = %q, want empty", got)
+	}
+}
+
+// A float64 cannot hold an identity above 2^53 exactly, which is where
+// snowflake ids live. json.Number keeps the digits, and a parser configured
+// with UseNumber hands one over.
+func TestAnIdentityBeyondFloat64PrecisionSurvives(t *testing.T) {
+	const big = int64(1<<53) + 1
+
+	if float64(big) == float64(big-1) {
+		// Stated rather than assumed: this is the property that makes the
+		// float64 path lossy in the first place.
+		t.Logf("float64 cannot separate %d from %d", big, big-1)
+	} else {
+		t.Fatalf("%d is not beyond float64 precision; the test needs a larger value", big)
+	}
+
+	c := contextWith(jwt.MapClaims{"identity": json.Number("9007199254740993")})
+	if got := GetUserIdStr(c); got != "9007199254740993" {
+		t.Errorf("GetUserIdStr = %q, want the digits unchanged", got)
+	}
+}
+
+func TestOrdinaryClaimsStillRead(t *testing.T) {
+	c := contextWith(jwt.MapClaims{
+		"identity": float64(7),
+		"nice":     "alice",
+		"rolekey":  "admin",
+		"roleid":   float64(3),
+		"deptid":   float64(5),
+		"deptkey":  "hq",
+	})
+
+	if got := GetUserId(c); got != 7 {
+		t.Errorf("GetUserId = %d, want 7", got)
+	}
+	if got := GetUserName(c); got != "alice" {
+		t.Errorf("GetUserName = %q, want alice", got)
+	}
+	if got := GetRoleId(c); got != 3 {
+		t.Errorf("GetRoleId = %d, want 3", got)
+	}
+	if got := GetDeptId(c); got != 5 {
+		t.Errorf("GetDeptId = %d, want 5", got)
+	}
+	if got := GetDeptName(c); got != "hq" {
+		t.Errorf("GetDeptName = %q, want hq", got)
+	}
+	_ = math.MaxInt64
+}

--- a/jwtauth/user/identity_test.go
+++ b/jwtauth/user/identity_test.go
@@ -1,0 +1,58 @@
+package user
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	gojwt "github.com/golang-jwt/jwt/v5"
+
+	jwtauth "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+)
+
+// identityBeyondFloat64 is 2^53 + 1: the first integer float64 cannot represent
+// exactly. Snowflake ids live well above it, and any system that does not use
+// auto-increment primary keys hands out identities of this size.
+const identityBeyondFloat64 = "9007199254740993"
+
+// The accessors read json.Number where it is present, but nothing produces one
+// unless the parser is told to. Without the option the claim is a float64 and
+// the digits are gone before any accessor is reached, so this has to be tested
+// through the parser rather than by handing a json.Number to claimInt.
+func TestLargeIdentitySurvivesTheParser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	key := []byte("a-key-for-this-test-only")
+
+	signed, err := gojwt.NewWithClaims(gojwt.SigningMethodHS256, gojwt.MapClaims{
+		"identity": int64(9007199254740993),
+		"nice":     "someone",
+	}).SignedString(key)
+	if err != nil {
+		t.Fatalf("sign the token: %v", err)
+	}
+
+	mw := &jwtauth.GinJWTMiddleware{
+		SigningAlgorithm: "HS256",
+		Key:              key,
+		TokenLookup:      "header: Authorization",
+		TokenHeadName:    "Bearer",
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	c.Request.Header.Set("Authorization", "Bearer "+signed)
+
+	claims, err := mw.GetClaimsFromJWT(c)
+	if err != nil {
+		t.Fatalf("parse the token: %v", err)
+	}
+	c.Set(jwtauth.JwtPayloadKey, claims)
+
+	if got := GetUserIdStr(c); got != identityBeyondFloat64 {
+		t.Fatalf("identity came back as %s, want %s", got, identityBeyondFloat64)
+	}
+	if got := GetUserId(c); int64(got) != 9007199254740993 {
+		t.Fatalf("identity came back as %d, want 9007199254740993", got)
+	}
+}

--- a/jwtauth/user/user.go
+++ b/jwtauth/user/user.go
@@ -1,13 +1,54 @@
 package user
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/go-admin-team/go-admin-core/v2/sdk/pkg"
 	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/pkg"
 )
+
+// A claim arrives as whatever encoding/json produced. A number is a float64 by
+// default and a json.Number when the parser was given UseNumber; a caller that
+// built the claims itself may have left an int. Reading one with a bare type
+// assertion panics on every case but the one it names — inside a request
+// handler, for a token an attacker controls the shape of.
+//
+// float64 is also the reason an identity above 2^53 cannot survive the trip:
+// it has no exact representation. json.Number keeps the digits, so it is
+// preferred where present.
+func claimInt(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case json.Number:
+		i, err := n.Int64()
+		return i, err == nil
+	case float64:
+		return int64(n), true
+	case int:
+		return int64(n), true
+	case int64:
+		return n, true
+	case string:
+		i, err := strconv.ParseInt(n, 10, 64)
+		return i, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func claimString(v interface{}) (string, bool) {
+	switch s := v.(type) {
+	case string:
+		return s, true
+	case json.Number:
+		return s.String(), true
+	default:
+		return "", false
+	}
+}
 
 func ExtractClaims(c *gin.Context) jwt.MapClaims {
 	claims, exists := c.Get(jwt.JwtPayloadKey)
@@ -30,7 +71,11 @@ func Get(c *gin.Context, key string) interface{} {
 func GetUserId(c *gin.Context) int {
 	data := ExtractClaims(c)
 	if data["identity"] != nil {
-		return int((data["identity"]).(float64))
+		if id, ok := claimInt(data["identity"]); ok {
+			return int(id)
+		}
+		fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetUserId: identity is not a number")
+		return 0
 	}
 	fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetUserId 缺少 identity")
 	return 0
@@ -39,7 +84,11 @@ func GetUserId(c *gin.Context) int {
 func GetUserIdStr(c *gin.Context) string {
 	data := ExtractClaims(c)
 	if data["identity"] != nil {
-		return pkg.Int64ToString(int64((data["identity"]).(float64)))
+		if id, ok := claimInt(data["identity"]); ok {
+			return pkg.Int64ToString(id)
+		}
+		fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetUserIdStr: identity is not a number")
+		return ""
 	}
 	fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetUserIdStr 缺少 identity")
 	return ""
@@ -48,7 +97,10 @@ func GetUserIdStr(c *gin.Context) string {
 func GetUserName(c *gin.Context) string {
 	data := ExtractClaims(c)
 	if data["nice"] != nil {
-		return (data["nice"]).(string)
+		if s, ok := claimString(data["nice"]); ok {
+			return s
+		}
+		return ""
 	}
 	fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetUserName 缺少 nice")
 	return ""
@@ -57,7 +109,10 @@ func GetUserName(c *gin.Context) string {
 func GetRoleName(c *gin.Context) string {
 	data := ExtractClaims(c)
 	if data["rolekey"] != nil {
-		return (data["rolekey"]).(string)
+		if s, ok := claimString(data["rolekey"]); ok {
+			return s
+		}
+		return ""
 	}
 	fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetRoleName 缺少 rolekey")
 	return ""
@@ -66,7 +121,11 @@ func GetRoleName(c *gin.Context) string {
 func GetRoleId(c *gin.Context) int {
 	data := ExtractClaims(c)
 	if data["roleid"] != nil {
-		i := int((data["roleid"]).(float64))
+		id, ok := claimInt(data["roleid"])
+		if !ok {
+			return 0
+		}
+		i := int(id)
 		return i
 	}
 	fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetRoleId 缺少 roleid")
@@ -76,7 +135,11 @@ func GetRoleId(c *gin.Context) int {
 func GetDeptId(c *gin.Context) int {
 	data := ExtractClaims(c)
 	if data["deptid"] != nil {
-		i := int((data["deptid"]).(float64))
+		id, ok := claimInt(data["deptid"])
+		if !ok {
+			return 0
+		}
+		i := int(id)
 		return i
 	}
 	fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetDeptId 缺少 deptid")
@@ -86,7 +149,10 @@ func GetDeptId(c *gin.Context) int {
 func GetDeptName(c *gin.Context) string {
 	data := ExtractClaims(c)
 	if data["deptkey"] != nil {
-		return (data["deptkey"]).(string)
+		if s, ok := claimString(data["deptkey"]); ok {
+			return s
+		}
+		return ""
 	}
 	fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetDeptName 缺少 deptkey")
 	return ""

--- a/jwtauth/user/user.go
+++ b/jwtauth/user/user.go
@@ -1,7 +1,6 @@
 package user
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/gin-gonic/gin"
@@ -10,15 +9,15 @@ import (
 	"github.com/go-admin-team/go-admin-core/v2/sdk/pkg"
 )
 
+// claimString reads a claim that has to be text.
+//
+// A number is not accepted in either encoding it can arrive in. Accepting
+// json.Number and not float64 would make the reading depend on how the parser
+// was configured: the same token would give a name of "42" with UseNumber on
+// and no name at all with it off.
 func claimString(v interface{}) (string, bool) {
-	switch s := v.(type) {
-	case string:
-		return s, true
-	case json.Number:
-		return s.String(), true
-	default:
-		return "", false
-	}
+	s, ok := v.(string)
+	return s, ok
 }
 
 func ExtractClaims(c *gin.Context) jwt.MapClaims {

--- a/jwtauth/user/user.go
+++ b/jwtauth/user/user.go
@@ -3,41 +3,12 @@ package user
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 
 	jwt "github.com/go-admin-team/go-admin-core/v2/jwtauth"
 	"github.com/go-admin-team/go-admin-core/v2/sdk/pkg"
 )
-
-// A claim arrives as whatever encoding/json produced. A number is a float64 by
-// default and a json.Number when the parser was given UseNumber; a caller that
-// built the claims itself may have left an int. Reading one with a bare type
-// assertion panics on every case but the one it names — inside a request
-// handler, for a token an attacker controls the shape of.
-//
-// float64 is also the reason an identity above 2^53 cannot survive the trip:
-// it has no exact representation. json.Number keeps the digits, so it is
-// preferred where present.
-func claimInt(v interface{}) (int64, bool) {
-	switch n := v.(type) {
-	case json.Number:
-		i, err := n.Int64()
-		return i, err == nil
-	case float64:
-		return int64(n), true
-	case int:
-		return int64(n), true
-	case int64:
-		return n, true
-	case string:
-		i, err := strconv.ParseInt(n, 10, 64)
-		return i, err == nil
-	default:
-		return 0, false
-	}
-}
 
 func claimString(v interface{}) (string, bool) {
 	switch s := v.(type) {
@@ -71,7 +42,7 @@ func Get(c *gin.Context, key string) interface{} {
 func GetUserId(c *gin.Context) int {
 	data := ExtractClaims(c)
 	if data["identity"] != nil {
-		if id, ok := claimInt(data["identity"]); ok {
+		if id, ok := data.Int64("identity"); ok {
 			return int(id)
 		}
 		fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetUserId: identity is not a number")
@@ -84,7 +55,7 @@ func GetUserId(c *gin.Context) int {
 func GetUserIdStr(c *gin.Context) string {
 	data := ExtractClaims(c)
 	if data["identity"] != nil {
-		if id, ok := claimInt(data["identity"]); ok {
+		if id, ok := data.Int64("identity"); ok {
 			return pkg.Int64ToString(id)
 		}
 		fmt.Println(pkg.GetCurrentTimeStr() + " [WARING] " + c.Request.Method + " " + c.Request.URL.Path + " GetUserIdStr: identity is not a number")
@@ -121,7 +92,7 @@ func GetRoleName(c *gin.Context) string {
 func GetRoleId(c *gin.Context) int {
 	data := ExtractClaims(c)
 	if data["roleid"] != nil {
-		id, ok := claimInt(data["roleid"])
+		id, ok := data.Int64("roleid")
 		if !ok {
 			return 0
 		}
@@ -135,7 +106,7 @@ func GetRoleId(c *gin.Context) int {
 func GetDeptId(c *gin.Context) int {
 	data := ExtractClaims(c)
 	if data["deptid"] != nil {
-		id, ok := claimInt(data["deptid"])
+		id, ok := data.Int64("deptid")
 		if !ok {
 			return 0
 		}


### PR DESCRIPTION
Seven bare type assertions read claims in `jwtauth/user`, and two more in `jwtauth` itself. A bare assertion panics on every case but the one it names, inside a request handler, over a token whose claim shapes a caller can influence.

```
panic: interface conversion: interface {} is string, not float64
```

The fix that was written for this sat on the abandoned `master` branch since **2022-11-24** and never reached a released line.

### The precision half did not work, and now does

The first version of this PR said an identity above 2^53 survives via `json.Number`. **It did not.** Neither parser was given `WithJSONNumber`, so nothing ever produced a `json.Number`: every numeric claim arrived as a `float64` and was already rounded before any accessor saw it.

```
identity came back as 9007199254740992, want 9007199254740993
```

Snowflake ids are above 2^53, which is every deployment that does not use auto-increment primary keys. The same branch carried the missing half — `fix: parse token添加WithJSONNumber Option`, 2022-10-25 — and the two halves sat apart for four years, each inert without the other.

### Turning the option on was not safe by itself

`jwtauth` reads two claims of its own, both asserted as `float64`:

- `exp`, once as a format check and once bare
- `orig_iat`, in the refresh path

With the parser decoding numbers as `json.Number`, the `exp` check fails and the middleware answers **every authenticated request** with `exp must be float64 format`. So the readers had to move first; the commits are ordered that way.

### Commits

| | |
|---|---|
| `read a claim without asserting what it is` | the seven in `jwtauth/user` |
| `read exp and orig_iat without asserting how they were encoded` | the two in `jwtauth`; the numeric reader moves onto `MapClaims` so both packages share it |
| `decode claims as numbers, not as float64` | `WithJSONNumber` on both parsers |
| `cover the path every authenticated request takes` | nothing exercised the guarded route at all |
| `the exp error no longer names one encoding` | the message stopped being true |

### Counter-proofs

| reverted | goes red |
|---|---|
| `MapClaims.Int64` → `claims["exp"].(float64)` | `TestMiddlewareLetsAValidTokenThrough`: `{"code":400,"message":"exp must be float64 format"}` |
| `MapClaims.Int64` → `claims["orig_iat"].(float64)` | three refresh tests, `missing orig_iat field` |
| `WithJSONNumber` removed | `TestLargeIdentitySurvivesTheParser`: `identity came back as 9007199254740992` |
| any of the seven accessors | `TestClaimsOfTheWrongTypeDoNotPanic` |

`make ci` green, `check-language` ok.