### PR TITLE
Run the startup registries from core, behind a guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,32 @@ Comments are for intent that the code cannot express. Prefer none over noise.
   belong in `docs/`, with at most a one-line pointer from the source.
 - Public API needs a doc comment; internal helpers usually do not.
 
+## Locking in sdk/runtime
+
+`Application` guards every field with one `sync.RWMutex`, and `sync.RWMutex` is
+not reentrant. Four rules, each of which has already been paid for once:
+
+- **Take `e.mux` exactly once per exported method.** Inside a locked section
+  call only `xxxLocked` helpers.
+- **A `xxxLocked` helper never takes the lock and never calls an exported
+  method.** The suffix is the whole contract; keep it in the name.
+- **Never run a user callback while holding the lock.** `Run*()` takes a
+  snapshot, releases, and then executes. Callbacks routinely call back into
+  `Application` - an app router asks for the engine and then sets it - and
+  under the lock that deadlocks on the first one.
+- **Never log while holding the lock.** `SetLogger` accepts any implementation,
+  so logging runs code the application supplied. Decide inside the lock, print
+  outside it.
+
+`sdk/runtime/application_lock_test.go` guards the first two with a two-second
+timeout per accessor; the deadlock it was written for hung thirteen of them.
+
 ## Documentation
 
 | Content | Location |
 |---|---|
 | Defects CI tolerates, with reproduction steps | `docs/known-issues.md` |
+| What the runtime registries promise downstream | `docs/contract.md` |
 | Architecture decisions and migration plans | `docs/` |
 | Usage and getting started | `README.md`, `README.zh-CN.md` |
 

