### PR TITLE
fix: one casbin enforcer per tenant, and stop recompiling route patterns

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -10,7 +10,7 @@ func Verify(id, code string, clear bool) bool
 
 ## github.com/go-admin-team/go-admin-core/v2/casbin
 var ReloadInterval = time.Minute
-func Setup(db *gorm.DB, _ string) *casbin.SyncedEnforcer
+func Setup(db *gorm.DB, key string) *casbin.SyncedEnforcer
 func UpdateCallback(msg string)
 type Logger struct {
 func (l *Logger) EnableLog(enable bool)

--- a/api/core.txt
+++ b/api/core.txt
@@ -10,6 +10,7 @@ func Verify(id, code string, clear bool) bool
 
 ## github.com/go-admin-team/go-admin-core/v2/casbin
 var ReloadInterval = time.Minute
+func KeyMatch2(path, pattern string) (bool, error)
 func Setup(db *gorm.DB, key string) *casbin.SyncedEnforcer
 func UpdateCallback(msg string)
 type Logger struct {

--- a/casbin/alloc_budget_test.go
+++ b/casbin/alloc_budget_test.go
@@ -1,0 +1,41 @@
+package mycasbin
+
+import "testing"
+
+// Every authorised request runs one Enforce, and its cost is dominated by what
+// the matcher allocates per policy it tests. The builtin keyMatch2 compiles a
+// regexp each time - about 98 allocations - so the budget below is what keeps
+// the cached matcher wired in: revert the model or the registration and this
+// fails, where a benchmark would only look slower on a machine nobody watches.
+//
+// Allocation counts are deterministic across machines; wall-clock is not.
+func TestEnforceAllocationBudget(t *testing.T) {
+	// The same fixture the benchmarks use: one role holding all of these, with
+	// the matching rule last so Enforce walks every one of them.
+	const policies = 50
+	e := sameSubjectEnforcer(t, policies, false)
+
+	ok, err := e.Enforce("operator", "/api/v1/dept", "GET")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("setup failed: the request is not allowed")
+	}
+
+	// Measured at 419 with the cached matcher and 4863 with the builtin. The
+	// budget sits between the two with room for the evaluator to change, and
+	// well below the number a regression would produce.
+	const budget = 900
+
+	got := testing.AllocsPerRun(50, func() {
+		if _, err := e.Enforce("operator", "/api/v1/dept", "GET"); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if got > budget {
+		t.Errorf("Enforce over %d policies allocates %.0f times, budget is %d\n"+
+			"the builtin keyMatch2 costs about 4863 here; check that the matcher still calls %s",
+			policies, got, budget, keyMatch2CachedName)
+	}
+}

--- a/casbin/bench_test.go
+++ b/casbin/bench_test.go
@@ -2,9 +2,11 @@ package mycasbin
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/casbin/casbin/v3"
+	"github.com/casbin/casbin/v3/model"
 )
 
 // Every request to a protected route runs one Enforce. The matcher compares the
@@ -44,9 +46,10 @@ func benchEnforcer(b *testing.B, n int) *casbin.SyncedEnforcer {
 	return e
 }
 
-func benchEnforce(b *testing.B, n int, sub, obj, act string, want bool) {
-	e := benchEnforcer(b, n)
-
+// runEnforce is the timing loop every benchmark here shares. SyncedEnforcer
+// takes a read lock, so this runs in parallel: the question is not only how
+// long one check takes but whether checks get in each other's way.
+func runEnforce(b *testing.B, e *casbin.SyncedEnforcer, sub, obj, act string, want bool) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -62,6 +65,10 @@ func benchEnforce(b *testing.B, n int, sub, obj, act string, want bool) {
 			}
 		}
 	})
+}
+
+func benchEnforce(b *testing.B, n int, sub, obj, act string, want bool) {
+	runEnforce(b, benchEnforcer(b, n), sub, obj, act, want)
 }
 
 // Allowed: the request matches, but only after every decoy has been tried.
