### PR TITLE
fix🐛: concurrency and capacity defects in storage, plus the tests that found them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 
-All notable changes to go-admin-core will be documented in this file.
+> **This file is no longer maintained.**
+>
+> Release notes live at
+> [GitHub Releases](https://github.com/go-admin-team/go-admin-core/releases).
+> This file stops at 1.6.0-beta and describes none of v1.6.4, v1.6.5, v1.7.0,
+> v1.8.0, v1.8.1, v2.0.0, v2.0.1 or v2.1.0 — reading it as current would put
+> the project eight releases behind.
+>
+> It is kept because the v1.5 and v1.6 entries below are the only record of
+> that work. For moving from v1 to v2, see
+> [docs/migration/v2.0.0.md](docs/migration/v2.0.0.md).
+
+All notable changes to go-admin-core were documented in this file up to
+1.6.0-beta.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO ?= go
 # so every target below runs with -short. Nothing is excluded from the race
 # target; anything that has to be would belong in docs/known-issues.md.
 
-.PHONY: all build vet test test-race lint vuln tidy api-snapshot api-check ci
+.PHONY: all build vet test test-race bench bench-compare soak lint vuln tidy api-snapshot api-check ci
 
 all: ci
 
@@ -25,6 +25,35 @@ test-race:
 # invisible to a run on another platform, which is how a finding in
 # watcher_linux.go stayed hidden from every local run and failed in CI.
 STATICCHECK ?= honnef.co/go/tools/cmd/staticcheck@v0.7.0
+
+# bench runs every benchmark once, briefly. It is a smoke test that the
+# benchmarks still compile and run - not a measurement. For numbers worth
+# comparing, raise -benchtime and use benchstat over several runs.
+#
+# Redis benchmarks skip unless REDIS_URL points at a server.
+bench:
+	$(GO) test -run '^$$' -bench . -benchtime 10x -benchmem ./...
+
+# bench-compare measures this tree against a base revision on one machine and
+# runs the results through benchstat. Timings are not gated in CI - see the
+# script's header - so this is the deliberate check to run when a change is
+# meant to affect performance.
+#
+#	make bench-compare                          # against origin/main
+#	make bench-compare BASE=HEAD~1 BENCH=Cache  # narrower
+BASE ?= origin/main
+BENCH ?= .
+BENCH_COUNT ?= 6
+bench-compare:
+	scripts/bench-compare.sh $(BASE) $(BENCH) $(BENCH_COUNT)
+
+# soak runs the tests that need time: sustained load, resource reclamation and
+# goroutine lifecycles. They are skipped by -short, which is what test and
+# test-race use, so nothing else in this Makefile covers them.
+#
+# GOADMIN_SOAK sets how long each one runs, e.g. GOADMIN_SOAK=2m make soak.
+soak:
+	$(GO) test -race -timeout 1800s -run 'Soak|Leak|Stall|Reclaim|Release' ./...
 
 lint:
 	@tmp=$$(mktemp -d); \

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -1,0 +1,241 @@
+# go-admin-core
+
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [繁體中文](README.zh-TW.md) · [日本語](README.ja-JP.md)
+
+## ✨ 主な機能
+
+### 📝 Logger モジュール（エンタープライズ向けロギング）
+
+- **非同期ロガー** - 45 倍の高速化（3,358ns → 75ns）、100k+ QPS に対応
+- **サンプリングロガー** - 29 倍の高速化（3,357ns → 116ns）、出力頻度を自動制御
+- **マスキングロガー** - 機密情報（電話番号・パスワード・メールアドレスなど）を自動マスクし、コンプライアンス要件に対応
+- **Logrus アダプター** - Logrus エコシステムに完全対応、50 種類以上の Hook が利用可能
+- **本番向け設定** - ベストプラクティス（非同期 + サンプリング + マスキング）を同梱
+- **並行安全** - Race Detector で検証済み、データ競合ゼロ
+
+### 🔐 JWT 認証
+
+- **Gin ミドルウェア** — Gin アプリケーションにログイン・更新・ID 解決を提供
+- **有限なトークン寿命** — `MaxRefresh` がトークンを更新できる総時間を、最初の発行時点から起算して制限
+- **設定可能** — `Timeout` と `MaxRefresh` はいずれも設定ファイルから制御
+
+### 🚀 その他のコンポーネント
+
+- [x] キャッシュ（memory / Redis）—— [docs/storage](docs/storage/README.md) を参照
+- [x] キュー（memory / Redis Streams）—— [docs/storage](docs/storage/README.md) を参照
+- [x] 設定管理（複数のデータソースに対応）
+- [x] ログライター（ファイルローテーション対応）
+
+> 変更のたびに、データ競合検出、2 プラットフォームでの staticcheck、
+> およびリクエストごとに実行されるコードパスのメモリアロケーション予算を検証します。
+
+---
+
+## 🚀 クイックスタート
+
+### インストール
+
+```bash
+go get -u github.com/go-admin-team/go-admin-core/v2
+```
+
+**動作要件:** Go 1.25 以降（`go.mod` の `go` ディレクティブを参照）
+
+### 基本的なロギング
+
+```go
+package main
+
+import "github.com/go-admin-team/go-admin-core/v2/logger"
+
+func main() {
+    // Logrus ロガーを生成
+    log := logger.NewLogrusLogger(
+        logger.WithPath("logs/app.log"),
+        logger.WithLevel(logger.InfoLevel),
+    )
+
+    log.Log(logger.InfoLevel, "Application started")
+    log.Fields(map[string]interface{}{
+        "user_id": 12345,
+        "action":  "login",
+    }).Log(logger.InfoLevel, "User action")
+}
+```
+
+### 高性能な非同期ロギング
+
+```go
+// 非同期ロガーを生成（高並行環境で推奨）
+baseLog := logger.NewLogrusLogger(
+    logger.WithPath("logs/app.log"),
+    logger.WithLevel(logger.InfoLevel),
+)
+
+asyncLog := logger.NewAsyncLogger(baseLog, logger.DefaultAsyncConfig)
+defer asyncLog.(interface{ Close() error }).Close()
+
+// 45 倍の高速化、レイテンシはわずか 75ns
+asyncLog.Log(logger.InfoLevel, "High performance logging")
+```
+
+### サンプリングロギング（頻度制御）
+
+```go
+// サンプリングロガーを生成（高頻度の重複ログを自動的に間引く）
+samplingLog := logger.NewSamplingLogger(baseLog, logger.DefaultSamplingConfig)
+
+// 毎秒最初の 100 件のみ記録し、以降は 100 件ごとに 1 件
+for i := 0; i < 10000; i++ {
+    samplingLog.Log(logger.InfoLevel, "High frequency log")
+}
+```
+
+### マスキングロギング（データ保護）
+
+```go
+// マスキングロガーを生成（機密情報を自動処理）
+sanitizerLog := logger.NewSanitizerLogger(baseLog, logger.DefaultSanitizerConfig)
+
+sanitizerLog.Fields(map[string]interface{}{
+    "phone":    "13812345678",  // 自動マスク → "138****5678"
+    "password": "secret123",    // 自動マスク → "[REDACTED]"
+    "email":    "user@example.com", // 自動マスク → "u***@example.com"
+}).Log(logger.InfoLevel, "User login")
+```
+
+### 本番向け構成（推奨）
+
+```go
+// 組み合わせ: マスキング → サンプリング → 非同期
+sanitized := logger.NewSanitizerLogger(baseLog, logger.DefaultSanitizerConfig)
+sampled := logger.NewSamplingLogger(sanitized, logger.DefaultSamplingConfig)
+asyncLog := logger.NewAsyncLogger(sampled, logger.DefaultAsyncConfig)
+defer asyncLog.(interface{ Close() error }).Close()
+
+// 34 倍の高速化 + データ保護 + 頻度制御
+asyncLog.Fields(map[string]interface{}{
+    "phone":   "13812345678",
+    "user_id": 12345,
+}).Log(logger.InfoLevel, "Production logging")
+```
+
+---
+
+## 📦 設定管理
+
+### 設定ファイルの読み込み
+
+```go
+package main
+
+import "github.com/go-admin-team/go-admin-core/v2/config"
+
+func main() {
+    source := config.FileSource("config.json")
+    config.Setup(source, func() {
+        // 設定変更時のコールバック
+    })
+}
+```
+
+---
+
+## 📊 パフォーマンス
+
+| 機能 | 高速化 | レイテンシ | メモリ使用量 | 適した用途 |
+|------|---------|------|---------|---------|
+| 非同期ロガー | 45x | 75ns | 120 B/op | 高並行での書き込み |
+| サンプリングロガー | 29x | 116ns | 16 B/op | 高頻度の重複ログ |
+| 本番向け構成 | 34x | 98ns | 149 B/op | 本番環境で推奨 |
+
+**測定環境:** Apple M1 Pro | Go 1.25.1 | Race Detector 検証済み
+
+---
+
+## 🧪 テスト
+
+```bash
+# CI ゲートが実行する内容すべて
+make ci
+
+# データ競合検出（全パッケージ）
+make test-race
+
+# ベンチマーク —— スモーク実行。比較可能な数値が必要なら -benchtime を上げる
+make bench
+
+# 継続的負荷・リソース回収・goroutine のライフサイクル
+GOADMIN_SOAK=2m make soak
+
+# ベースリビジョンと比較し、benchstat で判定
+make bench-compare BASE=origin/main
+```
+
+**変更のたびに強制されるもの:**
+
+- データ競合検出（全パッケージ）
+- darwin と linux 両方での staticcheck
+- `api/core.txt` の公開 API スナップショットがコードと一致すること
+- リクエストごとに実行されるコードパスのアロケーション予算
+- このツリーに対する下流利用者のビルド
+
+---
+
+## 📦 主な依存関係
+
+```go
+github.com/casbin/casbin/v3         v3.8.1
+github.com/gin-gonic/gin            v1.11.0
+github.com/golang-jwt/jwt/v5        v5.3.0
+gorm.io/gorm                        v1.31.1
+github.com/sirupsen/logrus          v1.9.4
+golang.org/x/crypto                 v0.47.0
+```
+
+上記は執筆時点の `go.mod` の内容です。実際のバージョンは同ファイルを参照してください。
+
+---
+
+## 🤝 コントリビューション
+
+Issue と Pull Request を歓迎します。
+
+1. 本リポジトリを Fork
+2. `main` から機能ブランチを作成 (`git checkout -b feature/AmazingFeature`)
+3. 変更をコミット (`git commit -m 'Add some AmazingFeature'`)
+4. ブランチへプッシュ (`git push origin feature/AmazingFeature`)
+5. **`main` に向けて Pull Request を作成**
+
+> **ブランチについて:** `main` が唯一のアクティブなブランチであり、すべての
+> リリースの供給元です。`master` と `dev` は履歴用のブランチで、変更は
+> 受け付けていません。`master` は 2022 年以降更新されておらず、リリース
+> ラインに乗ったこともありません。
+
+### 脆弱性の報告
+
+セキュリティに関する問題は公開 issue を立てず、
+[非公開の脆弱性報告](https://github.com/go-admin-team/go-admin-core/security/advisories/new)
+をご利用ください。
+
+---
+
+## 📝 License
+
+Apache License 2.0 - 詳細は [LICENSE](LICENSE) を参照してください。
+
+---
+
+## 🔗 関連プロジェクト
+
+- [go-admin](https://github.com/go-admin-team/go-admin) - Gin + Vue + Element UI によるフロントエンド・バックエンド分離型の権限管理システム
+- [go-admin-ui](https://github.com/go-admin-team/go-admin-ui) - go-admin のフロントエンド
+
+---
+
+## ⭐ Star History
+
+このプロジェクトがお役に立ちましたら、Star ⭐ をいただけると励みになります。

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ### Installation
 
 ```bash
-go get -u github.com/go-admin-team/go-admin-core
+go get -u github.com/go-admin-team/go-admin-core/v2
 ```
 
 **System Requirements:** Go 1.25 or higher (see the `go` directive in `go.mod`)
@@ -49,7 +49,7 @@ go get -u github.com/go-admin-team/go-admin-core
 ```go
 package main
 
-import "github.com/go-admin-team/go-admin-core/logger"
+import "github.com/go-admin-team/go-admin-core/v2/logger"
 
 func main() {
     // Create Logrus logger instance
@@ -132,7 +132,7 @@ asyncLog.Fields(map[string]interface{}{
 ```go
 package main
 
-import "github.com/go-admin-team/go-admin-core/config"
+import "github.com/go-admin-team/go-admin-core/v2/config"
 
 func main() {
     source := config.FileSource("config.json")

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-[中文文档](README.zh-CN.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [繁體中文](README.zh-TW.md) · [日本語](README.ja-JP.md)
 
 ## ✨ Core Features
 
@@ -30,7 +30,8 @@
 - [x] Configuration management (multiple data sources)
 - [x] Log writer (file rotation support)
 
-> **Latest Version:** Go 1.25 | 35 unit tests + 30+ performance benchmarks
+> Every change runs the race detector, staticcheck on two platforms, and
+> allocation budgets on the paths that execute per request.
 
 ---
 
@@ -156,24 +157,32 @@ func main() {
 
 ---
 
-## 🧪 Test Coverage
+## 🧪 Testing
 
 ```bash
-# Run all tests
-go test ./... -v
+# Everything the CI gate runs
+make ci
 
-# Performance benchmarks
-go test ./logger -bench=. -benchmem
+# Race detector, across every package
+make test-race
 
-# Concurrency safety check
-go test ./logger -race
+# Benchmarks — a smoke run; raise -benchtime for numbers worth comparing
+make bench
+
+# Sustained load, resource reclamation and goroutine lifecycles
+GOADMIN_SOAK=2m make soak
+
+# Measure this tree against a base revision, through benchstat
+make bench-compare BASE=origin/main
 ```
 
-**Test Results:**
-- ✅ Unit Tests: 35/35 passed
-- ✅ Performance Benchmarks: 30+ passed
-- ✅ Concurrency Safety: Race Detector 0 warnings
-- ✅ Code Coverage: 85%+
+**Enforced on every change:**
+
+- Race detector, every package
+- staticcheck for both darwin and linux
+- The exported API snapshot in `api/core.txt` must match the code
+- Allocation budgets on the paths that run per request
+- Downstream consumers are built against this tree
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
-[English](README.md)
+[English](README.md) · [简体中文](README.zh-CN.md) · [繁體中文](README.zh-TW.md) · [日本語](README.ja-JP.md)
 
 ## ✨ 核心特性
 
@@ -29,7 +29,8 @@
 - [x] 配置管理（支持多种数据源）
 - [x] 日志写入器（支持文件分割）
 
-> **最新版本:** Go 1.25 | 35 个单元测试 + 30+ 性能基准测试
+> 每次改动都会执行竞态检测、双平台 staticcheck，以及针对每请求代码路径的
+> 内存分配预算门禁。
 
 ---
 
@@ -155,24 +156,32 @@ func main() {
 
 ---
 
-## 🧪 测试覆盖
+## 🧪 测试
 
 ```bash
-# 运行所有测试
-go test ./... -v
+# CI 门禁跑的全部内容
+make ci
 
-# 性能基准测试
-go test ./logger -bench=. -benchmem
+# 竞态检测，覆盖所有包
+make test-race
 
-# 并发安全检查
-go test ./logger -race
+# 基准测试 —— 冒烟运行；需要可比较的数字请调高 -benchtime
+make bench
+
+# 持续负载、资源回收与 goroutine 生命周期
+GOADMIN_SOAK=2m make soak
+
+# 与基准版本对比，结果交给 benchstat 判定
+make bench-compare BASE=origin/main
 ```
 
-**测试结果:**
-- ✅ 单元测试: 35/35 通过
-- ✅ 性能基准测试: 30+ 通过
-- ✅ 并发安全: Race Detector 0 warnings
-- ✅ 代码覆盖率: 85%+
+**每次改动都会强制执行:**
+
+- 竞态检测，覆盖所有包
+- darwin 与 linux 双平台 staticcheck
+- `api/core.txt` 中的导出 API 快照必须与代码一致
+- 每请求代码路径的内存分配预算
+- 以本仓库当前代码构建下游使用方
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,7 +38,7 @@
 ### 安装
 
 ```bash
-go get -u github.com/go-admin-team/go-admin-core
+go get -u github.com/go-admin-team/go-admin-core/v2
 ```
 
 **系统要求:** Go 1.25 或更高版本（以 `go.mod` 中的 `go` 指令为准）
@@ -48,7 +48,7 @@ go get -u github.com/go-admin-team/go-admin-core
 ```go
 package main
 
-import "github.com/go-admin-team/go-admin-core/logger"
+import "github.com/go-admin-team/go-admin-core/v2/logger"
 
 func main() {
     // 创建 Logrus 日志实例
@@ -131,7 +131,7 @@ asyncLog.Fields(map[string]interface{}{
 ```go
 package main
 
-import "github.com/go-admin-team/go-admin-core/config"
+import "github.com/go-admin-team/go-admin-core/v2/config"
 
 func main() {
     source := config.FileSource("config.json")

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,239 @@
+# go-admin-core
+
+[![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)](https://go.dev/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+
+[English](README.md) · [简体中文](README.zh-CN.md) · [繁體中文](README.zh-TW.md) · [日本語](README.ja-JP.md)
+
+## ✨ 核心特性
+
+### 📝 Logger 模組（企業級日誌解決方案）
+
+- **非同步日誌** - 45x 效能提升（3,358ns → 75ns），支援 100k+ QPS
+- **取樣日誌** - 29x 效能提升（3,357ns → 116ns），智慧頻率控制
+- **遮罩日誌** - 自動遮罩敏感資料（手機號碼、密碼、電子郵件等），滿足法遵要求
+- **Logrus 轉接器** - 完整支援 Logrus 生態，可用 Hooks 超過 50 種
+- **正式環境設定** - 內建最佳實務設定（非同步 + 取樣 + 遮罩）
+- **並行安全** - 通過 Race Detector 驗證，零資料競爭
+
+### 🔐 JWT 認證
+
+- **Gin 中介軟體** — 為 Gin 應用提供登入、續期與身分解析
+- **有界的權杖生命週期** — `MaxRefresh` 限定權杖可被續期的總時長，自首次簽發起計算
+- **可設定** — `Timeout` 與 `MaxRefresh` 皆由設定驅動
+
+### 🚀 其他元件
+
+- [x] 快取元件（支援 memory、Redis）——見 [docs/storage](docs/storage/README.md)
+- [x] 佇列元件（支援 memory、Redis streams）——見 [docs/storage](docs/storage/README.md)
+- [x] 設定管理（支援多種資料來源）
+- [x] 日誌寫入器（支援檔案分割）
+
+> 每次改動都會執行競態偵測、雙平台 staticcheck，以及針對每請求程式碼路徑的
+> 記憶體配置預算把關。
+
+---
+
+## 🚀 快速開始
+
+### 安裝
+
+```bash
+go get -u github.com/go-admin-team/go-admin-core/v2
+```
+
+**系統需求:** Go 1.25 或更高版本（以 `go.mod` 中的 `go` 指令為準）
+
+### 基礎日誌用法
+
+```go
+package main
+
+import "github.com/go-admin-team/go-admin-core/v2/logger"
+
+func main() {
+    // 建立 Logrus 日誌實例
+    log := logger.NewLogrusLogger(
+        logger.WithPath("logs/app.log"),
+        logger.WithLevel(logger.InfoLevel),
+    )
+
+    log.Log(logger.InfoLevel, "Application started")
+    log.Fields(map[string]interface{}{
+        "user_id": 12345,
+        "action":  "login",
+    }).Log(logger.InfoLevel, "User action")
+}
+```
+
+### 高效能非同步日誌
+
+```go
+// 建立非同步日誌（建議用於高並行情境）
+baseLog := logger.NewLogrusLogger(
+    logger.WithPath("logs/app.log"),
+    logger.WithLevel(logger.InfoLevel),
+)
+
+asyncLog := logger.NewAsyncLogger(baseLog, logger.DefaultAsyncConfig)
+defer asyncLog.(interface{ Close() error }).Close()
+
+// 45x 效能提升，延遲僅 75ns
+asyncLog.Log(logger.InfoLevel, "High performance logging")
+```
+
+### 取樣日誌（頻率控制）
+
+```go
+// 建立取樣日誌（自動過濾高頻重複日誌）
+samplingLog := logger.NewSamplingLogger(baseLog, logger.DefaultSamplingConfig)
+
+// 每秒僅記錄前 100 筆，其後每 100 筆記錄 1 筆
+for i := 0; i < 10000; i++ {
+    samplingLog.Log(logger.InfoLevel, "High frequency log")
+}
+```
+
+### 遮罩日誌（資料安全）
+
+```go
+// 建立遮罩日誌（自動處理敏感資料）
+sanitizerLog := logger.NewSanitizerLogger(baseLog, logger.DefaultSanitizerConfig)
+
+sanitizerLog.Fields(map[string]interface{}{
+    "phone":    "13812345678",  // 自動遮罩 → "138****5678"
+    "password": "secret123",    // 自動遮罩 → "[REDACTED]"
+    "email":    "user@example.com", // 自動遮罩 → "u***@example.com"
+}).Log(logger.InfoLevel, "User login")
+```
+
+### 正式環境設定（建議）
+
+```go
+// 組合使用：遮罩 → 取樣 → 非同步
+sanitized := logger.NewSanitizerLogger(baseLog, logger.DefaultSanitizerConfig)
+sampled := logger.NewSamplingLogger(sanitized, logger.DefaultSamplingConfig)
+asyncLog := logger.NewAsyncLogger(sampled, logger.DefaultAsyncConfig)
+defer asyncLog.(interface{ Close() error }).Close()
+
+// 34x 效能提升 + 資料安全 + 頻率控制
+asyncLog.Fields(map[string]interface{}{
+    "phone":   "13812345678",
+    "user_id": 12345,
+}).Log(logger.InfoLevel, "Production logging")
+```
+
+---
+
+## 📦 設定管理
+
+### 讀取設定檔
+
+```go
+package main
+
+import "github.com/go-admin-team/go-admin-core/v2/config"
+
+func main() {
+    source := config.FileSource("config.json")
+    config.Setup(source, func() {
+        // 設定變更回呼
+    })
+}
+```
+
+---
+
+## 📊 效能指標
+
+| 功能 | 效能提升 | 延遲 | 記憶體用量 | 適用情境 |
+|------|---------|------|---------|---------|
+| 非同步日誌 | 45x | 75ns | 120 B/op | 高並行寫入 |
+| 取樣日誌 | 29x | 116ns | 16 B/op | 高頻重複日誌 |
+| 正式環境設定 | 34x | 98ns | 149 B/op | 正式環境建議 |
+
+**測試環境:** Apple M1 Pro | Go 1.25.1 | 通過 Race Detector 驗證
+
+---
+
+## 🧪 測試
+
+```bash
+# CI 把關執行的全部內容
+make ci
+
+# 競態偵測，涵蓋所有套件
+make test-race
+
+# 基準測試 —— 冒煙執行；需要可比較的數字請調高 -benchtime
+make bench
+
+# 持續負載、資源回收與 goroutine 生命週期
+GOADMIN_SOAK=2m make soak
+
+# 與基準版本比較，結果交由 benchstat 判定
+make bench-compare BASE=origin/main
+```
+
+**每次改動都會強制執行:**
+
+- 競態偵測，涵蓋所有套件
+- darwin 與 linux 雙平台 staticcheck
+- `api/core.txt` 中的匯出 API 快照必須與程式碼一致
+- 每請求程式碼路徑的記憶體配置預算
+- 以本儲存庫目前程式碼建置下游使用方
+
+---
+
+## 📦 主要相依套件
+
+```go
+github.com/casbin/casbin/v3         v3.8.1
+github.com/gin-gonic/gin            v1.11.0
+github.com/golang-jwt/jwt/v5        v5.3.0
+gorm.io/gorm                        v1.31.1
+github.com/sirupsen/logrus          v1.9.4
+golang.org/x/crypto                 v0.47.0
+```
+
+以上版本為撰寫時 `go.mod` 的內容，一律以該檔案為準。
+
+---
+
+## 🤝 貢獻指南
+
+歡迎提交 Issue 與 Pull Request！
+
+1. Fork 本儲存庫
+2. 基於 `main` 建立特性分支 (`git checkout -b feature/AmazingFeature`)
+3. 提交變更 (`git commit -m 'Add some AmazingFeature'`)
+4. 推送到分支 (`git push origin feature/AmazingFeature`)
+5. **向 `main` 開啟 Pull Request**
+
+> **分支說明：** `main` 是唯一活躍的分支，也是所有發布版本的來源。
+> `master` 與 `dev` 皆為歷史分支，不再接受改動 —— 其中 `master` 自 2022 年
+> 起未再變動，且從未進入過發布線。
+
+### 漏洞回報
+
+安全問題請勿開立公開 issue，改用
+[私密漏洞回報](https://github.com/go-admin-team/go-admin-core/security/advisories/new)。
+
+---
+
+## 📝 License
+
+Apache License 2.0 - 詳見 [LICENSE](LICENSE) 檔案
+
+---
+
+## 🔗 相關專案
+
+- [go-admin](https://github.com/go-admin-team/go-admin) - 基於 Gin + Vue + Element UI 的前後端分離權限管理系統
+- [go-admin-ui](https://github.com/go-admin-team/go-admin-ui) - go-admin 的前端專案
+
+---
+
+## ⭐ Star History
+
+如果這個專案對你有幫助，歡迎點一個 Star ⭐

--- a/api/core.txt
+++ b/api/core.txt
@@ -1360,6 +1360,7 @@ type Queue interface {
 ## github.com/go-admin-team/go-admin-core/v2/storage/cache
 type MemCache struct {
 func NewMemCache() *MemCache
+func NewMemCacheWithOptions(o MemCacheOptions) *MemCache
 func NewMemCacheWithSweep(interval time.Duration) *MemCache
 func (m *MemCache) Close() error
 func (m *MemCache) Del(ctx context.Context, keys ...string) error
@@ -1368,6 +1369,9 @@ func (m *MemCache) Get(ctx context.Context, key string) (string, error)
 func (m *MemCache) Incr(ctx context.Context, key string, delta int64) (int64, error)
 func (m *MemCache) Set(ctx context.Context, key, val string, ttl time.Duration) error
 func (c *MemCache) String() string
+type MemCacheOptions struct {
+	SweepInterval time.Duration
+	MaxEntries int
 type Memory struct {
 func NewMemory() *Memory
 func NewMemoryWithCleanupInterval(interval time.Duration) *Memory

--- a/captcha/alloc_budget_test.go
+++ b/captcha/alloc_budget_test.go
@@ -1,0 +1,36 @@
+//lint:file-ignore SA1019 Bridges to the deprecated AdapterCache, as the rest of this package does.
+
+package captcha
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/storage/cache"
+)
+
+// Verify runs on every login attempt. Generation is allocation-heavy by nature
+// - it renders a PNG - but verification is a store read and a comparison, and
+// there is no reason for it to allocate at all.
+//
+// Allocation counts are deterministic; see the note in
+// storage/cache/alloc_budget_test.go.
+func TestVerifyAllocationBudget(t *testing.T) {
+	c := cache.NewMemoryWithCleanupInterval(0)
+	defer func() { _ = c.Close() }()
+	store := NewCacheStore(c, 600)
+	SetStore(store)
+
+	if err := store.Set("budget-id", "1234"); err != nil {
+		t.Fatal(err)
+	}
+	if !Verify("budget-id", "1234", false) {
+		t.Fatal("setup failed: the answer does not verify")
+	}
+
+	got := testing.AllocsPerRun(100, func() {
+		Verify("budget-id", "1234", false)
+	})
+	if got > 0 {
+		t.Errorf("Verify allocates %.0f times, budget is 0", got)
+	}
+}

--- a/captcha/bench_test.go
+++ b/captcha/bench_test.go
@@ -1,0 +1,90 @@
+//lint:file-ignore SA1019 Bridges to the deprecated AdapterCache, as the rest of this package does.
+
+package captcha
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/storage/cache"
+)
+
+// The captcha endpoint is unauthenticated and sits in front of the login form,
+// which makes it the one route an anonymous client can call freely. An
+// end-to-end sweep put it at roughly 8k req/s while a plain framework route
+// reached 147k, so it is worth knowing which part costs that.
+//
+// Generation renders a PNG; the store is a cache write. These separate them.
+
+func benchStore(b *testing.B) {
+	b.Helper()
+	SetStore(NewCacheStore(cache.NewMemoryWithCleanupInterval(0), 600))
+}
+
+// BenchmarkDriverDigitGenerate is the digit captcha the login page uses:
+// render, base64-encode and store the answer.
+func BenchmarkDriverDigitGenerate(b *testing.B) {
+	benchStore(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := DriverDigitFunc(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDriverStringGenerate is the string variant, which loads a font and
+// so is not comparable to the digit driver.
+func BenchmarkDriverStringGenerate(b *testing.B) {
+	benchStore(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, _, err := DriverStringFunc(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkDriverDigitGenerateParallel answers whether generation scales across
+// cores or contends on the shared store.
+func BenchmarkDriverDigitGenerateParallel(b *testing.B) {
+	benchStore(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, _, _, err := DriverDigitFunc(); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+// BenchmarkVerify is the login path: one store read plus a delete. It is the
+// half that runs on every login attempt, generation being the half that runs
+// when the form is displayed.
+func BenchmarkVerify(b *testing.B) {
+	c := cache.NewMemoryWithCleanupInterval(0)
+	defer func() { _ = c.Close() }()
+	store := NewCacheStore(c, 600)
+	SetStore(store)
+
+	// Verify with clear=false so the entry survives every iteration; clearing
+	// would measure a miss after the first.
+	if err := store.Set("bench-id", "1234"); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !Verify("bench-id", "1234", false) {
+			b.Fatal("verification failed")
+		}
+	}
+}

--- a/captcha/captcha.go
+++ b/captcha/captcha.go
@@ -2,8 +2,8 @@ package captcha
 
 import (
 	"image/color"
+	"sync"
 
-	"github.com/google/uuid"
 	"github.com/mojocn/base64Captcha"
 )
 
@@ -12,33 +12,43 @@ func SetStore(s base64Captcha.Store) {
 	base64Captcha.DefaultMemStore = s
 }
 
-// configJsonBody json request body.
-type configJsonBody struct {
-	Id            string
-	CaptchaType   string
-	VerifyValue   string
-	DriverAudio   *base64Captcha.DriverAudio
-	DriverString  *base64Captcha.DriverString
-	DriverChinese *base64Captcha.DriverChinese
-	DriverMath    *base64Captcha.DriverMath
-	DriverDigit   *base64Captcha.DriverDigit
-}
+// The drivers are built once and shared.
+//
+// ConvertFonts reads the font files on every call, and the string driver was
+// calling it per captcha: eleven megabytes allocated to render one image that
+// is a couple of kilobytes. A converted driver is read-only afterwards - it
+// holds the parsed fonts and the drawing parameters - so one instance serves
+// every request.
+//
+// The Captcha wrapper is still built per call, because it binds the driver to
+// whatever store SetStore has installed, and that can change.
+var (
+	stringDriverOnce sync.Once
+	stringDriver     *base64Captcha.DriverString
+
+	digitDriverOnce sync.Once
+	digitDriver     *base64Captcha.DriverDigit
+)
 
 func DriverStringFunc() (id, b64s, answer string, err error) {
-	e := configJsonBody{}
-	e.Id = uuid.New().String()
-	e.DriverString = base64Captcha.NewDriverString(46, 140, 2, 2, 4, "234567890abcdefghjkmnpqrstuvwxyz", &color.RGBA{240, 240, 246, 246}, nil, []string{"wqy-microhei.ttc"})
-	driver := e.DriverString.ConvertFonts()
-	captcha := base64Captcha.NewCaptcha(driver, base64Captcha.DefaultMemStore)
+	stringDriverOnce.Do(func() {
+		stringDriver = base64Captcha.NewDriverString(
+			46, 140, 2, 2, 4,
+			"234567890abcdefghjkmnpqrstuvwxyz",
+			&color.RGBA{240, 240, 246, 246},
+			nil,
+			[]string{"wqy-microhei.ttc"},
+		).ConvertFonts()
+	})
+	captcha := base64Captcha.NewCaptcha(stringDriver, base64Captcha.DefaultMemStore)
 	return captcha.Generate()
 }
 
 func DriverDigitFunc() (id, b64s, answer string, err error) {
-	e := configJsonBody{}
-	e.Id = uuid.New().String()
-	e.DriverDigit = base64Captcha.NewDriverDigit(80, 240, 4, 0.7, 80)
-	driver := e.DriverDigit
-	captcha := base64Captcha.NewCaptcha(driver, base64Captcha.DefaultMemStore)
+	digitDriverOnce.Do(func() {
+		digitDriver = base64Captcha.NewDriverDigit(80, 240, 4, 0.7, 80)
+	})
+	captcha := base64Captcha.NewCaptcha(digitDriver, base64Captcha.DefaultMemStore)
 	return captcha.Generate()
 }
 

--- a/casbin/bench_test.go
+++ b/casbin/bench_test.go
@@ -1,0 +1,88 @@
+package mycasbin
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/casbin/casbin/v3"
+	"github.com/casbin/casbin/v3/model"
+)
+
+// Every request to a protected route runs one Enforce. The matcher compares the
+// subject and then calls keyMatch2 and keyMatch on the path, per policy, so the
+// cost grows with the number of rules - and the rule count grows with the
+// application, one row per API the roles can reach.
+//
+// go-admin uses a SyncedEnforcer, whose Enforce takes a read lock, so these run
+// in parallel as well: the question is not only how long one check takes but
+// whether checks get in each other's way.
+
+// benchEnforcer builds an enforcer with n decoy policies plus one that matches,
+// placed last so the matcher has to walk everything first. That is the honest
+// case to measure: a hit found immediately would report the best position in
+// the table rather than a typical one.
+func benchEnforcer(b *testing.B, n int) *casbin.SyncedEnforcer {
+	b.Helper()
+
+	m, err := model.NewModelFromString(text)
+	if err != nil {
+		b.Fatal(err)
+	}
+	e, err := casbin.NewSyncedEnforcer(m)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	rules := make([][]string, 0, n+1)
+	for i := 0; i < n; i++ {
+		rules = append(rules, []string{
+			"role" + strconv.Itoa(i%16),
+			"/api/v1/resource" + strconv.Itoa(i) + "/:id",
+			"GET",
+		})
+	}
+	rules = append(rules, []string{"admin", "/api/v1/dept", "GET"})
+
+	if _, err := e.AddPolicies(rules); err != nil {
+		b.Fatal(err)
+	}
+	return e
+}
+
+func benchEnforce(b *testing.B, n int, sub, obj, act string, want bool) {
+	e := benchEnforcer(b, n)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ok, err := e.Enforce(sub, obj, act)
+			if err != nil {
+				b.Error(err)
+				return
+			}
+			if ok != want {
+				b.Errorf("Enforce = %v, want %v", ok, want)
+				return
+			}
+		}
+	})
+}
+
+// Allowed: the request matches, but only after every decoy has been tried.
+func BenchmarkEnforceAllow10(b *testing.B) { benchEnforce(b, 10, "admin", "/api/v1/dept", "GET", true) }
+func BenchmarkEnforceAllow100(b *testing.B) {
+	benchEnforce(b, 100, "admin", "/api/v1/dept", "GET", true)
+}
+func BenchmarkEnforceAllow1000(b *testing.B) {
+	benchEnforce(b, 1000, "admin", "/api/v1/dept", "GET", true)
+}
+func BenchmarkEnforceAllow5000(b *testing.B) {
+	benchEnforce(b, 5000, "admin", "/api/v1/dept", "GET", true)
+}
+
+// Denied: nothing matches, so the whole table is walked every time. This is
+// what an unauthorised request costs, and it is the worst case by construction.
+func BenchmarkEnforceDeny1000(b *testing.B) {
+	benchEnforce(b, 1000, "nobody", "/api/v1/secret", "DELETE", false)
+}

--- a/docs/storage/README.md
+++ b/docs/storage/README.md
@@ -85,6 +85,13 @@ from the Redis one in two ways that only show up on the switch:
 - The original memory queue retries a failed message three times on its own.
   Redis retries through `max_attempts`; `MemQueue`, which `Open()` returns, does
   not retry at all.
+- **A full queue behaves differently.** The original memory queue drops the
+  message and returns an error, so `poolSize` is the point at which messages
+  start being lost rather than a tuning knob: one consumer goroutine per topic
+  draining into a database will not keep up with a busy endpoint, and the
+  default of 100 empties into losses under load. `MemQueue` and Redis apply
+  back pressure instead — `Publish` blocks until there is room or the context
+  is done. Size the original queue for the burst, or move to `Open()`.
 
 Code that wants one behaviour on both backends should move to `Open()` and the
 `Queue` contract.
@@ -107,7 +114,7 @@ type Cache interface {
 
 | Implementation | Constructor | Use |
 | --- | --- | --- |
-| memory | `cache.NewMemCache()` | one instance, nothing to run |
+| memory | `cache.NewMemCache()` / `cache.NewMemCacheWithOptions(o)` | one instance, nothing to run |
 | Redis | `redis.New(client)` / `redis.Open(ctx, url)` | several instances |
 
 `redis.New` borrows the client and leaves it open on `Close`; `redis.Open` owns
@@ -125,6 +132,22 @@ Rules worth knowing before writing against it:
   no ttl.
 - `ctx` is checked first, so a caller that gave up gets its own error rather
   than `ErrCacheClosed`.
+- **`MemCache` is bounded — the older `Memory` is not.** `cache.NewMemCache`,
+  which is what `Open()` returns, holds a million entries by default and evicts
+  to stay within that, so an entry can disappear before its ttl expires. Expired
+  entries are dropped first; only a shard with none to spare drops a live one.
+  Treat any read as able to miss — which the contract already required.
+  `cache.NewMemCacheWithOptions(cache.MemCacheOptions{MaxEntries: n})` sets
+  another limit, and a negative `MaxEntries` restores unbounded growth, which is
+  only safe where the keyspace is bounded by something else. Redis is bounded by
+  that server's own `maxmemory` policy instead.
+
+  `Setup()`'s memory branch still returns `cache.NewMemory`, which has **no such
+  bound** and grows until the process runs out of memory. Everything reached
+  through `AdapterCache` is on that path — `captcha.NewCacheStore` and
+  `Runtime.SetCacheAdapter` among them — so a caller that writes one entry per
+  request under a key it never reuses should either bound the keyspace itself or
+  move to `Open()`.
 
 `storage.WithPrefix(c, "app:")` namespaces one backend across applications.
 

--- a/jwtauth/alloc_budget_test.go
+++ b/jwtauth/alloc_budget_test.go
@@ -1,0 +1,30 @@
+package jwtauth
+
+import "testing"
+
+// Parsing a token is the fixed cost of every authenticated request. The budget
+// is generous because the work is genuinely allocation-heavy - HMAC
+// verification plus JSON decoding into a claim map - but it still catches a
+// change that makes it materially worse, which is what a gate is for.
+//
+// Allocation counts are deterministic; see the note in
+// storage/cache/alloc_budget_test.go for why the timing figures are not gated.
+func TestParseTokenAllocationBudget(t *testing.T) {
+	mw := newBenchMiddlewareForTest(t)
+	token, _, err := mw.TokenGenerator(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := mw.ParseTokenString(token); err != nil {
+		t.Fatal(err)
+	}
+
+	got := testing.AllocsPerRun(50, func() {
+		_, _ = mw.ParseTokenString(token)
+	})
+	const budget = 90
+	if got > budget {
+		t.Errorf("ParseTokenString allocates %.0f times, budget is %d", got, budget)
+	}
+}

--- a/jwtauth/concurrency_bench_test.go
+++ b/jwtauth/concurrency_bench_test.go
@@ -1,0 +1,162 @@
+package jwtauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Every authenticated request pays for a token parse before any business code
+// runs, so this is the floor under the API's throughput. The claim set matches
+// what go-admin actually issues (identity, roleid, rolekey, nice, datascope,
+// rolename, deptid) - claim count drives both the signature size and the map
+// allocation, so a smaller set would report a number nobody sees in practice.
+
+const benchKey = "bench-secret-key-for-jwtauth-throughput"
+
+// newBenchMiddlewareForTest mirrors newBenchMiddleware for callers holding a
+// *testing.T rather than a *testing.B.
+func newBenchMiddlewareForTest(t *testing.T) *GinJWTMiddleware {
+	t.Helper()
+	mw := benchMiddleware()
+	if err := mw.MiddlewareInit(); err != nil {
+		t.Fatal(err)
+	}
+	return mw
+}
+
+// benchMiddleware builds the middleware without initialising it, so the two
+// wrappers above can report failure through their own testing type.
+func benchMiddleware() *GinJWTMiddleware {
+	return &GinJWTMiddleware{
+		Realm:            "bench",
+		Key:              []byte(benchKey),
+		SigningAlgorithm: "HS256",
+		Timeout:          time.Hour,
+		MaxRefresh:       time.Hour,
+		TokenLookup:      "header: Authorization",
+		TokenHeadName:    "Bearer",
+		PayloadFunc: func(data interface{}) MapClaims {
+			return MapClaims{
+				IdentityKey:  1,
+				RoleIdKey:    1,
+				RoleKey:      "admin",
+				NiceKey:      "admin",
+				DataScopeKey: "2",
+				RoleNameKey:  "System Administrator",
+				"deptid":     1,
+			}
+		},
+	}
+}
+
+func newBenchMiddleware(b *testing.B) *GinJWTMiddleware {
+	b.Helper()
+	mw := benchMiddleware()
+	if err := mw.MiddlewareInit(); err != nil {
+		b.Fatal(err)
+	}
+	return mw
+}
+
+func benchToken(b *testing.B, mw *GinJWTMiddleware) string {
+	b.Helper()
+	token, _, err := mw.TokenGenerator(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return token
+}
+
+// BenchmarkTokenGenerator is the login path: signing happens once per login,
+// not once per request.
+func BenchmarkTokenGenerator(b *testing.B) {
+	mw := newBenchMiddleware(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, _, err := mw.TokenGenerator(nil); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+// BenchmarkParseTokenString is the per-request cost: HMAC verification plus
+// claim decoding, with no HTTP or routing around it.
+func BenchmarkParseTokenString(b *testing.B) {
+	mw := newBenchMiddleware(b)
+	token := benchToken(b, mw)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := mw.ParseTokenString(token); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+// BenchmarkMiddlewareFunc measures what a protected route costs before it
+// reaches a handler: gin routing, header extraction, parse, claim injection.
+// The handler does nothing, so the difference against an unprotected route is
+// the price of authentication.
+func BenchmarkMiddlewareFunc(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+	mw := newBenchMiddleware(b)
+	token := benchToken(b, mw)
+
+	r := gin.New()
+	r.GET("/ping", mw.MiddlewareFunc(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		for pb.Next() {
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				b.Errorf("status %d", w.Code)
+				return
+			}
+		}
+	})
+}
+
+// BenchmarkBareRoute is the control: the same route without the middleware, so
+// the authentication cost can be read as a difference rather than an absolute.
+func BenchmarkBareRoute(b *testing.B) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.GET("/ping", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+		for pb.Next() {
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			if w.Code != http.StatusOK {
+				b.Errorf("status %d", w.Code)
+				return
+			}
+		}
+	})
+}

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Compares benchmark results between the working tree and a base revision.
+#
+# Allocation counts are gated by tests (see any alloc_budget_test.go); timings
+# cannot be, because a threshold loose enough to survive a shared CI runner is
+# too loose to catch anything. This script exists for the other half: it runs
+# both revisions on one machine, back to back, and hands the numbers to
+# benchstat so the noise is quantified rather than guessed at.
+#
+# Usage:
+#   scripts/bench-compare.sh [base-ref] [bench-regexp] [count]
+#
+#   scripts/bench-compare.sh                 # against origin/main, all benchmarks
+#   scripts/bench-compare.sh HEAD~1 Cache    # one revision back, cache only
+#   scripts/bench-compare.sh main Enforce 10 # ten runs for a tighter interval
+#
+# The base revision is built in a throw-away git worktree, so the working tree
+# is never touched and uncommitted changes are what gets measured.
+#
+# Read the output as benchstat intends: a delta with "~" means the difference
+# did not clear the noise, however large the percentage looks. If everything
+# reads "~", raise the count rather than the conclusion.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+PATTERN="${2:-.}"
+COUNT="${3:-6}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo "bench-compare: no such revision: $BASE_REF" >&2
+  exit 1
+fi
+
+WORKDIR="$(mktemp -d)"
+BASE_TREE="$WORKDIR/base"
+cleanup() {
+  git worktree remove --force "$BASE_TREE" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+echo "==> base revision: $BASE_REF ($(git rev-parse --short "$BASE_REF"))"
+git worktree add --detach "$BASE_TREE" "$BASE_REF" >/dev/null
+
+run_bench() {
+  local dir="$1" out="$2" label="$3"
+  echo "==> benchmarking $label (count=$COUNT, pattern=$PATTERN)"
+  # -run '^$' keeps ordinary tests out of the timings.
+  ( cd "$dir" && go test -run '^$' -bench "$PATTERN" -benchmem -count "$COUNT" ./... ) \
+    2>&1 | tee "$out" | grep -E '^(Benchmark|FAIL|ok)' || true
+}
+
+run_bench "$BASE_TREE" "$WORKDIR/base.txt" "base"
+run_bench "$REPO_ROOT" "$WORKDIR/head.txt" "working tree"
+
+echo
+echo "==> benchstat base -> working tree"
+go run golang.org/x/perf/cmd/benchstat@latest "$WORKDIR/base.txt" "$WORKDIR/head.txt"

--- a/sdk/config/cache.go
+++ b/sdk/config/cache.go
@@ -45,6 +45,12 @@ func (e Cache) Setup() (storage.AdapterCache, error) {
 	// The memory branch stays on the older implementation. Both satisfy
 	// AdapterCache, but only this one preserves the retry and expiry behaviour
 	// that current call sites were written against.
+	//
+	// Two consequences of that choice, stated here rather than left to be
+	// discovered: cache.Memory has no entry limit, so a caller that writes keys
+	// it never reads again grows it until the process runs out of memory; and
+	// its counters serialise on a single mutex. Open() returns MemCache, which
+	// is bounded and sharded. Callers that need either should move to it.
 	if e.Redis == nil {
 		return cache.NewMemory(), nil
 	}

--- a/sdk/pkg/alloc_budget_test.go
+++ b/sdk/pkg/alloc_budget_test.go
@@ -1,0 +1,32 @@
+package pkg
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+// Both helpers run on every request. Allocation counts are deterministic, so
+// these are gates rather than measurements - see the note in
+// storage/cache/alloc_budget_test.go.
+func TestPkgAllocationBudget(t *testing.T) {
+	c := benchContext(true)
+	c.Set("db", new(gorm.DB))
+
+	// A type assertion off the context map; nothing is constructed.
+	if got := testing.AllocsPerRun(100, func() { _, _ = GetOrm(c) }); got > 0 {
+		t.Errorf("GetOrm allocates %.0f times, budget is 0", got)
+	}
+
+	// The failure path is on every request of a misconfigured route, so it is
+	// budgeted too - a fresh error per call is a fresh allocation per call.
+	missing := benchContext(true)
+	if got := testing.AllocsPerRun(100, func() { _, _ = GetOrm(missing) }); got > 0 {
+		t.Errorf("GetOrm on a request without a db allocates %.0f times, budget is 0", got)
+	}
+
+	// When a gateway already supplied the correlation id this is a header read.
+	if got := testing.AllocsPerRun(100, func() { _ = GenerateMsgIDFromContext(c) }); got > 0 {
+		t.Errorf("GenerateMsgIDFromContext with an existing id allocates %.0f times, budget is 0", got)
+	}
+}

--- a/sdk/pkg/bench_test.go
+++ b/sdk/pkg/bench_test.go
@@ -1,0 +1,81 @@
+package pkg
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// Two helpers run on essentially every request. GenerateMsgIDFromContext gives
+// the request its correlation id, and GetOrm is how handlers and services reach
+// the database - go-admin calls it from fourteen places, several of them more
+// than once per request.
+
+func benchContext(withHeader bool) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	if withHeader {
+		c.Request.Header.Set(TrafficKey, "11111111-2222-3333-4444-555555555555")
+	}
+	return c
+}
+
+// BenchmarkGenerateMsgIDFromContextNew is a request that arrived without a
+// correlation id: a UUID is minted and written to the response header.
+//
+// One context serves every iteration because the lookup reads the *request*
+// header while the write goes to the *response* header, so the miss repeats
+// and every iteration mints a fresh id.
+func BenchmarkGenerateMsgIDFromContextNew(b *testing.B) {
+	c := benchContext(false)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = GenerateMsgIDFromContext(c)
+	}
+}
+
+// BenchmarkGenerateMsgIDFromContextExisting is every later call, and the case
+// where a gateway already supplied the id: a header read and nothing else.
+func BenchmarkGenerateMsgIDFromContextExisting(b *testing.B) {
+	c := benchContext(true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = GenerateMsgIDFromContext(c)
+	}
+}
+
+func BenchmarkGetOrm(b *testing.B) {
+	c := benchContext(true)
+	c.Set("db", new(gorm.DB))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := GetOrm(c); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGetOrmMissing is the error path. It matters because the handlers
+// call GetOrm before doing anything else, so a misconfigured request pays this
+// on every route.
+func BenchmarkGetOrmMissing(b *testing.B) {
+	c := benchContext(true)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := GetOrm(c); err == nil {
+			b.Fatal("expected an error")
+		}
+	}
+}

--- a/sdk/pkg/utils.go
+++ b/sdk/pkg/utils.go
@@ -67,17 +67,22 @@ func GenerateMsgIDFromContext(c *gin.Context) string {
 	return requestId
 }
 
+// errDBNotInContext is built once rather than per call. Handlers call GetOrm
+// before doing anything else, so a misconfigured route allocated an error on
+// every request it served - and the message was identical every time.
+var errDBNotInContext = errors.New("db connect not exist")
+
 // GetOrm 获取orm连接
 func GetOrm(c *gin.Context) (*gorm.DB, error) {
 	idb, exist := c.Get("db")
 	if !exist {
-		return nil, errors.New("db connect not exist")
+		return nil, errDBNotInContext
 	}
 	switch db := idb.(type) {
 	case *gorm.DB:
 		//新增操作
 		return db, nil
 	default:
-		return nil, errors.New("db connect not exist")
+		return nil, errDBNotInContext
 	}
 }

--- a/storage/cache/alloc_budget_test.go
+++ b/storage/cache/alloc_budget_test.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Allocation counts are the half of a performance regression that can be
+// asserted. Wall-clock numbers move with whatever else the machine is doing,
+// so a CI gate built on them either has a threshold loose enough to miss real
+// regressions or tight enough to fail at random. Allocations per operation are
+// deterministic: the same code path allocates the same number of times on every
+// machine, so a change in the count is a change in the code.
+//
+// The budgets below are the measured counts with a little headroom. Raising one
+// is a deliberate act - it should come with a reason, because these paths run
+// on every request.
+
+func assertAllocs(t *testing.T, name string, budget float64, fn func()) {
+	t.Helper()
+	// Warm the path once: first-call lazy initialisation is not what the
+	// budget is about.
+	fn()
+	got := testing.AllocsPerRun(100, fn)
+	if got > budget {
+		t.Errorf("%s allocates %.0f times per call, budget is %.0f", name, got, budget)
+	}
+}
+
+func TestCacheAllocationBudget(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("MemCache", func(t *testing.T) {
+		m := NewMemCacheWithSweep(0)
+		defer func() { _ = m.Close() }()
+		if err := m.Set(ctx, "k", "v", time.Hour); err != nil {
+			t.Fatal(err)
+		}
+
+		// A hit returns a string already in the map; nothing needs to be built.
+		assertAllocs(t, "MemCache.Get(hit)", 0, func() {
+			_, _ = m.Get(ctx, "k")
+		})
+		// A miss must not allocate either - an unauthenticated endpoint can
+		// drive misses at will.
+		assertAllocs(t, "MemCache.Get(miss)", 0, func() {
+			_, _ = m.Get(ctx, "absent")
+		})
+		assertAllocs(t, "MemCache.Set", 2, func() {
+			_ = m.Set(ctx, "k", "v", time.Hour)
+		})
+	})
+
+	t.Run("Memory", func(t *testing.T) {
+		m := NewMemoryWithCleanupInterval(0)
+		defer func() { _ = m.Close() }()
+		if err := m.Set("k", "v", 3600); err != nil {
+			t.Fatal(err)
+		}
+
+		assertAllocs(t, "Memory.Get(hit)", 0, func() {
+			_, _ = m.Get("k")
+		})
+	})
+}

--- a/storage/cache/capacity_test.go
+++ b/storage/cache/capacity_test.go
@@ -1,0 +1,137 @@
+package cache
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// Without a cap the cache grows until the process dies, and reaching that state
+// needs no bug - an unauthenticated endpoint that writes one entry per request
+// is enough. These pin the bound and what it costs.
+
+// TestCapacityIsBounded writes far past the cap with distinct keys, which is
+// the shape of the captcha endpoint under load: a fresh key every time, none of
+// them read again.
+func TestCapacityIsBounded(t *testing.T) {
+	ctx := context.Background()
+	const cap = 3200 // 100 per shard
+	m := NewMemCacheWithOptions(MemCacheOptions{MaxEntries: cap})
+	defer func() { _ = m.Close() }()
+
+	for i := 0; i < cap*10; i++ {
+		if err := m.Set(ctx, "k"+strconv.Itoa(i), "v", time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := countEntries(m)
+	if got > cap {
+		t.Errorf("cache holds %d entries with a cap of %d", got, cap)
+	}
+	// A cap that evicts far more than it must would make the cache useless.
+	if got < cap/2 {
+		t.Errorf("cache holds only %d entries with a cap of %d; eviction is too eager", got, cap)
+	}
+}
+
+// TestEvictionPrefersExpiredEntries checks the cheap option is taken first. A
+// shard full of expired entries should need no eviction of live ones.
+func TestEvictionPrefersExpiredEntries(t *testing.T) {
+	ctx := context.Background()
+	const cap = 3200
+	m := NewMemCacheWithOptions(MemCacheOptions{MaxEntries: cap})
+	defer func() { _ = m.Close() }()
+
+	// Fill with entries that expire almost immediately.
+	for i := 0; i < cap; i++ {
+		if err := m.Set(ctx, "old"+strconv.Itoa(i), "v", time.Millisecond); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	// Now write live entries. They should displace the expired ones.
+	const live = 1000
+	for i := 0; i < live; i++ {
+		if err := m.Set(ctx, "live"+strconv.Itoa(i), "v", time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	survived := 0
+	for i := 0; i < live; i++ {
+		if _, err := m.Get(ctx, "live"+strconv.Itoa(i)); err == nil {
+			survived++
+		}
+	}
+	// Expired entries were available to reclaim, so the live writes should
+	// almost all still be there. Some loss is possible when writes concentrate
+	// on one shard, so this is a floor rather than an equality.
+	if survived < live*9/10 {
+		t.Errorf("only %d of %d live entries survived; eviction is dropping live "+
+			"entries while expired ones remain", survived, live)
+	}
+}
+
+// TestUnlimitedIsOptOut keeps the escape hatch honest for a caller whose
+// keyspace is bounded some other way.
+func TestUnlimitedIsOptOut(t *testing.T) {
+	ctx := context.Background()
+	m := NewMemCacheWithOptions(MemCacheOptions{MaxEntries: -1})
+	defer func() { _ = m.Close() }()
+
+	const n = 5000
+	for i := 0; i < n; i++ {
+		if err := m.Set(ctx, "k"+strconv.Itoa(i), "v", time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := countEntries(m); got != n {
+		t.Errorf("unlimited cache holds %d of %d entries", got, n)
+	}
+}
+
+// TestDefaultConstructorIsBounded is the one that matters in production: the
+// constructors everything actually calls must carry the cap, not just the
+// options form nobody uses.
+func TestDefaultConstructorIsBounded(t *testing.T) {
+	for name, m := range map[string]*MemCache{
+		"NewMemCache":          NewMemCache(),
+		"NewMemCacheWithSweep": NewMemCacheWithSweep(0),
+	} {
+		if m.maxPerShard <= 0 {
+			t.Errorf("%s builds an unbounded cache", name)
+		}
+		_ = m.Close()
+	}
+}
+
+// BenchmarkSetAtCapacity is the steady state of a cache that has filled up:
+// every write adds a key nobody will read again, so every write has to evict.
+// This is the captcha endpoint under load, and the shape that makes eviction a
+// per-write cost rather than an occasional one.
+//
+// It is here to keep that cost flat. An eviction that scanned the shard for
+// expired entries instead of sampling made this grow with shard size.
+func BenchmarkSetAtCapacity(b *testing.B) {
+	ctx := context.Background()
+	const capacity = 32 * 4096 // 4096 per shard
+	m := NewMemCacheWithOptions(MemCacheOptions{MaxEntries: capacity})
+	defer func() { _ = m.Close() }()
+
+	for i := 0; i < capacity; i++ {
+		if err := m.Set(ctx, "fill"+strconv.Itoa(i), "v", time.Hour); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := m.Set(ctx, "new"+strconv.Itoa(i), "v", time.Hour); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/storage/cache/concurrency_test.go
+++ b/storage/cache/concurrency_test.go
@@ -1,0 +1,365 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The in-memory cache is what a single-instance deployment runs on: leaving the
+// redis section unset in settings.yml selects it. Everything here therefore
+// exercises it the way a live server does - every operation from many
+// goroutines at once - rather than one call at a time.
+//
+// Run the correctness tests under -race. The throughput benchmarks are meant to
+// be read as a ceiling for one process, so run those without it.
+
+const (
+	concurrentWriters = 50
+	opsPerWriter      = 200
+)
+
+// TestMemoryIncreaseIsAtomic pins the counter contract. Increase used to take
+// the read lock, which does not exclude other writers, so concurrent callers
+// read the same value and wrote back the same result. The count came out around
+// 10% short and the race detector flagged the write.
+func TestMemoryIncreaseIsAtomic(t *testing.T) {
+	m := NewMemoryWithCleanupInterval(0)
+	defer func() { _ = m.Close() }()
+
+	if err := m.Set("n", 0, 60); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(concurrentWriters)
+	for i := 0; i < concurrentWriters; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerWriter; j++ {
+				if err := m.Increase("n"); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := m.Get("n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := strconv.Atoi(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := concurrentWriters * opsPerWriter; n != want {
+		t.Errorf("lost %d of %d increments, counter reports %d", want-n, want, n)
+	}
+}
+
+// TestMemoryDecreaseIsAtomic covers the other direction, which shares the
+// implementation but not the test.
+func TestMemoryDecreaseIsAtomic(t *testing.T) {
+	m := NewMemoryWithCleanupInterval(0)
+	defer func() { _ = m.Close() }()
+
+	start := concurrentWriters * opsPerWriter
+	if err := m.Set("n", start, 60); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(concurrentWriters)
+	for i := 0; i < concurrentWriters; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < opsPerWriter; j++ {
+				if err := m.Decrease("n"); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	got, err := m.Get("n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := strconv.Atoi(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("counter should be back to 0, got %d", n)
+	}
+}
+
+// TestMemoryExpireDoesNotRaceWithReaders covers the second half of the same
+// defect: Expire reached through the pointer it had just read to reset the
+// deadline, and that pointer is published in the map where readers hold it.
+func TestMemoryExpireDoesNotRaceWithReaders(t *testing.T) {
+	m := NewMemoryWithCleanupInterval(0)
+	defer func() { _ = m.Close() }()
+
+	if err := m.Set("k", "v", 60); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if _, err := m.Get("k"); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 2000; i++ {
+		if err := m.Expire("k", time.Minute); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	readers.Wait()
+}
+
+// TestMemoryMixedTrafficIsRaceFree runs the four operations a request path
+// actually mixes. It asserts nothing beyond "no race and no error", which is
+// what -race is here to check.
+func TestMemoryMixedTrafficIsRaceFree(t *testing.T) {
+	m := NewMemoryWithCleanupInterval(10 * time.Millisecond)
+	defer func() { _ = m.Close() }()
+
+	if err := m.Set("counter", 0, 60); err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentWriters; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			key := fmt.Sprintf("key-%d", id)
+			for j := 0; j < opsPerWriter; j++ {
+				if err := m.Set(key, j, 60); err != nil {
+					t.Error(err)
+					return
+				}
+				if _, err := m.Get(key); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := m.Increase("counter"); err != nil {
+					t.Error(err)
+					return
+				}
+				if err := m.Expire(key, time.Minute); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+			if err := m.Del(key); err != nil {
+				t.Error(err)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// --- throughput ---------------------------------------------------------
+//
+// RunParallel spreads the work over GOMAXPROCS goroutines, so these report what
+// one process sustains with every core pushing, not a single-threaded figure.
+
+func BenchmarkMemoryGet(b *testing.B) {
+	m := NewMemoryWithCleanupInterval(0)
+	defer func() { _ = m.Close() }()
+	if err := m.Set("k", "v", 3600); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := m.Get("k"); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+func BenchmarkMemorySet(b *testing.B) {
+	m := NewMemoryWithCleanupInterval(0)
+	defer func() { _ = m.Close() }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			// Distinct keys per goroutine, so this measures the store rather
+			// than contention on one map bucket.
+			if err := m.Set("k"+strconv.Itoa(i%64), "v", 3600); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkMemoryIncrease is the serialised path: every caller takes the same
+// write lock, so this is the one that does not scale with cores.
+func BenchmarkMemoryIncrease(b *testing.B) {
+	m := NewMemoryWithCleanupInterval(0)
+	defer func() { _ = m.Close() }()
+	if err := m.Set("n", 0, 3600); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := m.Increase("n"); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+// --- the same three against the current contract ------------------------
+//
+// MemCache is what Cache.Open returns. Setup, which is what most call sites
+// still go through, returns Memory above. Keeping both here makes the cost of
+// staying on the deprecated one visible.
+
+// BenchmarkMemCacheGet spreads reads over many keys, which is what a cache
+// holding sessions, captchas or per-user data actually sees.
+func BenchmarkMemCacheGet(b *testing.B) {
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(0)
+	defer func() { _ = m.Close() }()
+	for i := 0; i < 1024; i++ {
+		if err := m.Set(ctx, "k"+strconv.Itoa(i), "v", time.Hour); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if _, err := m.Get(ctx, "k"+strconv.Itoa(i%1024)); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkMemCacheGetHotKey is the worst case: every goroutine reads the same
+// key, so they all land on one shard and sharding buys nothing. Keeping it
+// alongside the spread version stops the spread number from being read as a
+// promise about hot keys.
+func BenchmarkMemCacheGetHotKey(b *testing.B) {
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(0)
+	defer func() { _ = m.Close() }()
+	if err := m.Set(ctx, "k", "v", time.Hour); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := m.Get(ctx, "k"); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+func BenchmarkMemCacheSet(b *testing.B) {
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(0)
+	defer func() { _ = m.Close() }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if err := m.Set(ctx, "k"+strconv.Itoa(i%64), "v", time.Hour); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkMemCacheIncr counts on one key, which is what a rate limiter or a
+// failed-login counter does. It is a hot key by nature, so it does not scale
+// with shards - the serialisation is the point of the operation.
+func BenchmarkMemCacheIncr(b *testing.B) {
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(0)
+	defer func() { _ = m.Close() }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := m.Incr(ctx, "n", 1); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+// BenchmarkMemCacheIncrSpread counts on many keys - per-user or per-IP
+// counters, which is the shape that should scale.
+func BenchmarkMemCacheIncrSpread(b *testing.B) {
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(0)
+	defer func() { _ = m.Close() }()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if _, err := m.Incr(ctx, "n"+strconv.Itoa(i%1024), 1); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	})
+}

--- a/storage/cache/memcache.go
+++ b/storage/cache/memcache.go
@@ -21,19 +21,50 @@ func (e entry) expired(now time.Time) bool {
 	return !e.expiresAt.IsZero() && e.expiresAt.Before(now)
 }
 
-// MemCache is an in-process storage.Cache.
+// shardCount is how many independently locked maps the keyspace is split
+// across. It must be a power of two so the index is a mask rather than a
+// modulo.
 //
-// A single mutex guards the map. Incr must be atomic, and sync.Map cannot
-// express a read-modify-write, which is how the previous implementation lost
-// updates under concurrency.
-type MemCache struct {
+// One mutex over one map is simpler, and that is what this was. It cost two
+// things. Every operation contended on the same lock, which is why reads were
+// several times slower than the sync.Map implementation next door. And the
+// periodic sweep walks the whole map under that lock, so the cache stalled for
+// the length of the walk: at a million entries, reads that normally take 33µs
+// took 16ms - the sweep duration, exactly. Sharding bounds both by the size of
+// one shard.
+const shardCount = 32
+
+// memShard is one independently locked partition. Incr still needs an atomic
+// read-modify-write and still gets one: a key always maps to the same shard, so
+// the operations on it remain mutually exclusive.
+type memShard struct {
 	mu     sync.Mutex
 	items  map[string]entry
 	closed bool
+}
+
+// MemCache is an in-process storage.Cache.
+type MemCache struct {
+	shards [shardCount]memShard
 
 	stop     chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
+}
+
+// shard picks the partition for a key with FNV-1a, which is short enough to
+// inline and spreads the uuid-shaped keys this cache mostly holds.
+func (m *MemCache) shard(key string) *memShard {
+	const (
+		offset64 = uint32(2166136261)
+		prime64  = uint32(16777619)
+	)
+	h := offset64
+	for i := 0; i < len(key); i++ {
+		h ^= uint32(key[i])
+		h *= prime64
+	}
+	return &m.shards[h&(shardCount-1)]
 }
 
 var _ storage.Cache = (*MemCache)(nil)
@@ -51,9 +82,9 @@ func NewMemCache() *MemCache {
 // NewMemCacheWithSweep sets the sweep interval. Zero or less starts no
 // sweeper, leaving expiry entirely lazy.
 func NewMemCacheWithSweep(interval time.Duration) *MemCache {
-	m := &MemCache{
-		items: make(map[string]entry),
-		stop:  make(chan struct{}),
+	m := &MemCache{stop: make(chan struct{})}
+	for i := range m.shards {
+		m.shards[i].items = make(map[string]entry)
 	}
 	if interval > 0 {
 		m.wg.Add(1)
@@ -78,14 +109,26 @@ func (m *MemCache) sweep(interval time.Duration) {
 	}
 }
 
+// deleteExpired reclaims entries nobody reads any more. Lazy expiry handles
+// everything that is read again; this exists for the rest, which would
+// otherwise be held for the life of the process.
+//
+// It takes one shard at a time. The whole map is still walked, but no single
+// acquisition covers more than a shard of it, so the stall any concurrent
+// operation can see is bounded by shard size rather than cache size.
 func (m *MemCache) deleteExpired() {
 	now := time.Now()
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for k, e := range m.items {
-		if e.expired(now) {
-			delete(m.items, k)
+	for i := range m.shards {
+		s := &m.shards[i]
+		s.mu.Lock()
+		if !s.closed {
+			for k, e := range s.items {
+				if e.expired(now) {
+					delete(s.items, k)
+				}
+			}
 		}
+		s.mu.Unlock()
 	}
 }
 
@@ -101,18 +144,19 @@ func (m *MemCache) Get(ctx context.Context, key string) (string, error) {
 		return "", err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.closed {
+	s := m.shard(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
 		return "", storage.ErrCacheClosed
 	}
 
-	e, ok := m.items[key]
+	e, ok := s.items[key]
 	if !ok {
 		return "", storage.ErrCacheMiss
 	}
 	if e.expired(time.Now()) {
-		delete(m.items, key)
+		delete(s.items, key)
 		return "", storage.ErrCacheMiss
 	}
 	return e.value, nil
@@ -123,13 +167,14 @@ func (m *MemCache) Set(ctx context.Context, key, val string, ttl time.Duration) 
 		return err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.closed {
+	s := m.shard(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
 		return storage.ErrCacheClosed
 	}
 
-	m.items[key] = entry{value: val, expiresAt: expiry(ttl)}
+	s.items[key] = entry{value: val, expiresAt: expiry(ttl)}
 	return nil
 }
 
@@ -138,14 +183,17 @@ func (m *MemCache) Del(ctx context.Context, keys ...string) error {
 		return err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.closed {
-		return storage.ErrCacheClosed
-	}
-
+	// Keys are locked one shard at a time rather than all at once; the
+	// contract makes no atomicity promise across keys.
 	for _, k := range keys {
-		delete(m.items, k)
+		s := m.shard(k)
+		s.mu.Lock()
+		if s.closed {
+			s.mu.Unlock()
+			return storage.ErrCacheClosed
+		}
+		delete(s.items, k)
+		s.mu.Unlock()
 	}
 	return nil
 }
@@ -155,14 +203,15 @@ func (m *MemCache) Incr(ctx context.Context, key string, delta int64) (int64, er
 		return 0, err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.closed {
+	s := m.shard(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
 		return 0, storage.ErrCacheClosed
 	}
 
 	var current int64
-	if e, ok := m.items[key]; ok && !e.expired(time.Now()) {
+	if e, ok := s.items[key]; ok && !e.expired(time.Now()) {
 		n, err := strconv.ParseInt(e.value, 10, 64)
 		if err != nil {
 			return 0, err
@@ -172,7 +221,7 @@ func (m *MemCache) Incr(ctx context.Context, key string, delta int64) (int64, er
 
 	current += delta
 	// A counter created here carries no ttl, matching Redis INCR.
-	m.items[key] = entry{value: strconv.FormatInt(current, 10)}
+	s.items[key] = entry{value: strconv.FormatInt(current, 10)}
 	return current, nil
 }
 
@@ -181,20 +230,21 @@ func (m *MemCache) Expire(ctx context.Context, key string, ttl time.Duration) er
 		return err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.closed {
+	s := m.shard(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
 		return storage.ErrCacheClosed
 	}
 
-	e, ok := m.items[key]
+	e, ok := s.items[key]
 	if !ok || e.expired(time.Now()) {
-		delete(m.items, key)
+		delete(s.items, key)
 		return storage.ErrCacheMiss
 	}
 
 	e.expiresAt = expiry(ttl)
-	m.items[key] = e
+	s.items[key] = e
 	return nil
 }
 
@@ -204,9 +254,12 @@ func (m *MemCache) Close() error {
 	})
 	m.wg.Wait()
 
-	m.mu.Lock()
-	m.closed = true
-	m.items = nil
-	m.mu.Unlock()
+	for i := range m.shards {
+		s := &m.shards[i]
+		s.mu.Lock()
+		s.closed = true
+		s.items = nil
+		s.mu.Unlock()
+	}
 	return nil
 }

--- a/storage/cache/memcache.go
+++ b/storage/cache/memcache.go
@@ -11,6 +11,39 @@ import (
 
 const defaultSweepInterval = time.Minute
 
+// defaultMaxEntries bounds how much an in-process cache can hold.
+//
+// Without a bound the cache grows until the process dies, and reaching that
+// state needs no bug. Any endpoint that writes an entry under a key it will
+// never reuse - a one-time token, a per-request nonce - grows the cache at
+// whatever rate callers can drive, and an unauthenticated one puts that rate in
+// the caller's hands. At roughly 180 bytes an entry, a few thousand writes a
+// second is hundreds of megabytes before the first ttl expires.
+//
+// A million entries is about 180MB: far above what an application legitimately
+// caches in one process, far below what it takes to exhaust a machine. The
+// point is that a number exists, not that this one is exactly right; pass
+// MemCacheOptions.MaxEntries to choose another.
+//
+// The bound is on this implementation only. Memory, in the same package, backs
+// the deprecated AdapterCache and is still unbounded.
+const defaultMaxEntries = 1 << 20
+
+// MemCacheOptions configures NewMemCacheWithOptions.
+type MemCacheOptions struct {
+	// SweepInterval is how often expired entries are collected. Zero or less
+	// starts no sweeper, leaving expiry entirely lazy.
+	SweepInterval time.Duration
+
+	// MaxEntries caps the number of entries held. Zero means
+	// defaultMaxEntries; a negative value means no limit, which is only
+	// appropriate when the keyspace is known to be bounded by something else.
+	//
+	// The cap is enforced per shard, so the effective total is rounded down to
+	// a multiple of shardCount.
+	MaxEntries int
+}
+
 type entry struct {
 	value string
 	// expiresAt is the zero time when the entry never expires.
@@ -47,6 +80,9 @@ type memShard struct {
 type MemCache struct {
 	shards [shardCount]memShard
 
+	// maxPerShard is the entry budget of one shard, or zero for no limit.
+	maxPerShard int
+
 	stop     chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
@@ -76,21 +112,108 @@ var _ storage.Cache = (*MemCache)(nil)
 func (c *MemCache) String() string { return "memory" }
 
 func NewMemCache() *MemCache {
-	return NewMemCacheWithSweep(defaultSweepInterval)
+	return NewMemCacheWithOptions(MemCacheOptions{SweepInterval: defaultSweepInterval})
 }
 
 // NewMemCacheWithSweep sets the sweep interval. Zero or less starts no
 // sweeper, leaving expiry entirely lazy.
 func NewMemCacheWithSweep(interval time.Duration) *MemCache {
+	return NewMemCacheWithOptions(MemCacheOptions{SweepInterval: interval})
+}
+
+// NewMemCacheWithOptions builds a cache from an explicit configuration.
+func NewMemCacheWithOptions(o MemCacheOptions) *MemCache {
 	m := &MemCache{stop: make(chan struct{})}
 	for i := range m.shards {
 		m.shards[i].items = make(map[string]entry)
 	}
-	if interval > 0 {
+
+	switch {
+	case o.MaxEntries < 0:
+		m.maxPerShard = 0 // unlimited
+	case o.MaxEntries == 0:
+		m.maxPerShard = defaultMaxEntries / shardCount
+	default:
+		// At least one per shard, so a small explicit cap is not rounded to
+		// zero and read as "unlimited".
+		if per := o.MaxEntries / shardCount; per > 0 {
+			m.maxPerShard = per
+		} else {
+			m.maxPerShard = 1
+		}
+	}
+
+	if o.SweepInterval > 0 {
 		m.wg.Add(1)
-		go m.sweep(interval)
+		go m.sweep(o.SweepInterval)
 	}
 	return m
+}
+
+// evictionSample bounds how many entries one eviction may examine.
+//
+// The cap is what keeps eviction off the critical path. Once a shard is at its
+// limit, freeing one slot lets the caller insert one - which fills it again, so
+// the next write of a new key evicts too. Eviction is therefore per-write in
+// the steady state, not occasional, and a scan of the whole shard here would
+// cost every write what the unsharded sweep used to cost once a minute. The
+// workload that reaches the limit at all is precisely the one that writes a new
+// key every time.
+const evictionSample = 64
+
+// evictIfFull frees a slot when the shard is at its limit and the pending write
+// would add a key rather than replace one. The caller holds the shard lock.
+//
+// The key lookup happens only once the shard is known to be full, so a cache
+// that never fills pays a single length comparison.
+func (s *memShard) evictIfFull(limit int, key string) {
+	if limit <= 0 || len(s.items) < limit {
+		return
+	}
+	if _, replacing := s.items[key]; replacing {
+		return
+	}
+	s.makeRoom(limit)
+}
+
+// makeRoom frees a slot in a shard that has reached its budget. The caller
+// holds the shard lock.
+//
+// Expired entries go first: they are owed to nobody. The search for one stops
+// after evictionSample entries rather than scanning the shard to prove there is
+// none - the sweep reclaims the rest on its own schedule, and this path cannot
+// afford to look. Failing that it drops an entry chosen by map iteration order,
+// which Go leaves unspecified and is therefore effectively arbitrary.
+//
+// Arbitrary rather than least-recently-used is deliberate. Tracking recency
+// means a linked list updated on every read, and reads are the operation this
+// cache exists to make cheap; an approximate policy on a cache whose contract
+// already allows any entry to vanish is the better trade.
+func (s *memShard) makeRoom(limit int) {
+	now := time.Now()
+
+	scanned := 0
+	for k, e := range s.items {
+		if e.expired(now) {
+			delete(s.items, k)
+			if len(s.items) < limit {
+				return
+			}
+		}
+		scanned++
+		if scanned >= evictionSample {
+			break
+		}
+	}
+
+	// Nothing reclaimable in the sample. One live entry has to go; the loop
+	// exits on the first iteration, since the shard holds exactly limit.
+	for k := range s.items {
+		delete(s.items, k)
+		if len(s.items) < limit {
+			return
+		}
+	}
 }
 
 func (m *MemCache) sweep(interval time.Duration) {
@@ -174,6 +297,7 @@ func (m *MemCache) Set(ctx context.Context, key, val string, ttl time.Duration) 
 		return storage.ErrCacheClosed
 	}
 
+	s.evictIfFull(m.maxPerShard, key)
 	s.items[key] = entry{value: val, expiresAt: expiry(ttl)}
 	return nil
 }
@@ -220,6 +344,7 @@ func (m *MemCache) Incr(ctx context.Context, key string, delta int64) (int64, er
 	}
 
 	current += delta
+	s.evictIfFull(m.maxPerShard, key)
 	// A counter created here carries no ttl, matching Redis INCR.
 	s.items[key] = entry{value: strconv.FormatInt(current, 10)}
 	return current, nil

--- a/storage/cache/memory.go
+++ b/storage/cache/memory.go
@@ -189,39 +189,53 @@ func (m *Memory) Decrease(key string) error {
 	return m.calculate(key, -1)
 }
 
+// calculate is a read-modify-write, so it takes the write lock. Under the read
+// lock it used to take, concurrent callers all read the same value and wrote
+// back the same result: 50 goroutines incrementing 200 times each landed about
+// 10% short of the expected total.
+//
+// It also stores a new item rather than writing through the pointer it just
+// read. That pointer is published in the sync.Map and concurrent Get callers
+// hold it, so assigning to its fields races with them however the writers are
+// locked against each other.
 func (m *Memory) calculate(key string, num int) error {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	item, err := m.getItem(key)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	it, err := m.getItem(key)
 	if err != nil {
 		return err
 	}
 
-	if item == nil {
+	if it == nil {
 		err = fmt.Errorf("%s not exist", key)
 		return err
 	}
 	var n int
-	n, err = cast.ToIntE(item.Value)
+	n, err = cast.ToIntE(it.Value)
 	if err != nil {
 		return err
 	}
-	n += num
-	item.Value = strconv.Itoa(n)
-	return m.setItem(key, item)
+	return m.setItem(key, &item{
+		Value:   strconv.Itoa(n + num),
+		Expired: it.Expired,
+	})
 }
 
+// Expire replaces the item for the same reason calculate does: the item it
+// reads is already visible to concurrent readers.
 func (m *Memory) Expire(key string, dur time.Duration) error {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
-	item, err := m.getItem(key)
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	it, err := m.getItem(key)
 	if err != nil {
 		return err
 	}
-	if item == nil {
+	if it == nil {
 		err = fmt.Errorf("%s not exist", key)
 		return err
 	}
-	item.Expired = time.Now().Add(dur)
-	return m.setItem(key, item)
+	return m.setItem(key, &item{
+		Value:   it.Value,
+		Expired: time.Now().Add(dur),
+	})
 }

--- a/storage/cache/soak_test.go
+++ b/storage/cache/soak_test.go
@@ -1,0 +1,144 @@
+package cache
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Peak throughput says nothing about whether a process survives a week. These
+// run a steady mixed load and watch the things that only go wrong slowly:
+// goroutines that are never reaped, and a heap that never comes back down.
+//
+// They are skipped under -short, which is what CI runs today. Give them time
+// with:
+//
+//	GOADMIN_SOAK=2m go test -run Soak ./storage/cache/
+const soakEnv = "GOADMIN_SOAK"
+
+func soakDuration(t *testing.T) time.Duration {
+	t.Helper()
+	if testing.Short() {
+		t.Skipf("soak test; skipped under -short (set %s to run it longer)", soakEnv)
+	}
+	if v := os.Getenv(soakEnv); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			t.Fatalf("%s=%q: %v", soakEnv, v, err)
+		}
+		return d
+	}
+	return 15 * time.Second
+}
+
+// heapInUse reports the live heap after giving the collector two chances to
+// run. One GC is not enough: the first can leave objects finalised but not yet
+// freed, which reads as growth that is not there.
+func heapInUse() uint64 {
+	runtime.GC()
+	runtime.GC()
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	return ms.HeapInuse
+}
+
+// TestMemCacheSoak keeps a bounded working set under continuous mixed traffic
+// with short TTLs. The heap must reach a plateau: entries expire and are
+// reclaimed at roughly the rate they arrive, so a heap that keeps climbing
+// means expiry is not keeping up with writes.
+func TestMemCacheSoak(t *testing.T) {
+	duration := soakDuration(t)
+
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(200 * time.Millisecond)
+	defer func() { _ = m.Close() }()
+
+	goroutinesBefore := runtime.NumGoroutine()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	const workers = 8
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			i := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// A bounded key space with short TTLs: the steady state is a
+				// working set, not unbounded accumulation.
+				key := "soak-" + strconv.Itoa(id) + "-" + strconv.Itoa(i%5000)
+				_ = m.Set(ctx, key, "value", 300*time.Millisecond)
+				_, _ = m.Get(ctx, key)
+				if i%10 == 0 {
+					_, _ = m.Incr(ctx, "counter-"+strconv.Itoa(id), 1)
+				}
+				if i%100 == 0 {
+					_ = m.Del(ctx, key)
+				}
+				i++
+			}
+		}(w)
+	}
+
+	// Sample after the working set has filled, so the baseline is the plateau
+	// rather than the ramp.
+	time.Sleep(duration / 3)
+	mid := heapInUse()
+
+	time.Sleep(duration - duration/3)
+	close(stop)
+	wg.Wait()
+
+	end := heapInUse()
+
+	t.Logf("heap at plateau %.1f MB, at end %.1f MB over %v",
+		float64(mid)/(1024*1024), float64(end)/(1024*1024), duration)
+
+	// Doubling from an established plateau is growth, not noise.
+	if end > mid*2 {
+		t.Errorf("heap grew from %d to %d bytes after the working set had settled; "+
+			"expired entries are not being reclaimed", mid, end)
+	}
+
+	// Workers are done and the sweeper is the only goroutine the cache owns.
+	time.Sleep(100 * time.Millisecond)
+	if after := runtime.NumGoroutine(); after > goroutinesBefore+2 {
+		t.Errorf("goroutines went from %d to %d", goroutinesBefore, after)
+	}
+}
+
+// TestMemCacheCloseReleasesEverything is the shutdown path. A server that
+// rebuilds its cache on a config reload does this repeatedly, and a sweeper
+// that outlives its cache accumulates one goroutine per reload.
+func TestMemCacheCloseReleasesEverything(t *testing.T) {
+	ctx := context.Background()
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 50; i++ {
+		m := NewMemCacheWithSweep(time.Millisecond)
+		for j := 0; j < 100; j++ {
+			if err := m.Set(ctx, "k"+strconv.Itoa(j), "v", time.Minute); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := m.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	if after := runtime.NumGoroutine(); after > before {
+		t.Errorf("50 cache lifecycles left %d goroutines behind (%d -> %d)",
+			after-before, before, after)
+	}
+}

--- a/storage/cache/sweep_latency_test.go
+++ b/storage/cache/sweep_latency_test.go
@@ -1,0 +1,127 @@
+package cache
+
+import (
+	"context"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A cache that stalls while it tidies up is a cache that adds a spike to the
+// latency graph once a minute, and the spike grows with the data. These
+// measure the readers rather than the sweep, because the reader is what the
+// user experiences.
+
+// countEntries totals the entries across every shard. Tests that assert on
+// capacity or reclamation need the whole picture, and a shard's map is only
+// safe to read under its own lock.
+func countEntries(m *MemCache) int {
+	n := 0
+	for i := range m.shards {
+		s := &m.shards[i]
+		s.mu.Lock()
+		n += len(s.items)
+		s.mu.Unlock()
+	}
+	return n
+}
+
+// sweepLatencyEntries is large enough for a full walk to be clearly measurable
+// and small enough to keep the test quick.
+const sweepLatencyEntries = 500000
+
+// TestSweepDoesNotStallReaders bounds what a concurrent reader can be made to
+// wait for. A single mutex over the whole map put this at the full duration of
+// the walk - a reader normally served in tens of microseconds waited the entire
+// sweep. Sharding bounds it by one shard.
+func TestSweepDoesNotStallReaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("fills half a million entries; skipped under -short")
+	}
+
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(0)
+	defer func() { _ = m.Close() }()
+
+	for i := 0; i < sweepLatencyEntries; i++ {
+		if err := m.Set(ctx, "k"+strconv.Itoa(i), "v", time.Hour); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := m.Set(ctx, "live", "v", time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	var worst atomic.Int64
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			t0 := time.Now()
+			if _, err := m.Get(ctx, "live"); err != nil {
+				t.Error(err)
+				return
+			}
+			d := time.Since(t0).Nanoseconds()
+			for {
+				cur := worst.Load()
+				if d <= cur || worst.CompareAndSwap(cur, d) {
+					break
+				}
+			}
+		}
+	}()
+
+	// Let the reader warm up, then reset so the measurement covers the sweep.
+	time.Sleep(100 * time.Millisecond)
+	worst.Store(0)
+
+	start := time.Now()
+	m.deleteExpired()
+	sweep := time.Since(start)
+
+	close(stop)
+	<-done
+
+	stalled := time.Duration(worst.Load())
+	t.Logf("sweep of %d entries took %v; worst concurrent Get %v",
+		sweepLatencyEntries, sweep.Round(time.Microsecond), stalled.Round(time.Microsecond))
+
+	// The reader must not be held for the whole walk. Half is a generous bound
+	// that still fails loudly if the sweep ever goes back to holding one lock
+	// across the entire map - with 32 shards the real figure is far below it.
+	if stalled > sweep/2 {
+		t.Errorf("a reader waited %v during a %v sweep; the sweep is holding a lock "+
+			"across more of the map than one shard", stalled, sweep)
+	}
+}
+
+// TestSweepReclaimsEveryShard guards the other half: bounding the stall must
+// not leave entries behind. Every shard has to be visited.
+func TestSweepReclaimsEveryShard(t *testing.T) {
+	ctx := context.Background()
+	m := NewMemCacheWithSweep(0)
+	defer func() { _ = m.Close() }()
+
+	const n = 20000
+	for i := 0; i < n; i++ {
+		if err := m.Set(ctx, "k"+strconv.Itoa(i), "v", time.Millisecond); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(20 * time.Millisecond)
+
+	m.deleteExpired()
+
+	if remaining := countEntries(m); remaining != 0 {
+		t.Errorf("%d of %d expired entries survived the sweep", remaining, n)
+	}
+}

--- a/storage/queue/concurrency_test.go
+++ b/storage/queue/concurrency_test.go
@@ -1,0 +1,142 @@
+package queue
+
+import (
+	"io"
+	"log"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/v2/storage"
+)
+
+// The in-memory queue carries the login and operation logs of a server running
+// without redis, which is the default. Producers are request goroutines and the
+// consumer is registered at startup, so the two overlap in the ordinary case
+// rather than an exotic one.
+
+// TestRegisterAndAppendAgreeOnOneQueue pins the fix for the queue-creation
+// race. Both sides used to Load, miss, and Store their own channel; whichever
+// stored second won, and anything already written to the loser was never read.
+// Registering while the first messages arrive lost about one in seven.
+func TestRegisterAndAppendAgreeOnOneQueue(t *testing.T) {
+	const attempts = 200
+	lost := 0
+
+	for i := 0; i < attempts; i++ {
+		m := NewMemory(100)
+		delivered := make(chan struct{}, 4)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			m.Register("s", func(storage.Messager) error {
+				delivered <- struct{}{}
+				return nil
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = m.Append(newTestMessage("s"))
+		}()
+		wg.Wait()
+
+		select {
+		case <-delivered:
+		case <-time.After(50 * time.Millisecond):
+			lost++
+		}
+	}
+
+	if lost > 0 {
+		t.Errorf("%d of %d messages never reached the consumer; Register and Append "+
+			"disagreed about which channel is the queue", lost, attempts)
+	}
+}
+
+// TestConcurrentAppendersShareOneQueue covers the producer-only case: many
+// request goroutines writing the same stream must all reach the one consumer.
+func TestConcurrentAppendersShareOneQueue(t *testing.T) {
+	m := NewMemory(4096)
+
+	var received atomic.Int64
+	m.Register("s", func(storage.Messager) error {
+		received.Add(1)
+		return nil
+	})
+
+	const producers, each = 32, 50
+	var sent atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(producers)
+	for i := 0; i < producers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < each; j++ {
+				if err := m.Append(newTestMessage("s")); err == nil {
+					sent.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	// The consumer runs on its own goroutine; give it a bounded chance to drain
+	// rather than sleeping a fixed amount and hoping.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && received.Load() < sent.Load() {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got, want := received.Load(), sent.Load(); got != want {
+		t.Errorf("consumer saw %d of %d accepted messages", got, want)
+	}
+}
+
+// --- throughput ---------------------------------------------------------
+
+// benchAppend measures Append with a consumer draining behind it, and reports
+// the share of messages the queue refused. Append is non-blocking: a full queue
+// drops the message and returns an error rather than parking the caller, so
+// throughput alone would look excellent while the log silently went missing.
+// The drop rate is the number worth reading.
+func benchAppend(b *testing.B, poolNum uint, streams int) {
+	// Every drop is reported through the standard logger. At benchmark rates
+	// that is millions of lines competing for stderr, which would be what the
+	// numbers below measured. Worth noting for production too: a saturated
+	// queue turns into a log storm exactly when the process is already behind.
+	prev := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(prev)
+
+	m := NewMemory(poolNum)
+	for i := 0; i < streams; i++ {
+		m.Register("s"+strconv.Itoa(i), func(storage.Messager) error { return nil })
+	}
+
+	var dropped atomic.Int64
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if err := m.Append(newTestMessage("s" + strconv.Itoa(i%streams))); err != nil {
+				dropped.Add(1)
+			}
+			i++
+		}
+	})
+	b.StopTimer()
+
+	if b.N > 0 {
+		b.ReportMetric(float64(dropped.Load())*100/float64(b.N), "%dropped")
+	}
+}
+
+func BenchmarkMemoryQueueAppend(b *testing.B)            { benchAppend(b, 100, 1) }
+func BenchmarkMemoryQueueAppendLargePool(b *testing.B)   { benchAppend(b, 10000, 1) }
+func BenchmarkMemoryQueueAppendMultiStream(b *testing.B) { benchAppend(b, 10000, 8) }

--- a/storage/queue/memory.go
+++ b/storage/queue/memory.go
@@ -40,6 +40,31 @@ func (m *Memory) makeQueue() queue {
 	return make(queue, m.PoolNum)
 }
 
+// queueFor returns the channel for a stream, creating it at most once.
+//
+// LoadOrStore is what makes it once. The Load-then-Store it replaces let two
+// callers each miss, each build a channel, and the second overwrite the first:
+// a producer that had already published to the discarded channel lost those
+// messages, and a consumer registered on it stopped receiving. Register racing
+// against the first Append is the ordinary case - a server registers its log
+// consumers while requests are already arriving - and it dropped about one
+// message in seven.
+func (m *Memory) queueFor(name string) queue {
+	if v, ok := m.queue.Load(name); ok {
+		if q, ok := v.(queue); ok {
+			return q
+		}
+	}
+	v, _ := m.queue.LoadOrStore(name, m.makeQueue())
+	q, ok := v.(queue)
+	if !ok {
+		// Whatever is stored is not a queue. Replace it rather than fail.
+		q = m.makeQueue()
+		m.queue.Store(name, q)
+	}
+	return q
+}
+
 func (m *Memory) Append(message storage.Messager) error {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
@@ -48,21 +73,7 @@ func (m *Memory) Append(message storage.Messager) error {
 	memoryMessage.SetStream(message.GetStream())
 	memoryMessage.SetValues(message.GetValues())
 
-	v, ok := m.queue.Load(message.GetStream())
-
-	if !ok {
-		v = m.makeQueue()
-		m.queue.Store(message.GetStream(), v)
-	}
-
-	var q queue
-	switch v := v.(type) {
-	case queue:
-		q = v
-	default:
-		q = m.makeQueue()
-		m.queue.Store(message.GetStream(), q)
-	}
+	q := m.queueFor(message.GetStream())
 	// 不再为每条消息起 goroutine 投递。
 	//
 	// 原实现中，队列满时 goroutine 会阻塞在 channel 写入上且永不退出；
@@ -84,19 +95,7 @@ func (m *Memory) Append(message storage.Messager) error {
 func (m *Memory) Register(name string, f storage.ConsumerFunc) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	v, ok := m.queue.Load(name)
-	if !ok {
-		v = m.makeQueue()
-		m.queue.Store(name, v)
-	}
-	var q queue
-	switch v := v.(type) {
-	case queue:
-		q = v
-	default:
-		q = m.makeQueue()
-		m.queue.Store(name, q)
-	}
+	q := m.queueFor(name)
 	go func(out queue, gf storage.ConsumerFunc) {
 		var err error
 		for message := range q {

--- a/storage/redis/bench_test.go
+++ b/storage/redis/bench_test.go
@@ -1,0 +1,132 @@
+package redis_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/go-admin-team/go-admin-core/v2/storage"
+	redisstore "github.com/go-admin-team/go-admin-core/v2/storage/redis"
+)
+
+// These measure what moving off the in-memory backends costs. Redis is not
+// optional once more than one instance runs - an in-memory cache is not shared
+// and an in-memory queue is not durable - so the useful question is not whether
+// it is slower but by how much, and against what.
+//
+// Read them next to the in-memory figures in storage/cache and storage/queue.
+// Those are function calls; these are round trips, and the gap is the network,
+// not the code. A server on loopback flatters Redis compared to one across a
+// network, so treat these as the optimistic end.
+
+// benchClient is separate from adminClient in cache_test.go because the pool
+// has to be sized for the benchmark: with the default, parallel goroutines
+// queue for a connection and the numbers describe that queue rather than Redis.
+func benchClient(b *testing.B) *goredis.Client {
+	b.Helper()
+	opts, err := goredis.ParseURL(redisURL(b))
+	if err != nil {
+		b.Fatalf("parse REDIS_URL: %v", err)
+	}
+	opts.PoolSize = 128
+	client := goredis.NewClient(opts)
+	b.Cleanup(func() { _ = client.Close() })
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		b.Skipf("redis unreachable: %v", err)
+	}
+	return client
+}
+
+func BenchmarkRedisCacheGet(b *testing.B) {
+	ctx := context.Background()
+	c := redisstore.New(benchClient(b))
+	if err := c.Set(ctx, "k", "v", time.Hour); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := c.Get(ctx, "k"); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+func BenchmarkRedisCacheSet(b *testing.B) {
+	ctx := context.Background()
+	c := redisstore.New(benchClient(b))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if err := c.Set(ctx, "k"+strconv.Itoa(i%64), "v", time.Hour); err != nil {
+				b.Error(err)
+				return
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkRedisCacheIncr is the counter the in-memory implementation had to be
+// serialised by hand. Redis gets it from INCRBY, which is atomic on the server.
+func BenchmarkRedisCacheIncr(b *testing.B) {
+	ctx := context.Background()
+	c := redisstore.New(benchClient(b))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, err := c.Incr(ctx, "n", 1); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+// BenchmarkRedisQueuePublish is the counterpart to the memory queue's Append.
+// The two sit behind different contracts - this one takes a context and returns
+// an error the caller can act on - but both answer the same question: what does
+// handing off one message cost. Unlike the memory queue this cannot silently
+// drop; a stream write either lands or reports why it did not.
+func BenchmarkRedisQueuePublish(b *testing.B) {
+	ctx := context.Background()
+	client := benchClient(b)
+	q := redisstore.NewQueue(client, redisstore.QueueOptions{
+		Group:     "bench",
+		KeyPrefix: "bench",
+	})
+
+	// Publish refuses a topic nobody consumes, so the group has to exist first.
+	// Subscribe creates it without Start, which keeps the consumer loop out of
+	// the measurement - this benchmarks the producer side only.
+	if err := q.Subscribe("s", func(context.Context, storage.Message) error { return nil }); err != nil {
+		b.Fatal(err)
+	}
+
+	values := map[string]interface{}{"k": "v"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := q.Publish(ctx, storage.Message{Topic: "s", Values: values}); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+	b.StopTimer()
+	_ = client.FlushDB(ctx).Err()
+}

--- a/storage/redis/cache_test.go
+++ b/storage/redis/cache_test.go
@@ -14,7 +14,7 @@ import (
 
 // redisURL is where the tests look for a server. CI provides one through a
 // service container; locally the tests skip unless REDIS_URL is set.
-func redisURL(t *testing.T) string {
+func redisURL(t testing.TB) string {
 	t.Helper()
 
 	url := os.Getenv("REDIS_URL")

--- a/tools/search/alloc_budget_test.go
+++ b/tools/search/alloc_budget_test.go
@@ -1,0 +1,30 @@
+package search
+
+import "testing"
+
+// ResolveSearchQuery runs on every list request. The budget below is what an
+// unfiltered list page costs - the common case, since a list opens before
+// anyone types a filter.
+//
+// It was 51 allocations, because the tag of every field was parsed before the
+// field was checked for being zero, and an unfiltered request has nothing but
+// zero fields. Moving the check ahead of the parse dropped it to one. This
+// pins that: a change that puts the parse back in front fails here rather than
+// quietly costing every list request fifty allocations again.
+func TestResolveAllocationBudget(t *testing.T) {
+	q := benchSearchDTO{BenchPagination: BenchPagination{PageIndex: 1, PageSize: 10}}
+	cond := newCondition()
+
+	// Warm once; the first call through a reflect.Type populates caches inside
+	// the runtime that later calls reuse.
+	ResolveSearchQuery(Mysql, q, cond)
+
+	got := testing.AllocsPerRun(100, func() {
+		ResolveSearchQuery(Mysql, q, cond)
+	})
+	const budget = 2
+	if got > budget {
+		t.Errorf("an unfiltered search allocates %.0f times, budget is %d; "+
+			"the most likely cause is parsing tags before checking for zero values", got, budget)
+	}
+}

--- a/tools/search/bench_test.go
+++ b/tools/search/bench_test.go
@@ -1,0 +1,90 @@
+package search
+
+import (
+	"testing"
+	"time"
+)
+
+// ResolveSearchQuery runs on every list request: it walks the search DTO by
+// reflection and turns the struct tags into WHERE clauses. The DTO shape below
+// matches what go-admin generates for a CRUD module - a handful of optional
+// filters plus an embedded pagination struct.
+//
+// The interesting case is the empty one. A list page opened without filters
+// sends no search values at all, so every field is zero and the whole walk
+// produces nothing. That is the common request, not the exceptional one.
+
+type BenchPagination struct {
+	PageIndex int `search:"-"`
+	PageSize  int `search:"-"`
+}
+
+type benchSearchDTO struct {
+	BenchPagination
+	Username  string    `search:"type:contains;column:username;table:sys_user"`
+	NickName  string    `search:"type:contains;column:nick_name;table:sys_user"`
+	Phone     string    `search:"type:exact;column:phone;table:sys_user"`
+	Email     string    `search:"type:exact;column:email;table:sys_user"`
+	Status    string    `search:"type:exact;column:status;table:sys_user"`
+	DeptId    string    `search:"type:exact;column:dept_id;table:sys_user"`
+	RoleId    string    `search:"type:exact;column:role_id;table:sys_user"`
+	BeginTime time.Time `search:"type:gte;column:created_at;table:sys_user"`
+	EndTime   time.Time `search:"type:lte;column:created_at;table:sys_user"`
+	Order     string    `search:"type:order;column:created_at;table:sys_user"`
+	Ignored   string    `search:"-"`
+}
+
+func newCondition() *GormCondition {
+	return &GormCondition{GormPublic: GormPublic{}, Join: make([]*GormJoin, 0)}
+}
+
+func benchResolve(b *testing.B, q interface{}) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ResolveSearchQuery(Mysql, q, newCondition())
+	}
+}
+
+// BenchmarkResolveEmpty is a list page opened with no filters.
+func BenchmarkResolveEmpty(b *testing.B) {
+	benchResolve(b, benchSearchDTO{BenchPagination: BenchPagination{PageIndex: 1, PageSize: 10}})
+}
+
+// BenchmarkResolveTypical is a search with two filters filled in.
+func BenchmarkResolveTypical(b *testing.B) {
+	benchResolve(b, benchSearchDTO{
+		BenchPagination: BenchPagination{PageIndex: 1, PageSize: 10},
+		Username:        "admin",
+		Status:          "2",
+	})
+}
+
+// BenchmarkResolveFull fills everything, which is the upper bound.
+func BenchmarkResolveFull(b *testing.B) {
+	benchResolve(b, benchSearchDTO{
+		BenchPagination: BenchPagination{PageIndex: 1, PageSize: 10},
+		Username:        "admin",
+		NickName:        "administrator",
+		Phone:           "13800000000",
+		Email:           "a@b.c",
+		Status:          "2",
+		DeptId:          "1",
+		RoleId:          "1",
+		BeginTime:       time.Now().Add(-24 * time.Hour),
+		EndTime:         time.Now(),
+		Order:           "desc",
+	})
+}
+
+// BenchmarkMakeTag isolates the tag parser. ResolveSearchQuery calls it for
+// every tagged field before checking whether that field is zero, so an empty
+// DTO pays for it once per field and throws all of it away.
+func BenchmarkMakeTag(b *testing.B) {
+	const tag = "type:contains;column:username;table:sys_user"
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = makeTag(tag)
+	}
+}

--- a/tools/search/query.go
+++ b/tools/search/query.go
@@ -43,8 +43,17 @@ func ResolveSearchQuery(driver string, q interface{}, condition Condition) {
 	//}
 
 	for i := 0; i < qType.NumField(); i++ {
+		// Reflection cannot read an unexported field, and Interface panics on
+		// one rather than returning an error - so a single unexported field on
+		// a search DTO took down the whole list request. A field the author did
+		// not export is not part of the search contract either way.
+		field := qType.Field(i)
+		if !field.IsExported() {
+			continue
+		}
+
 		tag, ok = "", false
-		tag, ok = qType.Field(i).Tag.Lookup(FromQueryTag)
+		tag, ok = field.Tag.Lookup(FromQueryTag)
 		if !ok {
 			//递归调用
 			ResolveSearchQuery(driver, qValue.Field(i).Interface(), condition)

--- a/tools/search/query.go
+++ b/tools/search/query.go
@@ -63,10 +63,14 @@ func ResolveSearchQuery(driver string, q interface{}, condition Condition) {
 		case "-":
 			continue
 		}
-		t = makeTag(tag)
+		// The zero check comes before the tag is parsed, not after. A list page
+		// opened without filters leaves every field zero, and makeTag allocates
+		// on each one only for the result to be dropped on the next line - two
+		// thirds of the work on the most common request of all.
 		if qValue.Field(i).IsZero() {
 			continue
 		}
+		t = makeTag(tag)
 		//解析 Postgres `语法不支持，单独适配
 		if driver == Postgres {
 			pgSql(driver, t, condition, qValue, i)

--- a/tools/search/query_unexported_test.go
+++ b/tools/search/query_unexported_test.go
@@ -1,0 +1,39 @@
+package search
+
+import "testing"
+
+// unexportedDTO carries a field the author did not export. Nothing about it is
+// exotic - a cached value, a request-scoped helper - but reflection cannot read
+// it, and Interface panics rather than returning an error.
+type unexportedDTO struct {
+	Username string `search:"type:contains;column:username;table:sys_user"`
+
+	// No search tag, so the resolver used to recurse into it and panic with
+	// "cannot return value obtained from unexported field or method",
+	// taking down the whole list request.
+	internal struct{ Cached string }
+
+	// Tagged but unexported: the value can never be read either.
+	secret string `search:"type:exact;column:secret"`
+}
+
+func TestUnexportedFieldsAreSkipped(t *testing.T) {
+	q := unexportedDTO{Username: "admin"}
+	q.internal.Cached = "x"
+	q.secret = "y"
+
+	cond := &GormCondition{GormPublic: GormPublic{}, Join: make([]*GormJoin, 0)}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("an unexported field on a search DTO panicked the resolver: %v", r)
+		}
+	}()
+
+	ResolveSearchQuery(Mysql, q, cond)
+
+	// The exported field still has to work; skipping must not become ignoring.
+	if len(cond.Where) == 0 {
+		t.Error("the exported, tagged field produced no condition")
+	}
+}


### PR DESCRIPTION
Benchmark coverage was 37 cases and 36 of them were in `logger`, so nothing measured the components that run on every request. Writing those benchmarks turned up four defects, all of them reachable without a bug in caller code.

## Defects

| what | how it showed up |
|---|---|
| `Memory.Increase`/`Decrease` took the **read** lock for a read-modify-write | 50 goroutines × 200 increments landed ~10% short. They also wrote through a `*item` published in the `sync.Map`, so a reader could observe a torn string and fail to parse a counter that never held an invalid value |
| `Memory` queue's `Append` and `Register` each created their own channel | Whichever stored second won; a consumer registered on the loser went silently idle. Registering consumers while the first requests arrive is the ordinary startup sequence, and it lost ~1 message in 7 |
| `ResolveSearchQuery` recursed into unexported fields | `reflect.Value.Interface` panics on one, so a single unexported field on a search DTO took down the whole list request |
| `MemCache` held one mutex and swept the whole map under it | At a million entries a read normally served in 33µs waited 16.4ms — the sweep duration exactly. Once a minute, growing with the data |

Each fix has a regression test that fails without it.

## Behaviour change

**`MemCache` is now bounded** — a million entries by default, evicting to stay within it. Expired entries go first; only a shard with none to spare drops a live one. An entry can therefore disappear before its TTL, which the `Cache` contract already permitted but nothing previously exercised.

Unbounded growth needs no bug to reach: any endpoint writing an entry under a key it never reuses grows the cache at whatever rate callers can drive. `NewMemCacheWithOptions` sets another limit and a negative `MaxEntries` restores the old behaviour.

The bound is on `MemCache` only. `Setup()` still returns the older `Memory`, which has none — that tradeoff is now stated where the routing happens rather than left to be discovered.

## Performance

Sharding the cache 32 ways bounds the sweep stall by shard size instead of cache size (180µs against a 5.3ms sweep, versus the whole of it) and takes spread-key reads from 157ns to 56ns. A hot key does not scale with shards and is not meant to — that serialisation is the operation.

Eviction samples at most 64 entries rather than scanning the shard. Once a shard is full every write of a new key needs a slot, so eviction is a per-write cost in that state: scanning made a write at capacity 42,138ns, sampling makes it 1,208ns.

Two smaller ones: search tag parsing ran before the zero check and threw the result away on the most common request shape (unfiltered list: 2,479ns/51 allocs → 1,134ns/1); and the string captcha driver reloaded its fonts per call (936µs/10.9MB → 471µs/1.0MB).

## Tests

Benchmarks for the request path, soak tests for what only degrades slowly, and allocation budgets on the per-request paths.

Timing cannot be gated on a shared runner — a threshold loose enough to survive it is too loose to catch anything. Allocation counts can: the same code path allocates the same number of times on every machine. Those budgets are ordinary tests, so `make test-race` already runs them and CI needs no change. For timings, `make bench-compare` measures against a base revision on one machine and hands the result to benchstat.

## Docs

Both READMEs told readers to `go get` the module **without `/v2`**, which resolves to the last v1 release — so anyone following the install instructions got v1.8.1 and then found none of the examples compiled. Also adds Traditional Chinese and Japanese, and marks `CHANGELOG.md` as superseded (it stops at 1.6.0-beta and misses eight releases).

## Verification

Every commit compiles on its own — checked with `go vet` at each one, which caught a helper that was used one commit before it was introduced. `make test-race`, `lint` on both platforms, `api-check` (the API delta is additive: `MemCacheOptions`, `NewMemCacheWithOptions`) and the language check all pass.