--- a/api/core.txt
+++ b/api/core.txt
@@ -1112,6 +1112,8 @@ func NewCache(prefix string, store storage.AdapterCache, wxTokenStoreKey string)
 func NewQueue(prefix string, q storage.AdapterQueue) storage.AdapterQueue
 type Application struct {
 func NewConfig() *Application
+func (e *Application) AppRoutersSealed() bool
+func (e *Application) BeforeSealed() bool
 func (e *Application) GetAllCasbin() map[string]*casbin.SyncedEnforcer
 func (e *Application) GetAllCrontab() map[string]*cron.Cron
 func (e *Application) GetAllDb() map[string]*gorm.DB
@@ -1147,10 +1149,14 @@ func (e *Application) GetQueueAdapter() storage.AdapterQueue
 func (e *Application) GetQueuePrefix(key string) storage.AdapterQueue
 func (e *Application) GetRouter() []Router
 func (e *Application) GetStreamMessage(id, stream string, value map[string]interface{}) (storage.Messager, error)
+func (e *Application) RunAppRouters()
+func (e *Application) RunBefore()
 func (e *Application) SetApp(app interface{})
 func (e *Application) SetAppByTenant(key string, app interface{})
 func (e *Application) SetAppRouters(appRouters func())
+func (e *Application) SetAppRoutersWith(appRouters func(), opts ...CallbackOption)
 func (e *Application) SetBefore(f func())
+func (e *Application) SetBeforeWith(f func(), opts ...CallbackOption)
 func (e *Application) SetCacheAdapter(c storage.AdapterCache)
 func (e *Application) SetCasbin(enforcer *casbin.SyncedEnforcer)
 func (e *Application) SetCasbinByTenant(tenant string, enforcer *casbin.SyncedEnforcer)
@@ -1184,6 +1190,9 @@ func (e Cache) Set(key string, val interface{}, expire int) error
 func (e *Cache) SetPrefix(prefix string)
 func (e *Cache) String() string
 func (e Cache) Token() (token *oauth2.Token, err error)
+type CallbackOption func(*callbackConfig)
+func WithFatal() CallbackOption
+func WithName(name string) CallbackOption
 type Config map[string]interface{}
 type Queue struct {
 func (e *Queue) Append(message storage.Messager) error
@@ -1202,7 +1211,10 @@ type Runtime interface {
 	GetDb() *gorm.DB
 	GetAllDb() map[string]*gorm.DB
 	SetBefore(f func())
+	SetBeforeWith(f func(), opts ...CallbackOption)
 	GetBefore() []func()
+	RunBefore()
+	BeforeSealed() bool
 	SetAppByTenant(tenant string, app interface{})
 	SetApp(app interface{})
 	GetApp() map[string]interface{}
@@ -1252,7 +1264,10 @@ type Runtime interface {
 	GetConfig() map[string]interface{}
 	GetConfigValue(key string) interface{}
 	SetAppRouters(appRouters func())
+	SetAppRoutersWith(appRouters func(), opts ...CallbackOption)
 	GetAppRouters() []func()
+	RunAppRouters()
+	AppRoutersSealed() bool
 
 ## github.com/go-admin-team/go-admin-core/v2/sdk/service
 type Service struct {

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,0 +1,277 @@
+# The Runtime contract
+
+This document is for anyone who registers something into `sdk.Runtime`: an
+application module in go-admin, a fork, or a downstream framework such as
+go-admin-pro. It states what the runtime registries promise, when they stop
+accepting registrations, and what the panic guard does and does not cover.
+
+`sdk.Runtime` is a package-level singleton (`sdk/application.go`) of type
+`runtime.Runtime`, implemented by `*runtime.Application`.
+
+---
+
+## 1. Two kinds of state, and they have different rules
+
+`Application` holds two kinds of field, and the difference matters because one
+of them is rewritten while the server is running.
+
+| Kind | Fields | When it may be written |
+|---|---|---|
+| **Registration** | `before`, `appRouters` | Until the matching `Run*()` runs. After that, refused. |
+| **Registration (unsealed)** | `middlewares`, `handler` | Startup, by convention. Not enforced - see below. |
+| **Resource** | `dbs`, `casbins`, `cache`, `queue`, `memoryQueue`, `configs`, `crontab` | Startup **and at run time**. Reloading the configuration rewrites these deliberately. |
+| **Single value** | `engine`, `defaultTenant`, `routers`, `app` | Startup, by convention. Not enforced - see below. |
+
+Only `before` and `appRouters` are enforced, because only they have an
+execution entry point that can define the moment startup is over. `engine`,
+`handler` and `middlewares` have no such moment, and guessing one would mean
+dropping registrations for the wrong reason: `app/demo/router/router.go` sets
+the engine from *inside* an app router callback, which is precisely what
+`RunAppRouters()` executes.
+
+Everything in the table is guarded by the same mutex regardless. Not sealed is
+not the same as not protected.
+
+---
+
+## 2. When to register
+
+> Registration APIs must be called before the matching `Run*()`. A call made
+> afterwards is dropped and reported at ERROR level.
+
+`init()` is the easiest place to satisfy that - the Go specification runs all
+package initialisation on one goroutine before `main`, so there is no
+concurrency to think about - but it is not the only legal one. go-admin-pro
+registers from `run()`, and that is fine: `run()` happens before anything calls
+`RunAppRouters()`.
+
+The older wording, "registration is only allowed in `init()`", is not used here
+because nothing can check it and real code already violates it.
+
+To find out programmatically whether registration is still open:
+
+```go
+if sdk.Runtime.BeforeSealed() { /* RunBefore has already run */ }
+if sdk.Runtime.AppRoutersSealed() { /* RunAppRouters has already run */ }
+```
+
+---
+
+## 3. Execution order
+
+Callbacks run **in registration order**, and nothing is reordered. For code in
+`init()` that means the import order of the packages decides it.
+
+Order is only promised *within* one registry. If the host program has its own
+registry beside core's - go-admin has a package-level `AppRouters` slice - the
+relative order of the two is the host's business, and it documents it. Do not
+rely on it from a module.
+
+---
+
+## 4. The panic guard
+
+Every callback executed through `RunBefore()` or `RunAppRouters()` runs behind
+a `recover()`. A panicking callback does not stop the ones after it and does not
+take the process down.
+
+The panic is always reported, with three things:
+
+- **where it was registered** (`file:line` of the `SetXxx` call). The stack
+  unwinds into core, so without this the log names the framework rather than
+  the module that failed;
+- **the panic value**;
+- **the full stack**.
+
+```
+ERROR runtime: appRouters callback crm-router (/src/app/crm/router/router.go:24) panicked, continuing with the rest: runtime error: index out of range [0] with length 0
+goroutine 1 [running]:
+...
+```
+
+### Failure levels
+
+Two levels, expressed through options on the `*With` variants:
+
+```go
+// Default: a panic is reported, the remaining callbacks still run.
+sdk.Runtime.SetAppRouters(router.InitRouter)
+
+// Named, for a log line that says what it was rather than only where it was.
+sdk.Runtime.SetAppRoutersWith(router.InitRouter, runtime.WithName("crm-router"))
+
+// The process must not start without this one.
+sdk.Runtime.SetBeforeWith(checkLicence, runtime.WithFatal(), runtime.WithName("licence"))
+```
+
+`WithFatal()` reports the panic and then exits with status 1. **It is the
+exception.** A module that declares itself fatal makes the entire host program
+as fragile as itself, and the exit skips every deferred cleanup and any
+graceful shutdown - so it only belongs on work that runs before the server
+starts listening. Unless the program is useless without you, let the default
+degrade instead.
+
+`SetBefore` and `SetAppRouters` are exactly the no-option case of the `*With`
+variants: same registration path, same guard, same defaults.
+
+### What the guard does not cover
+
+> The guard covers **synchronous** panics: a panic in the callback body, or in
+> anything it calls directly. A panic on a goroutine the callback starts is
+> outside it, and always will be.
+
+`recover()` only works on the goroutine that is panicking. This shape - which
+is how go-admin-pro registers its jobs - gets no protection from the framework
+at all:
+
+```go
+sdk.Runtime.SetBefore(func() {
+    go func() {
+        defer func() { /* this recover is yours to write */ }()
+        job.InitJob()
+    }()
+})
+```
+
+If you start a goroutine, its `recover()` is your responsibility. Saying "the
+framework has a guard" and leaving this out would be a promise the framework
+cannot keep.
+
+A callback that recovers for itself needs no special treatment: the panic stops
+inside it, the callback returns normally, and the framework's guard sees
+nothing and logs nothing. Two layers cost nothing.
+
+Two more exits leave the guard behind, and neither is a panic, so neither is
+something `recover()` was ever going to catch.
+
+**`os.Exit`** ends the process where it is called. No deferred function runs -
+not the callback's own, not the guard's - so nothing is logged and the
+remaining callbacks never start.
+
+`logger.Fatal` and `logger.Fatalf` reach it, but only sometimes, which is worse
+than reaching it always. Both open with `if !Level.Enabled(FatalLevel) { return }`:
+
+- with fatal logging on, they write the line and `os.Exit(1)` - the process is
+  gone, and every later callback with it;
+- with it filtered out, they write nothing and **return normally**, so the
+  callback carries on past the line its author expected to be the last one.
+
+Which of the two you get is decided by logging configuration, in a place that
+has nothing to do with the decision being made. That is the reason this
+framework does not use them for the `WithFatal()` path either. Keep them out of
+callbacks: return an error state, or register with `WithFatal()` and panic -
+that path exits on purpose, at a level nothing can filter, and names the
+callback that did it.
+
+**`runtime.Goexit`** ends the goroutine and does run the deferred functions on
+the way out, which makes it the more confusing of the two: the guard's `defer`
+executes, `recover()` returns `nil` because nothing is panicking, and the guard
+concludes the callback returned normally. It did not. `Run*()` never returns,
+every later callback is skipped, and there is no log line anywhere saying why.
+`testing.T.Fatal` is the most common way to reach this by accident - a helper
+written for tests, reused inside a callback.
+
+Both are silent in a way a panic is not. If a startup hook can fail, let it
+panic: that is the one failure shape the guard can see, name, and survive.
+
+---
+
+## 5. Sealing
+
+Each registry closes when its own `Run*()` runs - `RunBefore()` closes `before`
+and nothing else. From then on:
+
+- `SetBefore` / `SetBeforeWith` (respectively `SetAppRouters` /
+  `SetAppRoutersWith`) drop the registration and log at ERROR level, naming the
+  registration site. They do not panic: a module that registered too late
+  should not be able to bring down the host program.
+- `Run*()` may be called again; it is a no-op. Callbacks that have already run
+  do not run twice.
+- `BeforeSealed()` / `AppRoutersSealed()` report the state.
+
+**Resource fields are never sealed.** Freezing them would break configuration
+reload (section 7), and it would break it silently.
+
+### Sealing is sticky, and `sdk.Runtime` is process-wide
+
+This is the one thing that bites in tests. Once a test has run a registry, every
+later test in the same binary loses its registrations to the seal - and only to
+an ERROR log, so nothing fails, routes are just missing.
+
+`sdk.Runtime` is a `var`, so replace it:
+
+```go
+func TestSomething(t *testing.T) {
+    previous := sdk.Runtime
+    t.Cleanup(func() { sdk.Runtime = previous })
+    sdk.Runtime = runtime.NewConfig()
+
+    // ... register, run, assert ...
+}
+```
+
+Do this in any test that calls `RunBefore()` or `RunAppRouters()`, directly or
+through a startup helper.
+
+---
+
+## 6. `Get*` and self-written loops
+
+`GetBefore()` and `GetAppRouters()` still work and still return
+`[]func()` in registration order. They are **deprecated** in favour of
+`RunBefore()` / `RunAppRouters()`, for two reasons: a loop you write yourself
+gets no panic guard and no failure levels, and core cannot see it.
+
+Two consequences to know about:
+
+1. **They return a copy**, not the live slice. The caller ranges over the
+   result with no lock held, and the registry can be written meanwhile;
+   returning the field itself was the same defect `GetAllDb` was fixed for.
+   Writing to the returned slice no longer reaches core's state.
+2. **Mixing the two styles runs the callbacks twice.** Core cannot prevent it -
+   it never sees a loop written downstream - so it warns instead:
+
+   ```
+   WARN runtime: GetBefore was called before RunBefore, and core cannot see a loop
+   written outside it; if you run the returned callbacks yourself they run twice -
+   drop your own loop
+   ```
+
+   Pick one style. `Run*()` is the one that is maintained.
+
+---
+
+## 7. Resources are rewritten at run time. This is by design.
+
+Configuration is watched. When the file changes, core re-runs **every** setup
+callback, while HTTP requests are being served:
+
+```
+config file changes
+  → config/default.go   Entity.OnChange()
+  → sdk/config/config.go  init() → runCallback()
+  → your setup callbacks → SetDbByTenant / SetCasbinByTenant
+                         → SetCacheAdapter / SetQueueAdapter
+```
+
+So:
+
+- a resource setter being called again after startup is normal, not misuse;
+- **the resource you are holding can be replaced while you hold it.** The lock
+  makes a single access safe; it does not give you a consistent view across
+  several. If a request needs the database and the cache to agree, fetch them
+  once at the top and use those values, rather than calling the getters twice;
+- your setup callback must be safe to run more than once.
+
+---
+
+## 8. Compatibility
+
+`runtime.Runtime` is **only ever added to**. No existing method changes its
+signature or its meaning, because the interface may be implemented or asserted
+downstream.
+
+Adding a method is still a source-breaking change for anyone who wrote their
+own implementation of `runtime.Runtime` - a mock, typically. There are none in
+go-admin, go-admin-pro or core itself, where the only implementation is
+`*Application`; if you have one, add the new methods listed in section 2 and 4.

--- a/sdk/config/hotreload_test.go
+++ b/sdk/config/hotreload_test.go
@@ -1,0 +1,148 @@
+//lint:file-ignore SA1019 Exercises the AdapterCache/AdapterQueue setters that the reload path actually calls; the deprecation is carried by the storage package itself.
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	coreconfig "github.com/go-admin-team/go-admin-core/v2/config"
+	"github.com/go-admin-team/go-admin-core/v2/config/source/file"
+	"github.com/go-admin-team/go-admin-core/v2/sdk"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
+	"github.com/go-admin-team/go-admin-core/v2/storage"
+	"gorm.io/gorm"
+)
+
+// labelled adapters carry the configuration value they were built from, so the
+// assertion is "the resource was replaced", not "a setter did not error".
+type labelledCache struct {
+	storage.AdapterCache
+	label string
+}
+
+func (c *labelledCache) String() string { return c.label }
+
+type labelledQueue struct {
+	storage.AdapterQueue
+	label string
+}
+
+func (q *labelledQueue) String() string { return q.label }
+
+const settingsTemplate = `settings:
+  application:
+    host: 0.0.0.0
+    port: 8000
+    name: %s
+    mode: dev
+  logger:
+    path: ""
+    stdout: ""
+    level: error
+  jwt:
+    secret: test
+    timeout: 3600
+  database:
+    driver: sqlite3
+    source: ":memory:"
+`
+
+// Acceptance 11: the whole reload path, through the real file watcher.
+//
+// This is the risk the seal was most likely to break, and it would have broken
+// it silently: the configuration file changes, core re-runs every setup
+// callback while requests are in flight, and if the registries' seal had been
+// applied to the resource fields the new database would simply not be
+// installed. Nothing would log, nothing would fail - the old connection would
+// just keep being used.
+//
+// Setup replaces the package-level _cfg, coreconfig.DefaultConfig and the
+// global logger, so this test must not run in parallel with anything.
+func TestConfigReloadReplacesResourcesAfterTheRegistriesAreSealed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.yml")
+	writeSettings(t, path, "v1")
+
+	// The registries are process-wide and the seal is sticky, so a test that
+	// trips it has to hand back a clean one - otherwise every later test in
+	// the binary quietly loses its registrations.
+	previousRuntime := sdk.Runtime
+	t.Cleanup(func() { sdk.Runtime = previousRuntime })
+	sdk.Runtime = runtime.NewConfig()
+
+	previousCfg := _cfg
+	previousDefault := coreconfig.DefaultConfig
+	t.Cleanup(func() {
+		if coreconfig.DefaultConfig != nil && coreconfig.DefaultConfig != previousDefault {
+			_ = coreconfig.DefaultConfig.Close()
+		}
+		_cfg = previousCfg
+		coreconfig.DefaultConfig = previousDefault
+		// logger.DefaultLogger is deliberately left as Setup left it. The
+		// watcher goroutine outlives Close by a moment and reads that global
+		// on its way out, so restoring it here would be a race this test
+		// creates rather than one it finds.
+	})
+
+	// Startup order as a server has it: the registries run and close first,
+	// then the resources are installed by the setup callbacks.
+	sdk.Runtime.RunBefore()
+	sdk.Runtime.RunAppRouters()
+	if !sdk.Runtime.BeforeSealed() || !sdk.Runtime.AppRoutersSealed() {
+		t.Fatal("the registries are not sealed; this test would prove nothing")
+	}
+
+	setup := func() {
+		label := ApplicationConfig.Name
+		sdk.Runtime.SetCacheAdapter(&labelledCache{label: label})
+		sdk.Runtime.SetQueueAdapter(&labelledQueue{label: label})
+		sdk.Runtime.SetDbByTenant(label, &gorm.DB{})
+	}
+
+	Setup(file.NewSource(file.WithPath(path)), setup)
+
+	if got := sdk.Runtime.GetCacheAdapter().String(); got != "v1" {
+		t.Fatalf("the first load installed %q, want v1", got)
+	}
+
+	writeSettings(t, path, "v2")
+
+	// The watcher is a goroutine and fsnotify coalesces, so the only honest
+	// way to wait is to poll for the effect.
+	waitFor(t, 15*time.Second, func() bool {
+		return sdk.Runtime.GetCacheAdapter().String() == "v2"
+	}, "the cache adapter was never replaced after the configuration changed")
+
+	if got := sdk.Runtime.GetQueueAdapter().String(); got != "v2" {
+		t.Errorf("the queue adapter is %q, want v2", got)
+	}
+	if sdk.Runtime.GetDbByTenant("v2") == nil {
+		t.Error("the reload did not install a database for the new tenant")
+	}
+	if !sdk.Runtime.BeforeSealed() || !sdk.Runtime.AppRoutersSealed() {
+		t.Error("the reload reopened a sealed registry")
+	}
+}
+
+func writeSettings(t *testing.T, path, name string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(fmt.Sprintf(settingsTemplate, name)), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func waitFor(t *testing.T, limit time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(limit)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}

--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -35,9 +35,9 @@ type Application struct {
 	handler       map[string][]func(r *gin.RouterGroup, hand ...*gin.HandlerFunc) // 路由处理器
 	routers       []Router                                                        // 路由表
 	configs       map[string]Config                                               // 系统参数
-	appRouters    []func()                                                        // app路由
+	appRouters    registry                                                        // app router registry
 	casbinExclude map[string]interface{}                                          // casbin排除
-	before        []func()                                                        // 启动前执行
+	before        registry                                                        // startup callback registry
 	defaultTenant string                                                          // 默认租户标识符
 	app           map[string]interface{}                                          // app
 }
@@ -98,14 +98,6 @@ func (e *Application) GetAllDb() map[string]*gorm.DB {
 	e.mux.RLock()
 	defer e.mux.RUnlock()
 	return maps.Clone(e.dbs)
-}
-
-func (e *Application) SetBefore(f func()) {
-	e.before = append(e.before, f)
-}
-
-func (e *Application) GetBefore() []func() {
-	return e.before
 }
 
 // SetAppByTenant 设置对应租户的app
@@ -201,12 +193,20 @@ func (e *Application) GetCasbinByTenant(tenant string) *casbin.SyncedEnforcer {
 }
 
 // SetEngine 设置路由引擎
+//
+// An app router callback is allowed to call this - the demo module does, on
+// the path where no engine has been set yet - so the field is written after
+// the server has started reading it elsewhere, and needs the lock.
 func (e *Application) SetEngine(engine http.Handler) {
+	e.mux.Lock()
+	defer e.mux.Unlock()
 	e.engine = engine
 }
 
 // GetEngine 获取路由引擎
 func (e *Application) GetEngine() http.Handler {
+	e.mux.RLock()
+	defer e.mux.RUnlock()
 	return e.engine
 }
 
@@ -217,31 +217,45 @@ func (e *Application) GetRouter() []Router {
 
 // setRouter 设置路由表（并发安全）
 func (e *Application) setRouter() []Router {
-	switch e.engine.(type) {
-	case *gin.Engine:
-		// 每次按当前 engine 路由全量重建，避免重复 append 累积：
-		// GetRouter 会被多次调用（启动 -a 同步 + 运行时手动「同步接口」），原写法把全量路由
-		// 反复追加进 e.routers，使路由表成倍膨胀、含大量重复项（下游 SaveSysApi 因此处理冗余、
-		// 消息体膨胀，FirstOrCreate 幂等故不影响正确性，但每次同步成本随调用次数线性增长）。
-		//
-		// 并发安全：engine.Routes() 遍历与 list 构建在锁外完成（gin 路由注册完成后 Routes() 只读、
-		// 本身并发安全），仅 e.routers 赋值瞬间持写锁，避免长时间占用 e.mux 阻塞 config 等读路径。
-		// 返回本次构建的局部快照（而非 e.routers 字段），即便随后被其他 goroutine 覆盖，调用方
-		// 持有的快照底层数组也不会被改写，可在锁外安全遍历——消除原先「写 e.routers 与读返回值」
-		// 之间的 data race。
-		routers := e.engine.(*gin.Engine).Routes()
-		list := make([]Router, 0, len(routers))
-		for _, router := range routers {
-			list = append(list, Router{RelativePath: router.Path, Handler: router.Handler, HttpMethod: router.Method})
-		}
-		e.mux.Lock()
-		e.routers = list
-		e.mux.Unlock()
-		return list
-	}
+	// The engine is read once, under the lock, and used from the local copy.
+	// The three bare reads this replaces raced with SetEngine, and this is the
+	// one engine access that really does happen at run time: GetRouter is
+	// reachable from the manual "sync API" endpoint, not just from startup.
 	e.mux.RLock()
-	defer e.mux.RUnlock()
-	return e.routers
+	engine := e.engine
+	e.mux.RUnlock()
+
+	ge, ok := engine.(*gin.Engine)
+	if !ok {
+		e.mux.RLock()
+		defer e.mux.RUnlock()
+		// Clone: returning the field itself lets the caller range over it once
+		// the lock is gone, which is the race the lock looks like it prevents.
+		return slices.Clone(e.routers)
+	}
+
+	// The table is rebuilt from the engine every time rather than appended to.
+	// GetRouter is called more than once - the -a sync at startup, and the
+	// manual sync endpoint at run time - and the original appended the full
+	// route set to e.routers on each call, so the table grew by a multiple
+	// every time. FirstOrCreate downstream kept that correct, but the cost of
+	// a sync grew linearly with the number of syncs already done.
+	//
+	// Routes() and the loop run with no lock held: gin's route table is
+	// read-only once registration is over, and holding e.mux across them would
+	// block the config read path for as long as it takes. Only the assignment
+	// takes the write lock, and the local snapshot is what is returned - the
+	// caller can range over it after another goroutine has replaced the field,
+	// which is the race that returning e.routers used to create.
+	routers := ge.Routes()
+	list := make([]Router, 0, len(routers))
+	for _, router := range routers {
+		list = append(list, Router{RelativePath: router.Path, Handler: router.Handler, HttpMethod: router.Method})
+	}
+	e.mux.Lock()
+	e.routers = list
+	e.mux.Unlock()
+	return list
 }
 
 // SetLogger 设置日志组件
@@ -520,14 +534,4 @@ func (e *Application) GetConfigValue(key string) interface{} {
 // SetConfigValue 设置默认租户的配置值
 func (e *Application) SetConfigValue(key string, value interface{}) {
 	e.SetConfigValueByTenant(e.GetDefaultTenant(), key, value)
-}
-
-// SetAppRouters 设置app的路由
-func (e *Application) SetAppRouters(appRouters func()) {
-	e.appRouters = append(e.appRouters, appRouters)
-}
-
-// GetAppRouters 获取app的路由
-func (e *Application) GetAppRouters() []func() {
-	return e.appRouters
 }

--- a/sdk/runtime/application_guard_fatal_test.go
+++ b/sdk/runtime/application_guard_fatal_test.go
@@ -1,0 +1,194 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+)
+
+// childEnv selects which scenario the re-executed test binary should play.
+// Exiting the process cannot be asserted from inside the process that would
+// exit, so the cases that really exit run in a child.
+const childEnv = "GO_ADMIN_CORE_GUARD_CHILD"
+
+// stdoutLogger writes where the parent can read it, and reports a level of the
+// caller's choosing so a test can prove the exit does not depend on anything
+// being logged.
+type stdoutLogger struct{ level logger.Level }
+
+func (l stdoutLogger) Init(...logger.Option) error                 { return nil }
+func (l stdoutLogger) Options() logger.Options                     { return logger.Options{Level: l.level} }
+func (l stdoutLogger) Fields(map[string]interface{}) logger.Logger { return l }
+func (l stdoutLogger) String() string                              { return "stdout" }
+
+func (l stdoutLogger) Log(_ logger.Level, v ...interface{}) {
+	fmt.Fprintln(os.Stdout, v...)
+}
+
+func (l stdoutLogger) Logf(_ logger.Level, format string, v ...interface{}) {
+	fmt.Fprintf(os.Stdout, format+"\n", v...)
+}
+
+// TestGuardChild is the body of every subprocess case. It is skipped in a
+// normal run, and the parent selects a case through the environment.
+func TestGuardChild(t *testing.T) {
+	scenario := os.Getenv(childEnv)
+	if scenario == "" {
+		t.Skip("child of the guard subprocess tests; run through the parent")
+	}
+
+	app := NewConfig()
+	switch scenario {
+	case "fatal":
+		app.SetLogger(stdoutLogger{level: logger.TraceLevel})
+		app.SetBeforeWith(func() { panic("the database is not reachable") },
+			WithFatal(), WithName("db-check"))
+		app.SetBefore(func() { fmt.Println("MUST-NOT-RUN") })
+		app.RunBefore()
+		fmt.Println("MUST-NOT-REACH")
+
+	case "fatal-silent-logger":
+		// A logger that drops everything, including FatalLevel. This is the
+		// reason the guard does not call Helper.Fatalf: that method returns
+		// without exiting when the level filters it out, which would turn
+		// "must not start" into "started anyway, quietly".
+		app.SetLogger(stdoutLogger{level: logger.FatalLevel + 1})
+		app.SetBeforeWith(func() { panic("boom") }, WithFatal())
+		app.RunBefore()
+		fmt.Println("MUST-NOT-REACH")
+
+	case "goroutine":
+		// The boundary of the guard, played out for real: the callback returns
+		// cleanly and the panic happens later, on a goroutine no recover of
+		// ours can reach.
+		app.SetLogger(stdoutLogger{level: logger.TraceLevel})
+		app.SetBefore(func() {
+			done := make(chan struct{})
+			go func() {
+				close(done)
+				panic("boom in a goroutine")
+			}()
+			<-done
+		})
+		app.RunBefore()
+		select {} // let the goroutine bring the process down
+	}
+}
+
+func runGuardChild(t *testing.T, scenario string) (string, int) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestGuardChild$", "-test.v")
+	cmd.Env = append(os.Environ(), childEnv+"="+scenario)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("the child exited successfully; it was supposed to die.\n%s", out)
+	}
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("could not run the child: %v\n%s", err, out)
+	}
+	return string(out), exitErr.ExitCode()
+}
+
+// Acceptance 7: a callback marked fatal takes the process down, and says why
+// on the way out. The exit code is part of it - a supervisor restarting the
+// service reads that, not the log.
+func TestFatalCallbackExitsTheProcess(t *testing.T) {
+	out, code := runGuardChild(t, "fatal")
+
+	if code != 1 {
+		t.Errorf("the child exited with %d, want 1\n%s", code, out)
+	}
+	for _, want := range []string{"db-check", "the database is not reachable", "application_guard_fatal_test.go"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the child must say %q before exiting, got:\n%s", want, out)
+		}
+	}
+	for _, unwanted := range []string{"MUST-NOT-RUN", "MUST-NOT-REACH"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("the process kept going after a fatal callback (%s):\n%s", unwanted, out)
+		}
+	}
+}
+
+// The exit must not be a side effect of logging. With a logger that filters
+// everything out, nothing is printed and the process still has to die -
+// otherwise raising the log level would silently re-enable a start-up that was
+// declared impossible.
+func TestFatalExitDoesNotDependOnTheLogLevel(t *testing.T) {
+	out, code := runGuardChild(t, "fatal-silent-logger")
+
+	if code != 1 {
+		t.Errorf("the child exited with %d, want 1\n%s", code, out)
+	}
+	if strings.Contains(out, "MUST-NOT-REACH") {
+		t.Errorf("a filtered log level let the process start anyway:\n%s", out)
+	}
+}
+
+// The other half of acceptance 8: proof that the guard's boundary is real. A
+// panic on a goroutine the callback started kills the process, and the guard
+// never gets a word in. This is why the contract says the protection covers
+// synchronous panics only - a module that copies pro's `go func()` shape is
+// responsible for its own recover.
+func TestGoroutinePanicEscapesTheGuard(t *testing.T) {
+	out, code := runGuardChild(t, "goroutine")
+
+	if code == 1 {
+		t.Errorf("exit code 1 suggests the guard handled it; it cannot:\n%s", out)
+	}
+	if !strings.Contains(out, "panic: boom in a goroutine") {
+		t.Errorf("the child must die of the raw panic, got:\n%s", out)
+	}
+	if strings.Contains(out, "continuing with the rest") {
+		t.Errorf("the guard reported a panic it cannot actually see:\n%s", out)
+	}
+}
+
+// The in-process half: the same decision, observed through the exit seam, so
+// the branch is covered by the normal test run as well as by the subprocess.
+//
+// The stub returns where os.Exit would not, so execution continues past it -
+// that is an artefact of the seam, not the behaviour under test.
+func TestFatalCallbackCallsExitWithOne(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	previous := exit
+	t.Cleanup(func() { exit = previous })
+	var codes []int
+	exit = func(code int) { codes = append(codes, code) }
+
+	app.SetBeforeWith(func() { panic("boom") }, WithFatal())
+	app.RunBefore()
+
+	if len(codes) != 1 || codes[0] != 1 {
+		t.Errorf("exit was called with %v, want exactly one call with 1", codes)
+	}
+}
+
+// A callback that does not declare itself fatal must never exit, whatever it
+// panics with. The default is the degradable one; that is what makes WithFatal
+// meaningful.
+func TestDefaultCallbackNeverExits(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	previous := exit
+	t.Cleanup(func() { exit = previous })
+	called := false
+	exit = func(int) { called = true }
+
+	app.SetBefore(func() { panic("boom") })
+	app.RunBefore()
+
+	if called {
+		t.Error("a callback registered without WithFatal must not bring the process down")
+	}
+}