@@ -81,3 +88,62 @@ func BenchmarkEnforceAllow5000(b *testing.B) {
 func BenchmarkEnforceDeny1000(b *testing.B) {
 	benchEnforce(b, 1000, "nobody", "/api/v1/secret", "DELETE", false)
 }
+
+// The benchmarks above give every decoy a different subject, so the matcher
+// short-circuits on r.sub == p.sub and only one policy reaches keyMatch2. Real
+// policy tables are not shaped that way: one role holds all of its own
+// permissions, so every one of them reaches the path comparison.
+//
+// That is what the pair below measures, and why the model calls
+// keyMatch2Cached rather than casbin's builtin - the builtin compiles a regexp
+// per policy tested.
+//
+// Position matters as much as count: the effect is some(where (p.eft ==
+// allow)), so Enforce stops at the first match. A permission near the top of
+// the table is cheap however long the table is; one near the bottom, and every
+// denied request, pays for the whole walk. The matching rule goes last here
+// for that reason.
+func sameSubjectEnforcer(tb testing.TB, n int, builtin bool) *casbin.SyncedEnforcer {
+	tb.Helper()
+
+	var e *casbin.SyncedEnforcer
+	var err error
+	if builtin {
+		// The comparison arm: casbin's own keyMatch2, reached by naming it in
+		// the matcher, since AddFunction cannot replace a builtin.
+		var m model.Model
+		m, err = model.NewModelFromString(
+			strings.Replace(text, keyMatch2CachedName+"(", "keyMatch2(", 1))
+		if err != nil {
+			tb.Fatal(err)
+		}
+		e, err = casbin.NewSyncedEnforcer(m)
+	} else {
+		e, err = newEnforcer(nil)
+	}
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	rules := make([][]string, 0, n+1)
+	for i := 0; i < n; i++ {
+		rules = append(rules, []string{"operator", "/api/v1/resource" + strconv.Itoa(i) + "/:id", "GET"})
+	}
+	rules = append(rules, []string{"operator", "/api/v1/dept", "GET"})
+	if _, err := e.AddPolicies(rules); err != nil {
+		tb.Fatal(err)
+	}
+	return e
+}
+
+func benchSameSubject(b *testing.B, n int, builtin bool) {
+	runEnforce(b, sameSubjectEnforcer(b, n, builtin), "operator", "/api/v1/dept", "GET", true)
+}
+
+func BenchmarkOwnPermissionsBuiltin10(b *testing.B)  { benchSameSubject(b, 10, true) }
+func BenchmarkOwnPermissionsBuiltin50(b *testing.B)  { benchSameSubject(b, 50, true) }
+func BenchmarkOwnPermissionsBuiltin200(b *testing.B) { benchSameSubject(b, 200, true) }
+
+func BenchmarkOwnPermissionsCached10(b *testing.B)  { benchSameSubject(b, 10, false) }
+func BenchmarkOwnPermissionsCached50(b *testing.B)  { benchSameSubject(b, 50, false) }
+func BenchmarkOwnPermissionsCached200(b *testing.B) { benchSameSubject(b, 200, false) }

--- a/casbin/bench_test.go
+++ b/casbin/bench_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/casbin/casbin/v3"
-	"github.com/casbin/casbin/v3/model"
 )
 
 // Every request to a protected route runs one Enforce. The matcher compares the
