### PR TITLE
Describe the rules rather than who follows them

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,9 +1,9 @@
 # The Runtime contract
 
 This document is for anyone who registers something into `sdk.Runtime`: an
-application module in go-admin, a fork, or a downstream framework such as
-go-admin-pro. It states what the runtime registries promise, when they stop
-accepting registrations, and what the panic guard does and does not cover.
+application module, a fork, or a framework built on top of this one. It states
+what the runtime registries promise, when they stop accepting registrations,
+and what the panic guard does and does not cover.
 
 `sdk.Runtime` is a package-level singleton (`sdk/application.go`) of type
 `runtime.Runtime`, implemented by `*runtime.Application`.
@@ -41,9 +41,9 @@ not the same as not protected.
 
 `init()` is the easiest place to satisfy that - the Go specification runs all
 package initialisation on one goroutine before `main`, so there is no
-concurrency to think about - but it is not the only legal one. go-admin-pro
-registers from `run()`, and that is fine: `run()` happens before anything calls
-`RunAppRouters()`.
+concurrency to think about - but it is not the only legal one. Registering from
+a `run()` that executes before `RunAppRouters()` is equally fine. The rule is
+about ordering, not about which function you use.
 
 The older wording, "registration is only allowed in `init()`", is not used here
 because nothing can check it and real code already violates it.
@@ -120,9 +120,9 @@ variants: same registration path, same guard, same defaults.
 > anything it calls directly. A panic on a goroutine the callback starts is
 > outside it, and always will be.
 
-`recover()` only works on the goroutine that is panicking. This shape - which
-is how go-admin-pro registers its jobs - gets no protection from the framework
-at all:
+`recover()` only works on the goroutine that is panicking. This shape - common
+when a callback kicks off background work - gets no protection from the
+framework at all:
 
 ```go
 sdk.Runtime.SetBefore(func() {
@@ -273,5 +273,5 @@ downstream.
 
 Adding a method is still a source-breaking change for anyone who wrote their
 own implementation of `runtime.Runtime` - a mock, typically. There are none in
-go-admin, go-admin-pro or core itself, where the only implementation is
-`*Application`; if you have one, add the new methods listed in section 2 and 4.
+this repository, where `*Application` is the only implementation; if you have
+one, add the new methods listed in section 2 and 4.

--- a/sdk/runtime/application_guard_fatal_test.go
+++ b/sdk/runtime/application_guard_fatal_test.go
@@ -135,7 +135,7 @@ func TestFatalExitDoesNotDependOnTheLogLevel(t *testing.T) {
 // The other half of acceptance 8: proof that the guard's boundary is real. A
 // panic on a goroutine the callback started kills the process, and the guard
 // never gets a word in. This is why the contract says the protection covers
-// synchronous panics only - a module that copies pro's `go func()` shape is
+// synchronous panics only - a module that starts its own goroutine is
 // responsible for its own recover.
 func TestGoroutinePanicEscapesTheGuard(t *testing.T) {
 	out, code := runGuardChild(t, "goroutine")

--- a/sdk/runtime/application_guard_test.go
+++ b/sdk/runtime/application_guard_test.go
@@ -128,9 +128,9 @@ func TestCallbackThatRecoversForItselfIsNotReportedAgain(t *testing.T) {
 
 // Acceptance 8b: the boundary of the promise. recover only works on the
 // goroutine that is panicking, so a callback whose real work is `go func()`
-// - which is how go-admin-pro registers its jobs - is outside the guard
-// entirely. Here the goroutine recovers for itself, as pro's does. Without
-// that recover the process dies, and no amount of framework code changes it;
+// - a common shape for background startup work - is outside the guard
+// entirely. Here the goroutine recovers for itself. Without that recover the
+// process dies, and no amount of framework code changes it;
 // TestGoroutinePanicEscapesTheGuard runs that case in a subprocess.
 func TestGuardDoesNotReachIntoASpawnedGoroutine(t *testing.T) {
 	app := NewConfig()

--- a/sdk/runtime/application_registry_test.go
+++ b/sdk/runtime/application_registry_test.go
@@ -109,8 +109,8 @@ func TestRunAppRoutersRunsInRegistrationOrder(t *testing.T) {
 }
 
 // Acceptance 3: the pre-existing way of using the registry - ask for the
-// callbacks and run them yourself - keeps working unchanged. go-admin-pro does
-// exactly this, and it is not being changed in this batch.
+// callbacks and run them yourself - keeps working unchanged. Consumers on that
+// pattern are not required to move to Run*().
 func TestSelfWrittenLoopStillWorks(t *testing.T) {
 	app := NewConfig()
 	var ran []string


### PR DESCRIPTION
Several comments in the runtime contract and its tests explained a rule by naming a downstream product and describing how it is built. The rule is what carries the meaning, and stating it directly reads the same way for every consumer.

- registering before `Run*()` is about ordering, not about which function you use
- a callback that starts a goroutine owns its own `recover()`, whoever wrote it
- the interface-implementer note now states only what this repository can verify

No behaviour change; the wording is the whole diff.