--- a/sdk/runtime/application_guard_test.go
+++ b/sdk/runtime/application_guard_test.go
@@ -1,0 +1,183 @@
+package runtime
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+)
+
+// Acceptance 5: one callback panicking must not cost the others their turn,
+// and must not take the process with it. Before this guard every registrant
+// had to write its own recover, which means the protection was only as good as
+// the least careful third-party module.
+func TestPanicInOneCallbackDoesNotStopTheRest(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var ran []string
+	app.SetBefore(func() { ran = append(ran, "first") })
+	app.SetBefore(func() { panic("boom") })
+	app.SetBefore(func() { ran = append(ran, "third") })
+
+	mustReturn(t, "RunBefore with a panicking callback", app.RunBefore)
+
+	if got := strings.Join(ran, ","); got != "first,third" {
+		t.Errorf("ran %q, want first,third", got)
+	}
+}
+
+// The same guard covers the router registry, which is the one a third-party
+// module actually registers into.
+func TestPanicInOneRouterDoesNotStopTheRest(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var ran []string
+	app.SetAppRouters(func() { ran = append(ran, "first") })
+	app.SetAppRouters(func() { panic("boom") })
+	app.SetAppRouters(func() { ran = append(ran, "third") })
+
+	app.RunAppRouters()
+
+	if got := strings.Join(ran, ","); got != "first,third" {
+		t.Errorf("ran %q, want first,third", got)
+	}
+}
+
+// Acceptance 6: recovering without reporting would only move the silent
+// failure. The line has to carry the panic value, the stack, and - because the
+// stack unwinds into core, not into the module - where the callback was
+// registered.
+func TestPanicIsReportedWithSiteValueAndStack(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	app.SetBeforeWith(func() { panic("boom") }, WithName("crm-installer"))
+	app.RunBefore()
+
+	errors := rec.only(logger.ErrorLevel)
+	if len(errors) != 1 {
+		t.Fatalf("want exactly one error line, got %v", errors)
+	}
+	got := errors[0]
+	for _, want := range []string{
+		"crm-installer",             // the label the registrant chose
+		"application_guard_test.go", // where it was registered
+		"boom",                      // what the panic said
+		"goroutine ",                // the stack, not just the message
+		"TestPanicIsReportedWithSiteValueAndStack", // the frame that panicked
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the report must contain %q, got:\n%s", want, got)
+		}
+	}
+}
+
+// Without WithName the line still has to be actionable, which means the
+// registration site is not optional.
+func TestUnnamedPanicStillNamesTheRegistrationSite(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	app.SetAppRouters(func() { panic("boom") })
+	app.RunAppRouters()
+
+	errors := rec.only(logger.ErrorLevel)
+	if len(errors) != 1 {
+		t.Fatalf("want exactly one error line, got %v", errors)
+	}
+	if !strings.Contains(errors[0], "application_guard_test.go") {
+		t.Errorf("the report must name the registration site, got:\n%s", errors[0])
+	}
+}
+
+// Acceptance 8a: a callback that recovers for itself is not a special case.
+// The panic stops inside it, the function returns normally, and the guard's
+// recover sees nil - so nothing is logged twice. This falls out of Go's
+// semantics; the test is here to keep it that way.
+func TestCallbackThatRecoversForItselfIsNotReportedAgain(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	recovered := false
+	app.SetBefore(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				recovered = true
+			}
+		}()
+		panic("handled inside")
+	})
+	after := false
+	app.SetBefore(func() { after = true })
+
+	app.RunBefore()
+
+	if !recovered {
+		t.Error("the callback's own recover did not run")
+	}
+	if !after {
+		t.Error("the following callback did not run")
+	}
+	if errors := rec.only(logger.ErrorLevel); len(errors) != 0 {
+		t.Errorf("the framework must stay quiet when the callback handled it, got %v", errors)
+	}
+}
+
+// Acceptance 8b: the boundary of the promise. recover only works on the
+// goroutine that is panicking, so a callback whose real work is `go func()`
+// - which is how go-admin-pro registers its jobs - is outside the guard
+// entirely. Here the goroutine recovers for itself, as pro's does. Without
+// that recover the process dies, and no amount of framework code changes it;
+// TestGoroutinePanicEscapesTheGuard runs that case in a subprocess.
+func TestGuardDoesNotReachIntoASpawnedGoroutine(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	handledInGoroutine := false
+	app.SetBefore(func() {
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					handledInGoroutine = true
+				}
+			}()
+			panic("boom in a goroutine")
+		}()
+	})
+
+	app.RunBefore()
+	wg.Wait()
+
+	if !handledInGoroutine {
+		t.Error("the goroutine's own recover did not run")
+	}
+	if errors := rec.only(logger.ErrorLevel); len(errors) != 0 {
+		t.Errorf("the framework cannot see across a goroutine boundary, so it must log nothing, got %v", errors)
+	}
+}
+
+// A nil logger is a bad configuration, but the paths that report a defect must
+// not turn it into a second one: the panic still has to be reported somewhere
+// rather than crashing on the way to being reported.
+func TestGuardSurvivesANilLogger(t *testing.T) {
+	app := NewConfig()
+	previous := logger.DefaultLogger
+	t.Cleanup(func() { logger.DefaultLogger = previous })
+	app.SetLogger(nil)
+
+	after := false
+	app.SetBefore(func() { panic("boom") })
+	app.SetBefore(func() { after = true })
+
+	mustReturn(t, "RunBefore with a nil logger", app.RunBefore)
+
+	if !after {
+		t.Error("a nil logger must not stop the remaining callbacks")
+	}
+}