@@ -24,11 +23,7 @@ import (
 func benchEnforcer(b *testing.B, n int) *casbin.SyncedEnforcer {
 	b.Helper()
 
-	m, err := model.NewModelFromString(text)
-	if err != nil {
-		b.Fatal(err)
-	}
-	e, err := casbin.NewSyncedEnforcer(m)
+	e, err := newEnforcer(nil)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/casbin/keymatch.go
+++ b/casbin/keymatch.go
@@ -1,0 +1,105 @@
+package mycasbin
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// The matcher calls keyMatch2(r.obj, p.obj) once per policy whose subject
+// matches the request, and casbin's implementation compiles a regexp on every
+// one of those calls: util.KeyMatch2 delegates to util.RegexMatch, which is
+// regexp.MatchString. The package does keep a compile cache, but only KeyGet2,
+// KeyGet3 and KeyMatch4 consult it.
+//
+// The cost is linear in the permissions a role holds - about 2.1us and 98
+// allocations per policy, so a role with 200 of them spends ~420us inside a
+// single Enforce. Caching the compiled form removes that work; the pattern a
+// route compiles to never changes, so no result changes with it.
+//
+// The upstream fix is small - RegexMatch calling mustCompileOrGet instead of
+// regexp.MatchString - so if casbin wires its own cache to KeyMatch2, this
+// file and the matcher rename below can go away.
+//
+// keyMatchCacheLimit bounds the cache. Patterns come from the policy side of
+// the matcher, so the distinct set is bounded by the API surface rather than
+// by traffic, and the limit is only a backstop against a model that puts a
+// request value there - past it, matching still works, uncached.
+const keyMatchCacheLimit = 4096
+
+// keyMatch2CachedName is the name the matcher in mycasbin.go calls. It cannot
+// be "keyMatch2": FunctionMap.AddFunction stores with LoadOrStore, so adding a
+// name casbin already defines is silently a no-op, and the builtin would keep
+// running with nothing to show that the replacement was ignored.
+const keyMatch2CachedName = "keyMatch2Cached"
+
+var (
+	// keyMatch2Param and the replacement below are casbin's, kept identical so
+	// the compiled expression is the one its KeyMatch2 would have built.
+	keyMatch2Param = regexp.MustCompile(`:[^/]+`)
+
+	keyMatch2Cache     sync.Map // pattern -> *regexp.Regexp
+	keyMatch2CacheSize atomic.Int64
+)
+
+var errKeyMatch2Args = errors.New("keyMatch2: expected 2 string arguments")
+
+// KeyMatch2 reports whether path matches the route pattern, e.g.
+// "/api/v1/dept/7" against "/api/v1/dept/:id".
+//
+// It answers exactly what casbin's util.KeyMatch2 answers, without
+// recompiling the pattern on every call. Callers that match a request path
+// against a fixed list of route patterns - an authorization allowlist, say -
+// pay a regexp compilation per entry per request otherwise.
+//
+// The error reports a pattern that will not compile; util.KeyMatch2 panics on
+// those.
+func KeyMatch2(path, pattern string) (bool, error) {
+	re, err := compileKeyMatch2(pattern)
+	if err != nil {
+		return false, err
+	}
+	return re.MatchString(path), nil
+}
+
+func compileKeyMatch2(pattern string) (*regexp.Regexp, error) {
+	if v, ok := keyMatch2Cache.Load(pattern); ok {
+		return v.(*regexp.Regexp), nil
+	}
+
+	expr := strings.Replace(pattern, "/*", "/.*", -1)
+	expr = keyMatch2Param.ReplaceAllString(expr, "$1[^/]+$2")
+	re, err := regexp.Compile("^" + expr + "$")
+	if err != nil {
+		// util.KeyMatch2 panics here. Enforce recovers panics into errors, so
+		// the outcome there is the same either way - but a direct caller, like
+		// an authorization allowlist walked in a middleware, gets an error it
+		// can log instead of a panic to recover from.
+		return nil, err
+	}
+
+	if keyMatch2CacheSize.Load() < keyMatchCacheLimit {
+		if _, loaded := keyMatch2Cache.LoadOrStore(pattern, re); !loaded {
+			keyMatch2CacheSize.Add(1)
+		}
+	}
+	return re, nil
+}
+
+// keyMatch2Func adapts keyMatch2 to the signature casbin's evaluator expects.
+func keyMatch2Func(args ...interface{}) (interface{}, error) {
+	if len(args) != 2 {
+		return false, errKeyMatch2Args
+	}
+	path, ok := args[0].(string)
+	if !ok {
+		return false, errKeyMatch2Args
+	}
+	pattern, ok := args[1].(string)
+	if !ok {
+		return false, errKeyMatch2Args
+	}
+	return KeyMatch2(path, pattern)
+}

--- a/casbin/keymatch_test.go
+++ b/casbin/keymatch_test.go
@@ -1,0 +1,152 @@
+package mycasbin
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/casbin/casbin/v3/util"
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// TestKeyMatch2AgreesWithCasbin is the whole safety argument for replacing the
+// builtin: the cached form has to answer identically, including for the shapes
+// nobody writes on purpose.
+func TestKeyMatch2AgreesWithCasbin(t *testing.T) {
+	paths := []string{
+		"/api/v1/dept", "/api/v1/dept/", "/api/v1/dept/7", "/api/v1/dept/7/sub",
+		"/api/v1/roleMenuTreeselect/12", "/", "", "/api/v1", "/api/v1/",
+		"/api/v1/gen/preview/3", "/api/v1/public/uploadFile", "/apix/v1/dept",
+		"/api/v1/dept?x=1", "/api/v1/de.pt",
+	}
+	patterns := []string{
+		"/api/v1/dept", "/api/v1/dept/:id", "/api/v1/dept/*", "/api/v1/*",
+		"/:a/:b/:c", "/", "*", "/api/v1/gen/preview/:tableId", "",
+		"/api/v1/de.pt", "/api/v1/dept/:id/sub",
+	}
+
+	for _, path := range paths {
+		for _, pattern := range patterns {
+			want := util.KeyMatch2(path, pattern)
+			got, err := KeyMatch2(path, pattern)
+			if err != nil {
+				t.Fatalf("KeyMatch2(%q, %q) returned an error casbin does not: %v", path, pattern, err)
+			}
+			if got != want {
+				t.Errorf("KeyMatch2(%q, %q) = %v, casbin says %v", path, pattern, got, want)
+			}
+		}
+	}
+}
+
+// TestKeyMatch2CacheIsBounded checks the backstop: a caller that feeds distinct
+// patterns must not be able to grow the cache without limit.
+//
+// Filling it has a lasting effect - past the limit nothing new is cached, by
+// design - so this test puts the cache back rather than leaving every later
+// test in the package running against a full one.
+func TestKeyMatch2CacheIsBounded(t *testing.T) {
+	t.Cleanup(func() {
+		keyMatch2Cache.Range(func(k, _ any) bool {
+			keyMatch2Cache.Delete(k)
+			return true
+		})
+		keyMatch2CacheSize.Store(0)
+	})
+
+	before := keyMatch2CacheSize.Load()
+	for i := 0; i < keyMatchCacheLimit+2000; i++ {
+		if _, err := KeyMatch2("/api/v1/x", "/api/v1/unbounded"+strconv.Itoa(i)+"/:id"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := keyMatch2CacheSize.Load(); got > keyMatchCacheLimit {
+		t.Fatalf("cache holds %d entries, limit is %d", got, keyMatchCacheLimit)
+	}
+	if keyMatch2CacheSize.Load() < before {
+		t.Fatal("counter went backwards")
+	}
+}
+
+// TestKeyMatch2MalformedPatternDoesNotPanic pins the one deliberate difference
+// from casbin, which panics on a pattern that will not compile.
+func TestKeyMatch2MalformedPatternDoesNotPanic(t *testing.T) {
+	if _, err := KeyMatch2("/api/v1/dept", "/api/v1/["); err == nil {
+		t.Fatal("expected an error for an uncompilable pattern")
+	}
+}
+
+// TestKeyMatch2ConcurrentAgrees runs the cache under the access pattern it has
+// in production - many goroutines, overlapping patterns - with -race.
+func TestKeyMatch2ConcurrentAgrees(t *testing.T) {
+	patterns := []string{"/api/v1/dept/:id", "/api/v1/*", "/api/v1/dept", "/:a/:b"}
+	done := make(chan struct{})
+	for g := 0; g < 8; g++ {
+		go func(g int) {
+			defer func() { done <- struct{}{} }()
+			for i := 0; i < 2000; i++ {
+				p := patterns[i%len(patterns)]
+				got, err := KeyMatch2("/api/v1/dept/9", p)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+					return
+				}
+				if want := util.KeyMatch2("/api/v1/dept/9", p); got != want {
+					t.Errorf("KeyMatch2(_, %q) = %v, want %v", p, got, want)
+					return
+				}
+			}
+		}(g)
+	}
+	for g := 0; g < 8; g++ {
+		<-done
+	}
+}
+
+// TestSetupWiresTheCachedMatcher is the regression test for the trap that made
+// the first attempt a no-op: casbin's FunctionMap.AddFunction stores with
+// LoadOrStore, so registering a name it already defines does nothing and the
+// builtin keeps running. Nothing reports that. If the matcher and the
+// registered name ever drift apart, Enforce fails to resolve the function and
+// this test catches it - a path pattern is the case that needs it.
+func TestSetupWiresTheCachedMatcher(t *testing.T) {
+	if !strings.Contains(text, keyMatch2CachedName+"(r.obj, p.obj)") {
+		t.Fatalf("the matcher does not call %s:\n%s", keyMatch2CachedName, text)
+	}
+
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ReloadInterval = 0
+	e := Setup(db, "keymatch.example")
+
+	if err := db.Exec(
+		`INSERT INTO casbin_rule (ptype, v0, v1, v2) VALUES (?, ?, ?, ?)`,
+		"p", "keymatch-role", "/api/v1/dept/:id", "GET",
+	).Error; err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if err := e.LoadPolicy(); err != nil {
+		t.Fatalf("LoadPolicy: %v", err)
+	}
+
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/api/v1/dept/7", true},
+		{"/api/v1/dept/7/sub", false},
+		{"/api/v1/dept", false},
+	}
+	for _, c := range cases {
+		got, err := e.Enforce("keymatch-role", c.path, "GET")
+		if err != nil {
+			t.Fatalf("Enforce(%q): %v", c.path, err)
+		}
+		if got != c.want {
+			t.Errorf("Enforce(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/casbin/mycasbin.go
+++ b/casbin/mycasbin.go
@@ -27,7 +27,7 @@ e = some(where (p.eft == allow))
 m = r.sub == p.sub && (keyMatch2(r.obj, p.obj) || keyMatch(r.obj, p.obj)) && (r.act == p.act || p.act == "*")
 `
 
-// ReloadInterval is how often the shared enforcer reloads its policy from the
+// ReloadInterval is how often an enforcer reloads its policy from the
 // database.
 //
 // A policy written on one instance reaches the others no other way: the
@@ -37,42 +37,57 @@ m = r.sub == p.sub && (keyMatch2(r.obj, p.obj) || keyMatch(r.obj, p.obj)) && (r.
 var ReloadInterval = time.Minute
 
 var (
-	enforcer *casbin.SyncedEnforcer
-	once     sync.Once
+	enforcersMu sync.Mutex
+	enforcers   = map[string]*casbin.SyncedEnforcer{}
 )
 
-func Setup(db *gorm.DB, _ string) *casbin.SyncedEnforcer {
-	once.Do(func() {
-		Apter, err := gormAdapter.NewAdapterByDBUseTableName(db, "", "casbin_rule")
-		if err != nil && err.Error() != "invalid DDL" {
-			panic(err)
-		}
+// Setup returns the enforcer for key, building it from db on first use.
+//
+// key names the policy source. An enforcer serves the policy it loaded, so a
+// deployment that reads from more than one database - the multi-tenant
+// configuration, where each host has its own - has to pass a distinct key per
+// database. Passing one key for all of them hands every caller the enforcer
+// built from whichever database arrived first, and the rest are then
+// authorized against a policy table that is not theirs. "" is the right key
+// for a single database.
+func Setup(db *gorm.DB, key string) *casbin.SyncedEnforcer {
+	enforcersMu.Lock()
+	defer enforcersMu.Unlock()
 
-		m, err := model.NewModelFromString(text)
-		if err != nil {
-			panic(err)
-		}
-		enforcer, err = casbin.NewSyncedEnforcer(m, Apter)
-		if err != nil {
-			panic(err)
-		}
-		err = enforcer.LoadPolicy()
-		if err != nil {
-			panic(err)
-		}
+	if e, ok := enforcers[key]; ok {
+		return e
+	}
 
-		// Without this the policy is whatever it was at startup. UpdateCallback
-		// below is written for a watcher, which would make this immediate
-		// rather than periodic; polling needs no second piece of infrastructure
-		// and closes the gap today.
-		if ReloadInterval > 0 {
-			enforcer.StartAutoLoadPolicy(ReloadInterval)
-		}
+	Apter, err := gormAdapter.NewAdapterByDBUseTableName(db, "", "casbin_rule")
+	if err != nil && err.Error() != "invalid DDL" {
+		panic(err)
+	}
 
-		// Casbin v3: 日志默认已启用，无需 EnableLog()
-	})
+	m, err := model.NewModelFromString(text)
+	if err != nil {
+		panic(err)
+	}
+	e, err := casbin.NewSyncedEnforcer(m, Apter)
+	if err != nil {
+		panic(err)
+	}
 
-	return enforcer
+	if err := e.LoadPolicy(); err != nil {
+		panic(err)
+	}
+
+	// Without this the policy is whatever it was at startup. UpdateCallback
+	// below is written for a watcher, which would make this immediate rather
+	// than periodic; polling needs no second piece of infrastructure and
+	// closes the gap today.
+	if ReloadInterval > 0 {
+		e.StartAutoLoadPolicy(ReloadInterval)
+	}
+
+	// Casbin v3 enables logging by default; EnableLog is not needed.
+
+	enforcers[key] = e
+	return e
 }
 
 // UpdateCallback reloads the policy, for use as a watcher's update callback.
@@ -83,11 +98,26 @@ func Setup(db *gorm.DB, _ string) *casbin.SyncedEnforcer {
 //
 //	enforcer.SetWatcher(w)
 //	w.SetUpdateCallback(mycasbin.UpdateCallback)
+//
+// The message carries no tenant, so every enforcer reloads. That is a wasted
+// query for the tenants whose policy did not change, and the alternative -
+// reloading whichever one happens to be first - is wrong rather than slow.
 func UpdateCallback(msg string) {
 	l := logger.NewHelper(sdk.Runtime.GetLogger())
 	l.Infof("casbin updateCallback msg: %v", msg)
-	err := enforcer.LoadPolicy()
-	if err != nil {
-		l.Errorf("casbin LoadPolicy err: %v", err)
+
+	// Copied out so LoadPolicy, which queries the database, does not hold the
+	// lock that Setup needs.
+	enforcersMu.Lock()
+	built := make([]*casbin.SyncedEnforcer, 0, len(enforcers))
+	for _, e := range enforcers {
+		built = append(built, e)
+	}
+	enforcersMu.Unlock()
+
+	for _, e := range built {
+		if err := e.LoadPolicy(); err != nil {
+			l.Errorf("casbin LoadPolicy err: %v", err)
+		}
 	}
 }

--- a/casbin/mycasbin.go
+++ b/casbin/mycasbin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/casbin/casbin/v3"
 	"github.com/casbin/casbin/v3/model"
+	"github.com/casbin/casbin/v3/persist"
 	gormAdapter "github.com/casbin/gorm-adapter/v3"
 	"github.com/go-admin-team/go-admin-core/v2/logger"
 	"github.com/go-admin-team/go-admin-core/v2/sdk"
@@ -13,6 +14,17 @@ import (
 )
 
 // Initialize the model from a string.
+//
+// The matcher calls keyMatch2Cached rather than casbin's builtin keyMatch2.
+// The two answer identically - keymatch_test.go pins that - but the builtin
+// recompiles a regexp for every policy it tests, which dominates Enforce once
+// a role holds more than a handful of permissions. See keymatch.go.
+//
+// keyMatch2Cached is not a casbin builtin, so this model only works on an
+// enforcer that has it registered. Copying this string into a customised
+// model - adding a domain to the request definition, say - means going
+// through newEnforcer below, or registering it the same way. An enforcer
+// without it fails every Enforce with an unresolved-function error.
 var text = `
 [request_definition]
 r = sub, obj, act
@@ -24,7 +36,7 @@ p = sub, obj, act
 e = some(where (p.eft == allow))
 
 [matchers]
-m = r.sub == p.sub && (keyMatch2(r.obj, p.obj) || keyMatch(r.obj, p.obj)) && (r.act == p.act || p.act == "*")
+m = r.sub == p.sub && (keyMatch2Cached(r.obj, p.obj) || keyMatch(r.obj, p.obj)) && (r.act == p.act || p.act == "*")
 `
 
 // ReloadInterval is how often an enforcer reloads its policy from the
@@ -40,6 +52,35 @@ var (
 	enforcersMu sync.Mutex
 	enforcers   = map[string]*casbin.SyncedEnforcer{}
 )
+
+// newEnforcer builds an enforcer on the model above with the matcher's
+// functions registered.
+//
+// Every construction has to go through here. The model calls keyMatch2Cached,
+// which casbin does not define, so an enforcer built without the registration
+// fails every Enforce with an unresolved-function error - fail-closed, but
+// only discovered at the first request. Registering has to happen before that
+// first Enforce as well: casbin compiles the matcher once and resolves
+// function names at that point.
+func newEnforcer(a persist.Adapter) (*casbin.SyncedEnforcer, error) {
+	m, err := model.NewModelFromString(text)
+	if err != nil {
+		return nil, err
+	}
+
+	var e *casbin.SyncedEnforcer
+	if a == nil {
+		e, err = casbin.NewSyncedEnforcer(m)
+	} else {
+		e, err = casbin.NewSyncedEnforcer(m, a)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	e.AddFunction(keyMatch2CachedName, keyMatch2Func)
+	return e, nil
+}
 
 // Setup returns the enforcer for key, building it from db on first use.
 //
@@ -63,11 +104,7 @@ func Setup(db *gorm.DB, key string) *casbin.SyncedEnforcer {
 		panic(err)
 	}
 
-	m, err := model.NewModelFromString(text)
-	if err != nil {
-		panic(err)
-	}
-	e, err := casbin.NewSyncedEnforcer(m, Apter)
+	e, err := newEnforcer(Apter)
 	if err != nil {
 		panic(err)
 	}

--- a/casbin/mycasbin_test.go
+++ b/casbin/mycasbin_test.go
@@ -20,8 +20,9 @@ func TestSetupReloadsPolicyWrittenElsewhere(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 
+	// Read when the enforcer is built, so it has to be set before Setup.
 	ReloadInterval = 50 * time.Millisecond
-	e := Setup(db, "")
+	e := Setup(db, "reload.example")
 
 	const sub, obj, act = "alice", "/data", "GET"
 

--- a/casbin/tenant_test.go
+++ b/casbin/tenant_test.go
@@ -1,0 +1,88 @@
+package mycasbin
+
+import (
+	"testing"
+
+	"github.com/glebarez/sqlite"
+	"gorm.io/gorm"
+)
+
+// openTenantDB opens a named in-memory database. The name matters: the
+// anonymous "file::memory:" form is shared process-wide, which would make two
+// tenants the same database and hide exactly what this test is checking.
+func openTenantDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	return db
+}
+
+func grant(t *testing.T, db *gorm.DB, sub, obj, act string) {
+	t.Helper()
+	if err := db.Exec(
+		`INSERT INTO casbin_rule (ptype, v0, v1, v2) VALUES (?, ?, ?, ?)`,
+		"p", sub, obj, act,
+	).Error; err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+}
+
+// A deployment can serve several databases - one per host - and Setup used to
+// build the enforcer under a sync.Once. The first tenant to arrive built it,
+// every later tenant got that same enforcer back, and none of them ever loaded
+// their own casbin_rule table. Requests for tenant B were then decided by
+// tenant A's policy: an authorization granted in one tenant applied in the
+// other, and one denied in A stayed denied in B however B was configured.
+func TestSetupGivesEachTenantItsOwnPolicy(t *testing.T) {
+	ReloadInterval = 0 // reload explicitly, so the assertions are not timing-dependent
+
+	dbA := openTenantDB(t, "casbin-tenant-a")
+	dbB := openTenantDB(t, "casbin-tenant-b")
+
+	eA := Setup(dbA, "tenant-a.example")
+	eB := Setup(dbB, "tenant-b.example")
+
+	if eA == eB {
+		t.Fatal("both tenants share one enforcer, so one tenant's policy decides the other's requests")
+	}
+
+	const sub, obj, act = "alice", "/data", "GET"
+	grant(t, dbA, sub, obj, act)
+	if err := eA.LoadPolicy(); err != nil {
+		t.Fatalf("tenant A LoadPolicy: %v", err)
+	}
+	if err := eB.LoadPolicy(); err != nil {
+		t.Fatalf("tenant B LoadPolicy: %v", err)
+	}
+
+	allowed, err := eA.Enforce(sub, obj, act)
+	if err != nil {
+		t.Fatalf("tenant A Enforce: %v", err)
+	}
+	if !allowed {
+		t.Error("tenant A granted the permission and was denied")
+	}
+
+	allowed, err = eB.Enforce(sub, obj, act)
+	if err != nil {
+		t.Fatalf("tenant B Enforce: %v", err)
+	}
+	if allowed {
+		t.Error("tenant B allowed a request its own casbin_rule table never granted")
+	}
+}
+
+// The cache still has to be a cache: repeated calls for one tenant must not
+// build a second enforcer, which would leave two policy reload loops running
+// against the same database.
+func TestSetupReusesTheEnforcerForOneTenant(t *testing.T) {
+	ReloadInterval = 0
+
+	db := openTenantDB(t, "casbin-tenant-repeat")
+	first := Setup(db, "repeat.example")
+	if second := Setup(db, "repeat.example"); second != first {
+		t.Error("Setup built a second enforcer for a tenant it had already built one for")
+	}
+}


### PR DESCRIPTION
## What this fixes

Two problems in the casbin path, found while measuring what an authenticated request actually costs.

### 1. Every tenant after the first was authorized against another tenant's policy

`Setup` built the enforcer under a `sync.Once`. A deployment that serves several databases — the multi-tenant configuration, one per host — calls `Setup` once per database, and every call after the first got the enforcer built from the first one. Those tenants never loaded their own `casbin_rule` table: a permission granted in one tenant applied in the others, and one denied there stayed denied however the tenant was configured.

The enforcer is now keyed by the tenant argument `Setup` already accepted and discarded. Callers passing `""` keep the single enforcer they had, so a single-database deployment is unaffected.

`UpdateCallback` reloads every enforcer now. A watcher message carries no tenant, so the alternative is reloading whichever one comes first, which is wrong rather than slow.

### 2. The matcher recompiled a regexp for every policy it tested

`util.KeyMatch2` delegates to `util.RegexMatch`, which is `regexp.MatchString` — it compiles its pattern on every call. The package does keep a compile cache, but only `KeyGet2`, `KeyGet3` and `KeyMatch4` consult it.

The matcher calls `keyMatch2` once per policy whose subject matches the request, so the cost is linear in the permissions a role holds — about 2.1µs and 98 allocations each.

## Numbers

`Enforce` over the permissions one role holds, with the matching rule last (the effect is `some(where (p.eft == allow))`, so Enforce stops at the first match — position matters as much as count, and every *denied* request pays for the whole walk):

| role's own permissions | before | after | allocations |
|---|---:|---:|---|
| 10 | 21,291 ns | 1,438 ns | 1,025 → 102 |
| 50 | 109,412 ns | 5,020 ns | 4,866 → 422 |
| 200 | 404,699 ns | 19,512 ns | 19,569 → 1,622 |

End to end against MySQL, `GET /api/v1/dept` with a non-admin token whose role holds 201 permissions, three interleaved rounds:

| concurrency | before | after | |
|---|---:|---:|---|
| 16 | 2,927 req/s | 8,890 req/s | 3.2x |
| 64 | 2,805 req/s | 12,961 req/s | 4.4x |
| 256 | 2,846 req/s | 13,882 req/s | 5.0x |

p99 at c=256: 359 ms → 39 ms. Before the change throughput was flat across all three levels — the process was saturated compiling regexps.

Measured on one machine; treat the ratios as the result, not the absolute numbers.

## Why the matcher names a non-standard function

`FunctionMap.AddFunction` stores with `LoadOrStore`, so registering a name casbin already defines is silently a no-op — the builtin keeps running with nothing to show the replacement was ignored. The matcher therefore calls `keyMatch2Cached`, and construction goes through `newEnforcer`, which registers it.

`keymatch_test.go` pins that the cached form answers identically to `util.KeyMatch2` across 154 path/pattern pairs, including malformed and edge shapes, under `-race`.

The upstream fix is small — `RegexMatch` calling casbin's own `mustCompileOrGet` — and if it lands, `keymatch.go` and the rename can go away.

## Protection

- `TestEnforceAllocationBudget` fails if the model or the registration is reverted: 419 allocations becomes 4,863. Allocation counts are deterministic across machines, so it runs in `make test-race`; a benchmark would only look slower on a machine nobody watches.
- `TestSetupGivesEachTenantItsOwnPolicy` fails if the enforcer goes back to being process-wide.
- `BenchmarkOwnPermissions{Builtin,Cached}{10,50,200}` keeps the comparison available.

Both were counter-proved: reverting each change turns the corresponding test red.

## Notes for review

- `Setup`'s signature is unchanged — the second parameter went from ignored to used.
- `KeyMatch2` is exported for callers matching a request path against a fixed list of route patterns, which pay the same compilation per entry per request. It returns an error where `util.KeyMatch2` panics.
- The pattern cache is bounded. Patterns come from the policy side of the matcher, so the distinct set is bounded by the API surface rather than by traffic; the limit is a backstop against a model that puts a request value there, and past it matching still works, uncached.
- Each commit builds and tests on its own, benchmarks included.