--- a/sdk/runtime/application_lock_test.go
+++ b/sdk/runtime/application_lock_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
@@ -69,5 +70,61 @@ func TestSingleTenantSettersUseDefaultTenant(t *testing.T) {
 	app.SetConfigValue("key", "value")
 	if got := app.GetConfigValueByTenant(DefaultTenant, "key"); got != "value" {
 		t.Errorf("SetConfigValue did not store under %q, got %v", DefaultTenant, got)
+	}
+}
+
+// Acceptance 14: the same guard applied to everything this batch put behind
+// the mutex. The failure mode is identical - a method that takes the lock and
+// then calls another one that takes it hangs forever - and it is invisible
+// until the one call order that triggers it happens in production.
+func TestRegistryAccessorsDoNotDeadlock(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	noop := func() {}
+
+	cases := []struct {
+		name string
+		fn   func()
+	}{
+		{"SetBefore", func() { NewConfig().SetBefore(noop) }},
+		{"SetBeforeWith", func() { NewConfig().SetBeforeWith(noop, WithName("x"), WithFatal()) }},
+		{"GetBefore", func() { NewConfig().GetBefore() }},
+		{"RunBefore", func() { NewConfig().RunBefore() }},
+		{"BeforeSealed", func() { NewConfig().BeforeSealed() }},
+		{"SetAppRouters", func() { NewConfig().SetAppRouters(noop) }},
+		{"SetAppRoutersWith", func() { NewConfig().SetAppRoutersWith(noop, WithName("x")) }},
+		{"GetAppRouters", func() { NewConfig().GetAppRouters() }},
+		{"RunAppRouters", func() { NewConfig().RunAppRouters() }},
+		{"AppRoutersSealed", func() { NewConfig().AppRoutersSealed() }},
+		{"SetEngine", func() { NewConfig().SetEngine(gin.New()) }},
+		{"GetEngine", func() { NewConfig().GetEngine() }},
+		{"GetRouter", func() { NewConfig().GetRouter() }},
+		{"GetRouter with a gin engine", func() {
+			app := NewConfig()
+			app.SetEngine(gin.New())
+			app.GetRouter()
+		}},
+		// The one that is not hypothetical: app/demo/router/router.go reads and
+		// writes the engine from inside the very callback RunAppRouters
+		// executes. Running callbacks under the lock hangs right here.
+		{"RunAppRouters with a callback that takes the lock", func() {
+			app := NewConfig()
+			app.SetAppRouters(func() {
+				if app.GetEngine() == nil {
+					app.SetEngine(gin.New())
+				}
+			})
+			app.RunAppRouters()
+		}},
+		{"RunBefore with a callback that takes the lock", func() {
+			app := NewConfig()
+			app.SetBefore(func() { app.SetConfigValue("k", "v") })
+			app.RunBefore()
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mustReturn(t, c.name, c.fn)
+		})
 	}
 }

--- a/sdk/runtime/application_race_test.go
+++ b/sdk/runtime/application_race_test.go
@@ -1,0 +1,109 @@
+package runtime
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Acceptance 12: the accessors that used to touch their fields with no lock at
+// all - before, appRouters and engine - hammered from several goroutines at
+// once. Under -race this fails on the old code and says nothing on the new.
+//
+// engine is the one that mattered in production: GetRouter reads it at run
+// time, from the manual "sync API" endpoint, while SetEngine wrote it with no
+// lock on the other side.
+func TestUnguardedAccessorsAreRaceFree(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	captureLogs(t, NewConfig())
+
+	app := NewConfig()
+	engines := []http.Handler{gin.New(), gin.New()}
+	for _, ge := range engines {
+		ge.(*gin.Engine).GET("/ping", func(c *gin.Context) {})
+	}
+	app.SetEngine(engines[0])
+
+	const goroutines, iters = 16, 100
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				switch (i + j) % 8 {
+				case 0:
+					app.SetBefore(func() {})
+				case 1:
+					app.GetBefore()
+				case 2:
+					app.SetAppRouters(func() {})
+				case 3:
+					app.GetAppRouters()
+				case 4:
+					app.SetEngine(engines[j%len(engines)])
+				case 5:
+					app.GetEngine()
+				case 6:
+					app.GetRouter()
+				case 7:
+					app.BeforeSealed()
+					app.AppRoutersSealed()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// Running a registry while other goroutines are still registering into it.
+//
+// The seal, the cursor and the batch of callbacks to run all move inside one
+// critical section, which is what leaves no middle state: a registration
+// either lands in the batch or is refused as late. What must never happen is a
+// callback that is accepted and then never run.
+func TestConcurrentRunAndRegisterIsRaceFree(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var mu sync.Mutex
+	ran := 0
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			app.SetBefore(func() {
+				mu.Lock()
+				ran++
+				mu.Unlock()
+			})
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			app.RunBefore()
+		}()
+	}
+	wg.Wait()
+
+	// Whatever the interleaving was, the registry is closed and everything it
+	// accepted has run exactly once.
+	app.RunBefore()
+	if !app.BeforeSealed() {
+		t.Fatal("the registry is not closed after RunBefore")
+	}
+
+	accepted := len(app.GetBefore())
+	mu.Lock()
+	defer mu.Unlock()
+	if ran != accepted {
+		t.Errorf("%d callbacks were accepted but %d ran; an accepted registration must never be dropped", accepted, ran)
+	}
+}

--- a/sdk/runtime/application_registry_test.go
+++ b/sdk/runtime/application_registry_test.go
@@ -1,0 +1,383 @@
+package runtime
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+	"github.com/go-admin-team/go-admin-core/v2/storage"
+	"gorm.io/gorm"
+)
+
+// recordingLogger keeps every line so a test can assert on what was said.
+//
+// It reports TraceLevel so nothing is filtered out: the guard's own defence
+// against Helper.Fatalf is that level filtering must never decide whether
+// something is reported, and a test logger that filters would hide exactly the
+// regression this file exists to catch.
+type recordingLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *recordingLogger) Init(...logger.Option) error { return nil }
+func (l *recordingLogger) Options() logger.Options     { return logger.Options{Level: logger.TraceLevel} }
+func (l *recordingLogger) Fields(map[string]interface{}) logger.Logger {
+	return l
+}
+func (l *recordingLogger) String() string { return "recording" }
+
+func (l *recordingLogger) Log(level logger.Level, v ...interface{}) {
+	l.record(level, fmt.Sprint(v...))
+}
+
+func (l *recordingLogger) Logf(level logger.Level, format string, v ...interface{}) {
+	l.record(level, fmt.Sprintf(format, v...))
+}
+
+func (l *recordingLogger) record(level logger.Level, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, level.String()+" "+msg)
+}
+
+func (l *recordingLogger) all() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.lines...)
+}
+
+// only returns the lines logged at one level.
+func (l *recordingLogger) only(level logger.Level) []string {
+	prefix := level.String() + " "
+	var out []string
+	for _, line := range l.all() {
+		if strings.HasPrefix(line, prefix) {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// captureLogs points the application at a recording logger for one test.
+//
+// SetLogger writes the package-level logger.DefaultLogger, so this is
+// process-wide: no test that calls it may run in parallel.
+func captureLogs(t *testing.T, app *Application) *recordingLogger {
+	t.Helper()
+	rec := &recordingLogger{}
+	previous := logger.DefaultLogger
+	t.Cleanup(func() { logger.DefaultLogger = previous })
+	app.SetLogger(rec)
+	return rec
+}
+
+// Acceptance 1: RunBefore runs every registered callback, in the order they
+// were registered. The order is part of the contract - it is what lets a
+// module rely on an earlier one having run - so it is asserted, not assumed.
+func TestRunBeforeRunsInRegistrationOrder(t *testing.T) {
+	app := NewConfig()
+	var order []string
+	for _, name := range []string{"first", "second", "third"} {
+		app.SetBefore(func() { order = append(order, name) })
+	}
+
+	app.RunBefore()
+
+	if got := strings.Join(order, ","); got != "first,second,third" {
+		t.Errorf("ran %q, want first,second,third", got)
+	}
+}
+
+// Acceptance 2: the same promise for the router registry.
+func TestRunAppRoutersRunsInRegistrationOrder(t *testing.T) {
+	app := NewConfig()
+	var order []string
+	for _, name := range []string{"first", "second", "third"} {
+		app.SetAppRouters(func() { order = append(order, name) })
+	}
+
+	app.RunAppRouters()
+
+	if got := strings.Join(order, ","); got != "first,second,third" {
+		t.Errorf("ran %q, want first,second,third", got)
+	}
+}
+
+// Acceptance 3: the pre-existing way of using the registry - ask for the
+// callbacks and run them yourself - keeps working unchanged. go-admin-pro does
+// exactly this, and it is not being changed in this batch.
+func TestSelfWrittenLoopStillWorks(t *testing.T) {
+	app := NewConfig()
+	var ran []string
+	app.SetBefore(func() { ran = append(ran, "before-1") })
+	app.SetBefore(func() { ran = append(ran, "before-2") })
+	app.SetAppRouters(func() { ran = append(ran, "router-1") })
+
+	for _, f := range app.GetBefore() {
+		f()
+	}
+	for _, f := range app.GetAppRouters() {
+		f()
+	}
+
+	if got := strings.Join(ran, ","); got != "before-1,before-2,router-1" {
+		t.Errorf("ran %q, want before-1,before-2,router-1", got)
+	}
+}
+
+// Get* hands out a copy. The caller ranges over the result with no lock held,
+// so returning the live slice was the same defect GetAllDb was fixed for.
+func TestGetReturnsASnapshot(t *testing.T) {
+	app := NewConfig()
+	app.SetBefore(func() {})
+
+	snapshot := app.GetBefore()
+	snapshot[0] = nil
+
+	if got := app.GetBefore(); got[0] == nil {
+		t.Error("writing to the returned slice reached the registry; Get* must return a copy")
+	}
+}
+
+// Acceptance 4: Run* is idempotent. Something has to be, because a fork that
+// added its own call keeps it while the framework gains one too, and a startup
+// hook that runs twice is a class of bug that only shows up in production.
+func TestRunIsIdempotent(t *testing.T) {
+	app := NewConfig()
+	before, routers := 0, 0
+	app.SetBefore(func() { before++ })
+	app.SetAppRouters(func() { routers++ })
+
+	for i := 0; i < 3; i++ {
+		app.RunBefore()
+		app.RunAppRouters()
+	}
+
+	if before != 1 || routers != 1 {
+		t.Errorf("before ran %d times and appRouters %d, want 1 each", before, routers)
+	}
+}
+
+// Acceptance 9: a registration that arrives after the registry has run is
+// dropped and said out loud. Keeping it would be worse: it would sit in a
+// slice nobody walks again, which is the silent failure this batch exists to
+// remove.
+func TestRegistrationAfterRunIsDroppedAndReported(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	ran := 0
+	app.SetBefore(func() { ran++ })
+	app.RunBefore()
+
+	late := 0
+	app.SetBefore(func() { late++ })
+	app.RunBefore()
+
+	if late != 0 {
+		t.Errorf("the late callback ran %d times, want 0", late)
+	}
+	if ran != 1 {
+		t.Errorf("the early callback ran %d times, want 1", ran)
+	}
+	if got := len(app.GetBefore()); got != 1 {
+		t.Errorf("the registry holds %d callbacks, want 1", got)
+	}
+
+	errors := rec.only(logger.ErrorLevel)
+	if len(errors) != 1 {
+		t.Fatalf("want exactly one error line, got %v", errors)
+	}
+	// What happened, why, and where the offending registration is: a line
+	// missing any of the three leaves the reader with nothing to act on.
+	for _, want := range []string{"SetBefore", "ignored", "RunBefore", "application_registry_test.go"} {
+		if !strings.Contains(errors[0], want) {
+			t.Errorf("the error must mention %q, got: %s", want, errors[0])
+		}
+	}
+}
+
+// The registries close one at a time. They have separate entry points, so
+// running one says nothing about whether the other is still open.
+func TestSealingIsPerRegistry(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	app.RunBefore()
+	if !app.BeforeSealed() {
+		t.Error("RunBefore must close the before registry")
+	}
+	if app.AppRoutersSealed() {
+		t.Error("RunBefore must not close the appRouters registry")
+	}
+
+	ran := false
+	app.SetAppRouters(func() { ran = true })
+	app.RunAppRouters()
+	if !ran {
+		t.Error("a router registered after RunBefore must still run")
+	}
+	if !app.AppRoutersSealed() {
+		t.Error("RunAppRouters must close the appRouters registry")
+	}
+}
+
+// labelledCache and labelledQueue carry an id so a test can tell which
+// instance the getters hand back; the real memory adapters both report their
+// type, which would pass whether or not the field was replaced.
+type labelledCache struct {
+	storage.AdapterCache
+	id string
+}
+
+func (c *labelledCache) String() string { return c.id }
+
+type labelledQueue struct {
+	storage.AdapterQueue
+	id string
+}
+
+func (q *labelledQueue) String() string { return q.id }
+
+// Acceptance 10: closing the registries must not reach the resource fields.
+// Reloading the configuration re-runs the setup callbacks while requests are
+// being served - replacing the database, the cache and the queue - so freezing
+// those would turn a config change into a silent no-op.
+func TestSealingDoesNotFreezeResources(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	app.RunBefore()
+	app.RunAppRouters()
+
+	db := &gorm.DB{}
+	app.SetDbByTenant("tenant-a", db)
+	if got := app.GetDbByTenant("tenant-a"); got != db {
+		t.Error("SetDbByTenant stopped working once the registries were closed")
+	}
+
+	app.SetCacheAdapter(&labelledCache{id: "cache-after-seal"})
+	if got := app.GetCacheAdapter().String(); got != "cache-after-seal" {
+		t.Errorf("GetCacheAdapter returned %q, want the adapter set after sealing", got)
+	}
+
+	app.SetQueueAdapter(&labelledQueue{id: "queue-after-seal"})
+	if got := app.GetQueueAdapter().String(); got != "queue-after-seal" {
+		t.Errorf("GetQueueAdapter returned %q, want the adapter set after sealing", got)
+	}
+
+	app.SetConfigValue("key", "value")
+	if got := app.GetConfigValue("key"); got != "value" {
+		t.Errorf("GetConfigValue returned %v, want the value set after sealing", got)
+	}
+}
+
+// A callback reaching back into Application is the normal case, not an edge
+// one: app/demo/router/router.go asks for the engine and sets it when there is
+// none, and that function is exactly what RunAppRouters executes. sync.RWMutex
+// is not reentrant, so running callbacks under the lock hangs here - which is
+// why the guard is a timeout rather than a plain call.
+func TestCallbackMayCallBackIntoRuntime(t *testing.T) {
+	app := NewConfig()
+	gin.SetMode(gin.TestMode)
+
+	var seen http.Handler
+	mustReturn(t, "RunAppRouters with a callback that touches Application", func() {
+		app.SetAppRouters(func() {
+			if h := app.GetEngine(); h == nil {
+				app.SetEngine(gin.New())
+			}
+			seen = app.GetEngine()
+			app.GetRouter()
+			app.GetDefaultTenant()
+		})
+		app.RunAppRouters()
+	})
+
+	if seen == nil {
+		t.Error("the callback did not observe the engine it had just set")
+	}
+}
+
+// Mixing the two styles runs the callbacks twice, and core cannot prevent that
+// - it never sees a loop written downstream. What it can do is say so, which
+// is the difference between a startup that is wrong and one that is wrong and
+// undiagnosable.
+func TestMixingGetAndRunWarns(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	ran := 0
+	app.SetBefore(func() { ran++ })
+
+	for _, f := range app.GetBefore() {
+		f()
+	}
+	app.RunBefore()
+
+	if ran != 2 {
+		t.Errorf("the callback ran %d times, want 2 (the double run the warning is about)", ran)
+	}
+	warnings := rec.only(logger.WarnLevel)
+	if len(warnings) != 1 {
+		t.Fatalf("want exactly one warning, got %v", warnings)
+	}
+	for _, want := range []string{"GetBefore", "RunBefore", "twice"} {
+		if !strings.Contains(warnings[0], want) {
+			t.Errorf("the warning must mention %q, got: %s", want, warnings[0])
+		}
+	}
+}
+
+// The warning belongs to a run that has something to run. A no-op second call
+// cannot double-run anything, and repeating the warning on every call would
+// train readers to ignore it.
+func TestNoWarningWhenThereIsNothingToRun(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	app.GetBefore()
+	app.RunBefore()
+
+	if warnings := rec.only(logger.WarnLevel); len(warnings) != 0 {
+		t.Errorf("an empty registry must not warn, got %v", warnings)
+	}
+}
+
+// The options carry the failure level, so an unnamed, unoptioned registration
+// has to end up on the same path with the same defaults - otherwise "no
+// options means the old behaviour" is a promise held up by nothing.
+func TestWithOptionsSharesThePlainPath(t *testing.T) {
+	app := NewConfig()
+	var order []string
+	app.SetBefore(func() { order = append(order, "plain") })
+	app.SetBeforeWith(func() { order = append(order, "with-name") }, WithName("named"))
+	app.SetAppRouters(func() { order = append(order, "router-plain") })
+	app.SetAppRoutersWith(func() { order = append(order, "router-named") }, WithName("named"))
+
+	app.RunBefore()
+	app.RunAppRouters()
+
+	if got := strings.Join(order, ","); got != "plain,with-name,router-plain,router-named" {
+		t.Errorf("ran %q, want plain,with-name,router-plain,router-named", got)
+	}
+}
+
+// The empty case used to return the nil field itself. Handing back an empty
+// non-nil slice instead would be a visible change for anyone who compares
+// against nil, and there is nothing to gain from it.
+func TestGetOnAnEmptyRegistryReturnsNil(t *testing.T) {
+	app := NewConfig()
+
+	if got := app.GetBefore(); got != nil {
+		t.Errorf("GetBefore returned %#v, want nil", got)
+	}
+	if got := app.GetAppRouters(); got != nil {
+		t.Errorf("GetAppRouters returned %#v, want nil", got)
+	}
+}

--- a/sdk/runtime/registry.go
+++ b/sdk/runtime/registry.go
@@ -1,0 +1,311 @@
+package runtime
+
+import (
+	"os"
+	goruntime "runtime" // aliased: this package is itself called runtime
+	"runtime/debug"
+	"slices"
+	"strconv"
+
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+)
+
+// callback is one registered startup function plus everything the guard needs
+// in order to say something useful when it panics.
+//
+// site is recorded at registration rather than at execution because a panic
+// unwinds to this file: without it the log names the framework, and the reader
+// still has to find out who registered the thing that failed.
+type callback struct {
+	fn    func()
+	name  string // caller-supplied label; empty unless WithName was used
+	site  string // "file:line" of the SetXxx call that registered it
+	fatal bool
+}
+
+// label is "name (file:line)", or "(file:line)" when the callback is unnamed.
+func (cb callback) label() string {
+	if cb.name == "" {
+		return "(" + cb.site + ")"
+	}
+	return cb.name + " (" + cb.site + ")"
+}
+
+// registry holds one kind of startup callback.
+//
+// cursor is what makes Run* idempotent: entries before it have already been
+// dispatched, so a second Run finds nothing to do. sealed is the other half:
+// once the registry has run, a late registration is dropped and reported,
+// instead of sitting in a slice that nobody will ever walk again.
+//
+// Every method here assumes the caller already holds Application.mux.
+// sync.RWMutex is not reentrant, so none of them may take it.
+type registry struct {
+	entries []callback
+	cursor  int
+	sealed  bool
+	handed  bool // Get* handed the entries out for a loop core cannot see
+}
+
+// appendLocked records a callback, reporting false when the registry is closed.
+func (r *registry) appendLocked(cb callback) bool {
+	if r.sealed {
+		return false
+	}
+	r.entries = append(r.entries, cb)
+	return true
+}
+
+// snapshotLocked returns the registered functions in registration order.
+//
+// It is a copy. Handing back the live slice let the caller range over it after
+// the lock was gone while another goroutine appended to it - the same defect
+// GetAllDb was fixed for.
+func (r *registry) snapshotLocked() []func() {
+	if len(r.entries) == 0 {
+		// nil rather than an empty slice: that is what the field itself used
+		// to return, and a caller comparing the result against nil should not
+		// start seeing a different answer.
+		return nil
+	}
+	out := make([]func(), len(r.entries))
+	for i := range r.entries {
+		out[i] = r.entries[i].fn
+	}
+	return out
+}
+
+// takePendingLocked claims everything not yet dispatched and closes the
+// registry, both in the caller's single critical section.
+//
+// Doing all three together is what removes the middle state: a concurrent
+// SetXxx either lands in this batch or is refused as late, never neither.
+func (r *registry) takePendingLocked() []callback {
+	pending := slices.Clone(r.entries[r.cursor:])
+	r.cursor = len(r.entries)
+	r.sealed = true
+	return pending
+}
+
+// CallbackOption configures a callback registered through SetBeforeWith or
+// SetAppRoutersWith.
+//
+// Passing no options is the historical behaviour: a panic is logged and the
+// remaining callbacks still run. Nothing a caller does not ask for changes.
+type CallbackOption func(*callbackConfig)
+
+type callbackConfig struct {
+	name  string
+	fatal bool
+}
+
+// WithFatal marks a callback the process must not start without: a panic in it
+// is logged and then the process exits with status 1.
+//
+// This is the exception, not the default. An application that marks itself
+// fatal makes the whole host program as fragile as itself, and the exit skips
+// every deferred cleanup - so it only belongs on work that happens before the
+// server starts listening.
+func WithFatal() CallbackOption { return func(c *callbackConfig) { c.fatal = true } }
+
+// WithName labels the callback in guard logs. Without it the log carries the
+// registration site only, which is enough to find the code but not enough to
+// know what it was for.
+func WithName(name string) CallbackOption { return func(c *callbackConfig) { c.name = name } }
+
+func newCallback(f func(), site string, opts []CallbackOption) callback {
+	cfg := callbackConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	return callback{fn: f, name: cfg.name, site: site, fatal: cfg.fatal}
+}
+
+// callerSite reports where a registration came from.
+//
+// skip is counted at the exported method on purpose - 0 is this function, 1 is
+// SetBefore, 2 is whoever called it. Computing it any deeper means every new
+// layer of indirection silently moves the answer.
+func callerSite(skip int) string {
+	_, file, line, ok := goruntime.Caller(skip)
+	if !ok {
+		return "unknown"
+	}
+	return file + ":" + strconv.Itoa(line)
+}
+
+// exit is os.Exit behind a seam so the fatal path can be asserted in-process
+// as well as in the subprocess test.
+var exit = os.Exit
+
+// log returns a helper over the configured logger.
+//
+// The nil fallback matters because every caller of this is already reporting a
+// defect: a program that called SetLogger(nil) should still be told that its
+// callback panicked, not crash a second time on the way to saying so.
+func (e *Application) log() *logger.Helper {
+	l := e.GetLogger()
+	if l == nil {
+		l = logger.NewLogger()
+	}
+	return logger.NewHelper(l)
+}
+
+// register records a callback, or reports that it arrived too late.
+//
+// The lock covers the append and nothing else. Logging under it would run a
+// logger the application supplied, and there is no promise that it will not
+// call back into Application.
+func (e *Application) register(r *registry, cb callback, setter, runner string) {
+	e.mux.Lock()
+	ok := r.appendLocked(cb)
+	e.mux.Unlock()
+	if ok {
+		return
+	}
+	e.log().Errorf("runtime: %s ignored - the registry was already run and closed by %s; "+
+		"register from init() or before the server starts (registered at %s)", setter, runner, cb.site)
+}
+
+// runRegistry executes everything registered and not yet dispatched.
+//
+// Callbacks run with no lock held. They routinely call back into Application -
+// an app router asks for the engine and then sets it, a config callback stores
+// a database - and sync.RWMutex is not reentrant, so holding mux across a
+// callback deadlocks on the first one that does.
+func (e *Application) runRegistry(r *registry, kind, getter, runner string) {
+	e.mux.Lock()
+	pending := r.takePendingLocked()
+	handed := r.handed
+	e.mux.Unlock()
+
+	if len(pending) == 0 {
+		return
+	}
+
+	log := e.log()
+	if handed {
+		log.Warnf("runtime: %s was called before %s, and core cannot see a loop written outside it; "+
+			"if you run the returned callbacks yourself they run twice - drop your own loop", getter, runner)
+	}
+	for i := range pending {
+		e.invoke(kind, pending[i], log)
+	}
+}
+
+// invoke runs one callback behind the panic guard.
+//
+// A callback that already recovers for itself needs no special case: the panic
+// stops there, cb.fn returns normally and the recover below sees nil. The
+// guard reaches exactly as far as Go's recover does - which is to say not into
+// a goroutine the callback started.
+func (e *Application) invoke(kind string, cb callback, log *logger.Helper) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		stack := debug.Stack()
+		if cb.fatal {
+			// Not log.Fatalf: Helper.Fatalf returns without exiting when the
+			// configured level filters FatalLevel out, which would turn "must
+			// not start" into "started anyway, quietly".
+			log.Errorf("runtime: fatal %s callback %s panicked, exiting: %v\n%s",
+				kind, cb.label(), r, stack)
+			exit(1)
+			return
+		}
+		log.Errorf("runtime: %s callback %s panicked, continuing with the rest: %v\n%s",
+			kind, cb.label(), r, stack)
+	}()
+	cb.fn()
+}
+
+// SetBefore registers a callback to run before the server starts.
+//
+// The callback runs when RunBefore is called, in registration order, behind a
+// panic guard. Registering after RunBefore has run is refused and reported.
+func (e *Application) SetBefore(f func()) {
+	e.register(&e.before, callback{fn: f, site: callerSite(2)}, "SetBefore", "RunBefore")
+}
+
+// SetBeforeWith registers a before callback and configures how a panic in it
+// is treated. With no options it is identical to SetBefore.
+func (e *Application) SetBeforeWith(f func(), opts ...CallbackOption) {
+	e.register(&e.before, newCallback(f, callerSite(2), opts), "SetBeforeWith", "RunBefore")
+}
+
+// GetBefore returns the registered before callbacks, in registration order.
+//
+// Deprecated: use RunBefore. Running the returned callbacks yourself gets no
+// panic guard and no failure levels, and core cannot see your loop: calling
+// RunBefore afterwards runs everything a second time.
+func (e *Application) GetBefore() []func() {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+	e.before.handed = true
+	return e.before.snapshotLocked()
+}
+
+// RunBefore executes every before callback that has not run yet, in
+// registration order, and closes the registry to further registration.
+//
+// Calling it again is a no-op: the callbacks that already ran do not run twice.
+func (e *Application) RunBefore() {
+	e.runRegistry(&e.before, "before", "GetBefore", "RunBefore")
+}
+
+// BeforeSealed reports whether RunBefore has run. A registration made after
+// that point is dropped, so an installer can ask rather than find out from a
+// log line.
+func (e *Application) BeforeSealed() bool {
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return e.before.sealed
+}
+
+// SetAppRouters registers a router initialiser for an application module.
+//
+// The callback runs when RunAppRouters is called, in registration order,
+// behind a panic guard. Registering after RunAppRouters has run is refused and
+// reported.
+func (e *Application) SetAppRouters(appRouters func()) {
+	e.register(&e.appRouters, callback{fn: appRouters, site: callerSite(2)}, "SetAppRouters", "RunAppRouters")
+}
+
+// SetAppRoutersWith registers a router initialiser and configures how a panic
+// in it is treated. With no options it is identical to SetAppRouters.
+func (e *Application) SetAppRoutersWith(appRouters func(), opts ...CallbackOption) {
+	e.register(&e.appRouters, newCallback(appRouters, callerSite(2), opts), "SetAppRoutersWith", "RunAppRouters")
+}
+
+// GetAppRouters returns the registered router initialisers, in registration
+// order.
+//
+// Deprecated: use RunAppRouters. Running the returned callbacks yourself gets
+// no panic guard and no failure levels, and core cannot see your loop: calling
+// RunAppRouters afterwards runs everything a second time.
+func (e *Application) GetAppRouters() []func() {
+	e.mux.Lock()
+	defer e.mux.Unlock()
+	e.appRouters.handed = true
+	return e.appRouters.snapshotLocked()
+}
+
+// RunAppRouters executes every router initialiser that has not run yet, in
+// registration order, and closes the registry to further registration.
+//
+// Calling it again is a no-op: the initialisers that already ran do not run
+// twice.
+func (e *Application) RunAppRouters() {
+	e.runRegistry(&e.appRouters, "appRouters", "GetAppRouters", "RunAppRouters")
+}
+
+// AppRoutersSealed reports whether RunAppRouters has run. A registration made
+// after that point is dropped, so an installer can ask rather than find out
+// from a log line.
+func (e *Application) AppRoutersSealed() bool {
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return e.appRouters.sealed
+}

--- a/sdk/runtime/type.go
+++ b/sdk/runtime/type.go
@@ -22,8 +22,21 @@ type Runtime interface {
 	GetDb() *gorm.DB
 	GetAllDb() map[string]*gorm.DB
 
+	// SetBefore registers a callback to run when RunBefore is called.
 	SetBefore(f func())
+	// SetBeforeWith registers a before callback and says how a panic in it is
+	// treated. With no options it is identical to SetBefore.
+	SetBeforeWith(f func(), opts ...CallbackOption)
+	// GetBefore returns the registered before callbacks.
+	//
+	// Deprecated: use RunBefore.
 	GetBefore() []func()
+	// RunBefore executes the before callbacks that have not run yet, in
+	// registration order, and closes the registry.
+	RunBefore()
+	// BeforeSealed reports whether RunBefore has run, i.e. whether a further
+	// SetBefore would be dropped.
+	BeforeSealed() bool
 
 	SetAppByTenant(tenant string, app interface{})
 	SetApp(app interface{})
@@ -94,7 +107,20 @@ type Runtime interface {
 	GetConfig() map[string]interface{}
 	GetConfigValue(key string) interface{}
 
-	// SetAppRouters set AppRouter
+	// SetAppRouters registers a router initialiser to run when RunAppRouters
+	// is called.
 	SetAppRouters(appRouters func())
+	// SetAppRoutersWith registers a router initialiser and says how a panic in
+	// it is treated. With no options it is identical to SetAppRouters.
+	SetAppRoutersWith(appRouters func(), opts ...CallbackOption)
+	// GetAppRouters returns the registered router initialisers.
+	//
+	// Deprecated: use RunAppRouters.
 	GetAppRouters() []func()
+	// RunAppRouters executes the router initialisers that have not run yet, in
+	// registration order, and closes the registry.
+	RunAppRouters()
+	// AppRoutersSealed reports whether RunAppRouters has run, i.e. whether a
+	// further SetAppRouters would be dropped.
+	AppRoutersSealed() bool
 }


### PR DESCRIPTION
# Run the startup registries from core, behind a guard

## The problem

`SetBefore` and `SetAppRouters` had no execution point anywhere in this
repository — only the field, the setter, the getter and the interface entry.
Every consumer wrote its own loop over the getter, which had two consequences:

- the open-source server had a loop for `appRouters` but **none for `before`**,
  so a callback registered there never ran and nothing said so;
- the panic guard each consumer wrapped around its own callbacks was written
  once per consumer, or not at all.

Three fields were also reachable without the mutex. The one that mattered is
`engine`: `SetEngine` wrote it unlocked while `setRouter` read it three times
building the router table, and `GetRouter` runs both at startup and whenever
the API sync is triggered by hand — a race with a real trigger, not a
theoretical one.

## What this changes

`RunBefore()` and `RunAppRouters()` execute the registered callbacks in
registration order, each behind a `recover()`, and close the registry
afterwards. `SetBeforeWith` / `SetAppRoutersWith` take options; `WithFatal()`
says a panic in that callback should stop the program, `WithName()` labels it
in the log.

Sealing is per registry — `RunBefore()` closes `before` and nothing else — and
covers only the two registries that have a `Run*()` entry point. Resources
(databases, cache, queue, casbin) are deliberately **not** sealed: configuration
reload replaces them at runtime, and freezing them would break reload silently.

The engine field and both registries are now behind the mutex. Callbacks run
**outside** it: a router initialiser typically calls `GetEngine()`, and
`RWMutex` is not reentrant.

## Compatibility

Nothing is removed. The API snapshot is 15 added lines with no deletions and no
signature changes. `GetBefore()` and `GetAppRouters()` keep working — they are
marked deprecated, not dropped — so a consumer that writes its own loop is
unaffected. `Run*()` tracks what it has already dispatched, so calling it twice
runs nothing twice.

Two behaviours changed on purpose:

- `GetBefore()` / `GetAppRouters()` return a copy rather than the live slice.
  Same fix as the one already applied to `GetAllDb`: handing out the live
  structure lets a caller iterate it outside the lock.
- Mixing a self-written loop with `Run*()` logs a warning. Core cannot see a
  loop written outside it, so this is the only way to report the double run.

## What the guard does not cover

`recover()` only reaches synchronous panics on the same goroutine. A panic on a
goroutine the callback starts, `os.Exit` (which `logger.Fatal` calls), and
`runtime.Goexit` (which `testing.T.Fatal` calls) all leave the guard behind.
`runtime.Goexit` is the confusing one: the guard's deferred function runs,
`recover()` returns nil, and `Run*()` never returns while every later callback
is skipped and nothing is logged. `docs/contract.md` states all three.

## Testing

Registration order, idempotent `Run*()`, the guard, sealing, the seal *not*
touching resources, and the locks — including a reload test that drives the
real file watcher, and a subprocess test for the fatal path that also asserts
the exit does not depend on the log level.

`make ci` passes: tidy, build, vet, lint, test with `-race`, API snapshot check.

## Known limitation

`Application.log()` reads the package-level `logger.DefaultLogger`, which
configuration reload writes. That variable is exported and read directly in
many places downstream, so it cannot be made atomic without breaking those
builds; this change adds a read of it on the startup path where there was none
before. A reproducer is kept out of the default test run. Fixing it means
deciding how `DefaultLogger` gets encapsulated, which belongs in its own change.
