### PR TITLE
feat✨: 生命周期阶段与优雅关闭

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -816,6 +816,9 @@ func (e *Api) OK(data interface{}, msg string)
 func (e *Api) PageOK(result interface{}, count int, pageIndex int, pageSize int, msg string)
 func (e Api) Translate(form, to interface{})
 
+## github.com/go-admin-team/go-admin-core/v2/sdk/bootstrap
+func SetupConfig(s source.Source, fs ...func())
+
 ## github.com/go-admin-team/go-admin-core/v2/sdk/config
 var (
 	DatabaseConfig  = new(Database)

--- a/api/core.txt
+++ b/api/core.txt
@@ -1370,6 +1370,7 @@ func (e *Application) PhaseSealed(p Phase) bool
 func (e *Application) RunAppRouters()
 func (e *Application) RunBefore()
 func (e *Application) RunPhase(p Phase)
+func (e *Application) RunShutdown(ctx context.Context) error
 func (e *Application) SetApp(app interface{})
 func (e *Application) SetAppByTenant(key string, app interface{})
 func (e *Application) SetAppRouters(appRouters func())
@@ -1396,6 +1397,7 @@ func (e *Application) SetLogger(l logger.Logger)
 func (e *Application) SetMiddleware(key string, middleware interface{})
 func (e *Application) SetPhase(p Phase, f func(), opts ...CallbackOption)
 func (e *Application) SetQueueAdapter(c storage.AdapterQueue)
+func (e *Application) SetShutdown(f func(context.Context), opts ...CallbackOption)
 type Cache struct {
 func (e Cache) Connect() error
 func (e Cache) Decrease(key string) error
@@ -1499,6 +1501,8 @@ type Runtime interface {
 	SetPhase(p Phase, f func(), opts ...CallbackOption)
 	RunPhase(p Phase)
 	PhaseSealed(p Phase) bool
+	SetShutdown(f func(context.Context), opts ...CallbackOption)
+	RunShutdown(ctx context.Context) error
 
 ## github.com/go-admin-team/go-admin-core/v2/sdk/service
 type Service struct {

--- a/api/core.txt
+++ b/api/core.txt
@@ -1411,6 +1411,13 @@ type CallbackOption func(*callbackConfig)
 func WithFatal() CallbackOption
 func WithName(name string) CallbackOption
 type Config map[string]interface{}
+type Phase int
+const (
+	AfterResource Phase = 10
+	BeforeRouter Phase = 20
+	AfterListen Phase = 30
+	BeforeExit Phase = 40
+func (p Phase) String() string
 type Queue struct {
 func (e *Queue) Append(message storage.Messager) error
 func (e *Queue) Register(name string, f storage.ConsumerFunc)

--- a/api/core.txt
+++ b/api/core.txt
@@ -1366,8 +1366,10 @@ func (e *Application) GetQueueAdapter() storage.AdapterQueue
 func (e *Application) GetQueuePrefix(key string) storage.AdapterQueue
 func (e *Application) GetRouter() []Router
 func (e *Application) GetStreamMessage(id, stream string, value map[string]interface{}) (storage.Messager, error)
+func (e *Application) PhaseSealed(p Phase) bool
 func (e *Application) RunAppRouters()
 func (e *Application) RunBefore()
+func (e *Application) RunPhase(p Phase)
 func (e *Application) SetApp(app interface{})
 func (e *Application) SetAppByTenant(key string, app interface{})
 func (e *Application) SetAppRouters(appRouters func())
@@ -1392,6 +1394,7 @@ func (e *Application) SetHandler(routerGroup func(r *gin.RouterGroup, hand ...*g
 func (e *Application) SetHandlerByTenant(tenant string, routerGroup func(r *gin.RouterGroup, hand ...*gin.HandlerFunc))
 func (e *Application) SetLogger(l logger.Logger)
 func (e *Application) SetMiddleware(key string, middleware interface{})
+func (e *Application) SetPhase(p Phase, f func(), opts ...CallbackOption)
 func (e *Application) SetQueueAdapter(c storage.AdapterQueue)
 type Cache struct {
 func (e Cache) Connect() error
@@ -1493,6 +1496,9 @@ type Runtime interface {
 	GetAppRouters() []func()
 	RunAppRouters()
 	AppRoutersSealed() bool
+	SetPhase(p Phase, f func(), opts ...CallbackOption)
+	RunPhase(p Phase)
+	PhaseSealed(p Phase) bool
 
 ## github.com/go-admin-team/go-admin-core/v2/sdk/service
 type Service struct {

--- a/api/core.txt
+++ b/api/core.txt
@@ -1330,6 +1330,7 @@ type Application struct {
 func NewConfig() *Application
 func (e *Application) AppRoutersSealed() bool
 func (e *Application) BeforeSealed() bool
+func (e *Application) BeginShutdown()
 func (e *Application) GetAllCasbin() map[string]*casbin.SyncedEnforcer
 func (e *Application) GetAllCrontab() map[string]*cron.Cron
 func (e *Application) GetAllDb() map[string]*gorm.DB
@@ -1501,6 +1502,7 @@ type Runtime interface {
 	SetPhase(p Phase, f func(), opts ...CallbackOption)
 	RunPhase(p Phase)
 	PhaseSealed(p Phase) bool
+	BeginShutdown()
 	SetShutdown(f func(context.Context), opts ...CallbackOption)
 	RunShutdown(ctx context.Context) error
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -500,9 +500,15 @@ So a callback here has to be **idempotent with respect to the same
 resource** - not "does nothing the second time". The queue example is the
 reason for that wording: `Register` unconditionally starts a consumer
 goroutine, and after a reload it *must*, because the adapter is new. What it
-must not do is start a second consumer on an adapter it already handled. The
-implementable rule is to remember the instance you last saw and return early
-when it has not changed.
+must not do is start a second consumer on an adapter it already handled.
+
+The rule is therefore to remember the resource you last acted on and return
+early when it has not changed - but **the getter is not where you get that
+identity from**. `GetQueueAdapter` and `GetQueuePrefix` build a fresh `*Queue`
+wrapper on every call, so comparing what they return compares two wrappers and
+never matches; the same is true of any accessor that decorates what it hands
+back. Record the resource where it is *created* - the setup callback that
+built it knows which instance it installed - and compare against that.
 
 Two consequences worth stating plainly:
 

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -462,3 +462,107 @@ separation, immune to that collision, should migrate to calling
 `RegisterExtend` itself under a reserved key (for example `"__host__"`) for
 its own section, and update its configuration files to nest its existing
 `extend:` fields one level deeper under that key.
+
+---
+
+## 12. Life-cycle phases
+
+A phase names a moment in the process's life that an application can hang
+work on. There are four, and each is a permanent promise about what has
+happened by the time it runs:
+
+| Phase | Runs when | Available |
+|---|---|---|
+| `AfterResource` | the database, cache, queue and casbin are built | configuration, every resource |
+| `BeforeRouter` | before the host installs its routes | the above, plus the engine |
+| `AfterListen` | the socket is accepting connections | everything |
+| `BeforeExit` | on the way out, after the server stopped serving | everything, while it is being taken down |
+
+```go
+sdk.Runtime.SetPhase(runtime.AfterResource, func() { /* ... */ })
+sdk.Runtime.SetShutdown(func(ctx context.Context) { /* ... */ })
+```
+
+The numeric values are **not** part of the contract. They are spaced so a
+phase can be added between two existing ones without moving what is already
+there; do not persist them, transmit them, or compare them with `<`.
+
+### `AfterResource` runs again, and its callbacks must tolerate that
+
+Every other phase runs once and then refuses further registration.
+`AfterResource` is different: it runs again after **every** configuration
+reload, because a reload rebuilds the resources it is named for. A queue
+consumer registered against the adapter that existed at startup is attached
+to an adapter nobody publishes to any more; re-running is what re-attaches
+it.
+
+So a callback here has to be **idempotent with respect to the same
+resource** - not "does nothing the second time". The queue example is the
+reason for that wording: `Register` unconditionally starts a consumer
+goroutine, and after a reload it *must*, because the adapter is new. What it
+must not do is start a second consumer on an adapter it already handled. The
+implementable rule is to remember the instance you last saw and return early
+when it has not changed.
+
+Two consequences worth stating plainly:
+
+- **`RunPhase(AfterResource)` is not synchronous.** Rounds are serialised: a
+  call arriving while a round is running marks the phase as owing another
+  round and returns immediately, without waiting. Only the once-only phases
+  give the caller "your callbacks have finished" on return. A trigger is
+  never dropped, because the reload that produced it may have swapped in a
+  resource after the running round took its snapshot.
+- **Do not call `RunPhase(AfterResource)` from inside an `AfterResource`
+  callback.** It marks another round owing, from within the round, forever.
+  There is no guard against it, deliberately: a guard would have to tell
+  self-recursion apart from a genuine reload on another goroutine, and
+  dropping the latter is exactly the bug this mechanism exists to prevent.
+
+The registry is never closed, so it only ever grows. A callback count that
+increases between rounds is reported as a warning - that is the one automatic
+signal that something is registering on every reload instead of being
+idempotent.
+
+### `BeforeExit` runs in reverse, and is the one phase shutdown does not close
+
+Cleanup runs **last-registered-first**. That is the right default for a chain
+of hooks that built on one another; it says nothing about resources the host
+created for itself, which this chain did not build and does not unwind.
+
+`SetShutdown` is the context-taking half of the same phase - both register
+into it, and one pass runs both. The context carries the host's shutdown
+budget so a callback that can cut its work short has something to consult.
+
+**What the context bounds is the wait, not the work.** When the budget is
+gone `RunShutdown` stops waiting and returns `ctx.Err()`; the callback that
+was running carries on until the process exits, possibly leaving a partial
+write behind. Go cannot cancel a function that does not check for
+cancellation, which is why callbacks are handed a context at all.
+
+`WithFatal` is not honoured here. Exiting from inside cleanup skips every
+callback after it, which is the opposite of what the option is for. The
+callback is kept and the option is reported - refusing the registration
+outright would mean one mistyped option silently costs you the cleanup.
+
+### Once shutdown starts, the other phases stop
+
+`BeginShutdown` marks the process as stopping. From then on `SetPhase` and
+`RunPhase` do nothing for every phase except `BeforeExit`, and say so at
+warning level. Without it, a configuration reload arriving in the shutdown
+window re-runs `AfterResource` - rebuilding the pool and the adapter, and
+re-registering consumers - undoing cleanup that has already run.
+
+`BeforeExit` is exempt because it is the shutdown. Gating it would make the
+flag skip the very work it was added to protect.
+
+### What these phases cannot do
+
+- **They cannot drain the queue.** `Memory.Shutdown` does not deliver what is
+  still buffered, so a `BeforeExit` callback has nothing to call that would
+  flush the log queue. See `known-issues.md`. A deployment that cannot lose
+  audit rows must not rely on this phase for that.
+- **They cannot take the process out of a load balancer.** The only hook here
+  runs *after* the HTTP server stopped accepting, and Kubernetes expects
+  readiness to start failing *before* that so endpoints are withdrawn first.
+  There is no pre-shutdown hook yet; without one, a rolling update can still
+  produce connection refused.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -483,9 +483,17 @@ sdk.Runtime.SetPhase(runtime.AfterResource, func() { /* ... */ })
 sdk.Runtime.SetShutdown(func(ctx context.Context) { /* ... */ })
 ```
 
-The numeric values are **not** part of the contract. They are spaced so a
-phase can be added between two existing ones without moving what is already
-there; do not persist them, transmit them, or compare them with `<`.
+The numeric values are **not** part of the contract: do not persist them,
+transmit them, or write them into configuration - name the constant instead.
+Their *order* is, and stays that way by construction. The values are spaced,
+so a phase added later takes a number in a gap rather than renumbering the
+ones already compiled into somebody else's binary, and `p1 < p2` keeps
+meaning "`p1` is reached first".
+
+It orders the first pass and nothing else. `AfterResource` runs again on
+every configuration reload, so for the rest of the process's life it happens
+*after* `AfterListen` while still holding the smaller number - `<` cannot
+tell you whether a phase is behind you. `PhaseSealed` can.
 
 ### `AfterResource` runs again, and its callbacks must tolerate that
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -16,3 +16,62 @@ instance matching the hard-coded DSN is reachable.
 
 **Plan:** move the DSN behind an environment variable so the test can run
 against a CI service container instead of being skipped.
+
+## 2. A hot reload leaks the previous queue's consumers
+
+`storage/queue/memory.go`'s `Shutdown` sets a flag and releases its wait
+group. It does not close the per-stream channels, and every consumer started
+by `Register` is blocked in `for message := range q` on one of them, so none
+of them ever returns. A host that rebuilds its queue adapter on every
+configuration reload leaks one goroutine per consumer each time - measured at
+three per reload for go-admin, roughly 25KB with the buffers.
+
+It leaks; it does not lose messages. Producers fetch the current adapter per
+call, so nothing is published to the abandoned channels after the swap.
+
+The fix is not `close(q)`: `Append` publishes with
+`select { case q <- m: default: }` and the consumer loop re-publishes a failed
+message after sleeping, so closing underneath either one panics the process
+during shutdown - worse than the leak. It needs a per-consumer stop channel,
+and the re-publish path has to stop first. **Order: stop publishing, drain,
+then close.**
+
+## 3. Nothing can drain a queue on the way out
+
+Neither `Memory.Shutdown` nor `MemQueue.Close` delivers what is still
+buffered. `MemQueue.Close` sets `closed` before it signals its drain loop, and
+the loop's `deliver` returns immediately when `closed` is set - so the drain
+takes the messages out of the channel and discards them, which is not what the
+comment above it describes.
+
+Measured: with a consumer blocked and twenty messages published,
+`Memory.Shutdown` delivers none of them and `MemQueue.Close` delivers one.
+End to end, 227 requests produced zero `sys_opera_log` rows across a shutdown
+that exited 0 and logged "Server exiting" - the successful path.
+
+This is why section 12 of `contract.md` says a `BeforeExit` callback cannot
+flush the queue: today there is nothing for it to call.
+
+## 4. A reload can rebuild resources while the process is shutting down
+
+The configuration watcher keeps running through shutdown, so an edit landing
+in that window re-runs `database.Setup` and `storage.Setup` - rebuilding the
+pool and the queue adapter as the process is being taken apart.
+`BeginShutdown` closes the half that goes through the phase registry; closing
+the watcher itself is the host's job, and `config.Close` returns without
+waiting for a reload already in flight.
+
+## 5. `logger.DefaultLogger` is written on every reload with no synchronisation
+
+`Logger.Setup` assigns the package-level `logger.DefaultLogger` from the
+watcher goroutine on each reload, while every log call in the process reads it
+without a lock. An interface value is two words; a torn read is a crash, not a
+stale line. It is a bare exported variable, so the fix is not local.
+
+## 6. Only the first tenant gets a cron scheduler
+
+`app/jobs`'s `Setup` loops over the tenant databases calling `setup`, and
+`setup` ends in `select {}` and never returns. With more than one entry under
+`databases:`, the loop never reaches the second one. The same `select {}` also
+makes the `defer crontab.Stop()` above it unreachable, so the scheduler has
+never been stopped on the way out either.

--- a/sdk/bootstrap/bootstrap.go
+++ b/sdk/bootstrap/bootstrap.go
@@ -1,0 +1,49 @@
+// Package bootstrap wires the configuration to the life-cycle phases.
+//
+// It is a package of its own because of the direction of the imports, not
+// because the code wants one. The trigger needs both sdk.Runtime and
+// sdk/config, and neither of those can hold it: sdk cannot import sdk/config,
+// because sdk/config's own test imports sdk and Go refuses the cycle that
+// closes; sdk/config cannot import sdk, because sdk pulls in the whole of
+// sdk/runtime - gin, casbin, gorm, cron - and sdk/config is what
+// sdk/contract/actions depends on, which is the surface an application is
+// meant to be able to use on its own. A leaf package that both of them can be
+// imported by costs nothing to anybody who does not call it.
+package bootstrap
+
+import (
+	"github.com/go-admin-team/go-admin-core/v2/config/source"
+	"github.com/go-admin-team/go-admin-core/v2/sdk"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
+)
+
+// SetupConfig loads the configuration, runs fs, and then announces that the
+// resources they built are ready.
+//
+// It is config.Setup plus the AfterResource phase, and it exists so that the
+// order is core's to keep rather than something every call site has to
+// remember. The announcement goes last, after every callback in fs has run:
+// the phase means "the database, the cache and the queue are ready", and a
+// hook that gets it before the callbacks that build them is worse than no
+// hook at all. Because fs is what config re-runs on a reload, the
+// announcement repeats there too, which is what AfterResource is for.
+//
+// config.Setup itself deliberately does not announce anything. Only the
+// command that serves traffic should: a migration or a config-dump command
+// that started queue consumers and warmed caches on its way to doing
+// something else would be doing the wrong thing quietly.
+func SetupConfig(s source.Source, fs ...func()) {
+	// Built rather than appended to: fs may share its backing array with a
+	// slice the caller still holds, and append would write the trigger into
+	// their spare capacity.
+	callbacks := make([]func(), 0, len(fs)+1)
+	callbacks = append(callbacks, fs...)
+	callbacks = append(callbacks, func() {
+		// Read at call time, not captured: a process that replaces
+		// sdk.Runtime - which the tests do - should have the replacement
+		// announced to, not the one that was there at wiring time.
+		sdk.Runtime.RunPhase(runtime.AfterResource)
+	})
+	config.Setup(s, callbacks...)
+}

--- a/sdk/bootstrap/bootstrap_test.go
+++ b/sdk/bootstrap/bootstrap_test.go
@@ -1,0 +1,156 @@
+package bootstrap
+
+import (
+	"testing"
+
+	coreconfig "github.com/go-admin-team/go-admin-core/v2/config"
+	"github.com/go-admin-team/go-admin-core/v2/config/source"
+	"github.com/go-admin-team/go-admin-core/v2/config/source/memory"
+	"github.com/go-admin-team/go-admin-core/v2/sdk"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/config"
+	"github.com/go-admin-team/go-admin-core/v2/sdk/runtime"
+)
+
+// The smallest settings tree Setup will accept: it runs the logger setup and
+// the multi-database fill on the way in, and both read from this.
+const settings = `settings:
+  application:
+    host: 0.0.0.0
+    port: 8000
+    name: bootstrap-test
+    mode: dev
+  logger:
+    path: ""
+    stdout: ""
+    level: error
+  jwt:
+    secret: test
+    timeout: 3600
+  database:
+    driver: sqlite3
+    source: ":memory:"
+`
+
+// isolate gives one test its own runtime and puts back the process-wide
+// config object afterwards. Setup replaces both, so none of these tests may
+// run in parallel.
+//
+// The config object is not Closed, deliberately. Close makes the watcher
+// goroutine log "watcher stopped" through logger.DefaultLogger on its way
+// out, and the next Setup in this binary overwrites that same package
+// variable from the test goroutine - an unsynchronised global that -race
+// reports, and that this test would be creating rather than finding. Left
+// alone, the watcher stays parked in Next() on a memory source nobody
+// updates: one goroutine per test, which ends with the binary and cannot
+// interfere with anything.
+//
+// The underlying defect is real but not this commit's: Logger.Setup writes
+// logger.DefaultLogger on every configuration reload, from the watcher
+// goroutine, while everything else in the process reads it.
+func isolate(t *testing.T) {
+	t.Helper()
+
+	previousRuntime := sdk.Runtime
+	previousConfig := coreconfig.DefaultConfig
+	t.Cleanup(func() {
+		coreconfig.DefaultConfig = previousConfig
+		sdk.Runtime = previousRuntime
+	})
+	sdk.Runtime = runtime.NewConfig()
+}
+
+func newSource() source.Source {
+	return memory.NewSource(memory.WithYAML([]byte(settings)))
+}
+
+// The announcement goes last. AfterResource means "the database, the cache
+// and the queue are ready", so a hook that runs before the callbacks that
+// build them would be handed the previous set - or nothing at all on first
+// start. This is the ordering the function exists to own.
+func TestTheResourcePhaseIsAnnouncedAfterEveryCallback(t *testing.T) {
+	isolate(t)
+
+	var order []string
+	sdk.Runtime.SetPhase(runtime.AfterResource, func() { order = append(order, "phase") })
+
+	SetupConfig(newSource(),
+		func() { order = append(order, "first") },
+		func() { order = append(order, "second") },
+	)
+
+	want := []string{"first", "second", "phase"}
+	if len(order) != len(want) {
+		t.Fatalf("ran %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("ran %v, want %v", order, want)
+		}
+	}
+}
+
+// With no callbacks at all the phase is still announced: an application whose
+// resources are all built by AfterResource hooks is a legitimate arrangement,
+// and it would get nothing if the announcement only came with company.
+func TestTheResourcePhaseIsAnnouncedWithNoCallbacks(t *testing.T) {
+	isolate(t)
+
+	ran := false
+	sdk.Runtime.SetPhase(runtime.AfterResource, func() { ran = true })
+
+	SetupConfig(newSource())
+
+	if !ran {
+		t.Error("SetupConfig with no callbacks announced nothing")
+	}
+}
+
+// config.Setup stays inert, and that is the point of having two functions.
+// Three of the four call sites in a go-admin tree are CLI commands - migrate,
+// config - and starting queue consumers or warming a cache on the way to
+// dumping a config file is the wrong thing to do quietly.
+func TestConfigSetupOnItsOwnAnnouncesNothing(t *testing.T) {
+	isolate(t)
+
+	ran := false
+	sdk.Runtime.SetPhase(runtime.AfterResource, func() { ran = true })
+
+	config.Setup(newSource(), func() {})
+
+	if ran {
+		t.Error("config.Setup announced the resource phase; only SetupConfig may")
+	}
+}
+
+// The announcement follows sdk.Runtime as it is when the callbacks run, not
+// as it was when SetupConfig was called. Anything else would leave a process
+// that swaps the runtime announcing into the one it replaced.
+func TestTheAnnouncementFollowsTheCurrentRuntime(t *testing.T) {
+	isolate(t)
+
+	replaced := runtime.NewConfig()
+	ran := false
+	replaced.SetPhase(runtime.AfterResource, func() { ran = true })
+
+	SetupConfig(newSource(), func() { sdk.Runtime = replaced })
+
+	if !ran {
+		t.Error("the announcement went to the runtime that was current at wiring time, not at run time")
+	}
+}
+
+// fs may share its backing array with a slice the caller still holds, and
+// appending to it in place would write the trigger into their spare capacity
+// - visible to them as a callback they never registered.
+func TestTheCallersSliceIsNotWrittenTo(t *testing.T) {
+	isolate(t)
+
+	callers := make([]func(), 1, 4) // room to spare, which is what makes it possible
+	callers[0] = func() {}
+
+	SetupConfig(newSource(), callers...)
+
+	if got := callers[:cap(callers)]; got[1] != nil || got[2] != nil || got[3] != nil {
+		t.Error("SetupConfig wrote into the caller's spare capacity")
+	}
+}

--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -38,6 +38,7 @@ type Application struct {
 	appRouters    registry                                                        // app router registry
 	casbinExclude map[string]interface{}                                          // casbin排除
 	before        registry                                                        // startup callback registry
+	phases        [phaseCount]registry                                            // life-cycle phase registries, indexed by Phase.index
 	defaultTenant string                                                          // 默认租户标识符
 	app           map[string]interface{}                                          // app
 }

--- a/sdk/runtime/application.go
+++ b/sdk/runtime/application.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"slices"
 	"sync"
+	"sync/atomic"
 
 	"github.com/casbin/casbin/v3"
 	"github.com/go-admin-team/go-admin-core/v2/logger"
@@ -39,6 +40,7 @@ type Application struct {
 	casbinExclude map[string]interface{}                                          // casbin排除
 	before        registry                                                        // startup callback registry
 	phases        [phaseCount]registry                                            // life-cycle phase registries, indexed by Phase.index
+	shuttingDown  atomic.Bool                                                     // set by BeginShutdown; see the gate in SetPhase
 	defaultTenant string                                                          // 默认租户标识符
 	app           map[string]interface{}                                          // app
 }

--- a/sdk/runtime/application_guard_fatal_test.go
+++ b/sdk/runtime/application_guard_fatal_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -61,6 +62,19 @@ func TestGuardChild(t *testing.T) {
 		app.SetBeforeWith(func() { panic("boom") }, WithFatal())
 		app.RunBefore()
 		fmt.Println("MUST-NOT-REACH")
+
+	case "shutdown-fatal":
+		// The counterpart of "fatal", one phase later: the same option, on a
+		// cleanup callback, must not exit. Exiting here would skip the
+		// cleanup behind it, which is what the option was meant to protect.
+		app.SetLogger(stdoutLogger{level: logger.TraceLevel})
+		app.SetShutdown(func(context.Context) { fmt.Println("CLEANUP-AFTER-THE-PANIC") })
+		app.SetShutdown(func(context.Context) { panic("the pool is already closed") },
+			WithFatal(), WithName("pool-close"))
+		if err := app.RunShutdown(context.Background()); err != nil {
+			fmt.Println("UNEXPECTED-ERROR", err)
+		}
+		fmt.Println("REACHED-THE-END")
 
 	case "goroutine":
 		// The boundary of the guard, played out for real: the callback returns

--- a/sdk/runtime/phase.go
+++ b/sdk/runtime/phase.go
@@ -1,0 +1,66 @@
+package runtime
+
+import "strconv"
+
+// Phase names a point in the life of the application that a module can attach
+// work to.
+//
+// The values are assigned explicitly rather than with iota, and with gaps: a
+// phase inserted later takes a number in a gap instead of moving the numbers
+// already compiled into somebody else's binary, and comparing two phases with
+// < keeps meaning "happens earlier". The numbers are an implementation
+// detail. They are not part of the contract, and must not be persisted, sent
+// over the wire, or written into configuration - name the constant instead.
+type Phase int
+
+const (
+	// AfterResource is reached once the database, cache, queue and casbin
+	// enforcer have been built from the configuration that is current at that
+	// moment.
+	//
+	// It is the one phase that runs more than once: a configuration reload
+	// rebuilds those resources, and the point of the phase is to give the
+	// code that depends on them a chance to attach itself to the new ones. A
+	// hook registered here must therefore be written to run repeatedly - see
+	// RunPhase for what "repeatedly" is allowed to mean.
+	AfterResource Phase = 10
+
+	// BeforeRouter is reached before the router is initialised, which is the
+	// last point at which a module can still affect how routes are built.
+	//
+	// It is not the same point as the SetBefore registry: those callbacks run
+	// after the router has been initialised, not before it.
+	BeforeRouter Phase = 20
+
+	// AfterListen is reached once the listening socket is accepting
+	// connections - not merely once the goroutine that serves it was started.
+	// A hook here can rely on the port being bound, because a failure to bind
+	// has already been reported by then.
+	AfterListen Phase = 30
+
+	// BeforeExit is reached after the HTTP server has been shut down and
+	// before the process returns, for work that must happen on the way out
+	// but does not need the server.
+	//
+	// It is not a place to drain a load balancer: by the time it runs the
+	// listener is already closed, so anything that depends on still being
+	// reachable belongs somewhere this package does not currently offer.
+	BeforeExit Phase = 40
+)
+
+// String names the phase, so that a log line reads AfterResource rather than
+// 10. An unknown value prints as Phase(42) rather than as a wrong name, which
+// is what the out-of-range reports in SetPhase and RunPhase carry.
+func (p Phase) String() string {
+	switch p {
+	case AfterResource:
+		return "AfterResource"
+	case BeforeRouter:
+		return "BeforeRouter"
+	case AfterListen:
+		return "AfterListen"
+	case BeforeExit:
+		return "BeforeExit"
+	}
+	return "Phase(" + strconv.Itoa(int(p)) + ")"
+}

--- a/sdk/runtime/phase.go
+++ b/sdk/runtime/phase.go
@@ -10,10 +10,17 @@ import (
 //
 // The values are assigned explicitly rather than with iota, and with gaps: a
 // phase inserted later takes a number in a gap instead of moving the numbers
-// already compiled into somebody else's binary, and comparing two phases with
-// < keeps meaning "happens earlier". The numbers are an implementation
-// detail. They are not part of the contract, and must not be persisted, sent
-// over the wire, or written into configuration - name the constant instead.
+// already compiled into somebody else's binary, so p1 < p2 keeps meaning "p1
+// is reached first".
+//
+// That orders the first pass and nothing else. AfterResource runs again on
+// every configuration reload, so for the rest of the process's life it
+// happens after AfterListen while still holding the smaller number: < cannot
+// answer "has that phase already run". PhaseSealed can.
+//
+// The numbers themselves are an implementation detail. They are not part of
+// the contract, and must not be persisted, sent over the wire, or written
+// into configuration - name the constant instead.
 type Phase int
 
 const (

--- a/sdk/runtime/phase.go
+++ b/sdk/runtime/phase.go
@@ -125,6 +125,15 @@ func (e *Application) SetPhase(p Phase, f func(), opts ...CallbackOption) {
 			"use AfterResource, BeforeRouter, AfterListen or BeforeExit (registered at %s)", p, site)
 		return
 	}
+	if e.shutDownFor(p) {
+		// Not an error: a module registering while the process happens to be
+		// going down has done nothing wrong, and there is nothing left to do
+		// with the callback either. Reporting it as a fault would teach the
+		// reader to skip the line that matters.
+		e.log().Warnf("runtime: SetPhase(%v) ignored - the application is shutting down and that phase "+
+			"will not run again (registered at %s)", p, site)
+		return
+	}
 	cb := newCallback(f, site, opts)
 	if p.reentrant() && cb.fatal {
 		// Kept, not stripped: "the database is unreachable, do not start"
@@ -172,6 +181,14 @@ func (e *Application) RunPhase(p Phase) {
 			"use AfterResource, BeforeRouter, AfterListen or BeforeExit", p)
 		return
 	}
+	if e.shutDownFor(p) {
+		// The reload that triggered this started before the shutdown did,
+		// and finishing it would rebuild resources the cleanup is taking
+		// apart. Losing it is the point.
+		e.log().Warnf("runtime: RunPhase(%v) did nothing - the application is shutting down; "+
+			"a configuration reload that arrives now must not rebuild what is being torn down", p)
+		return
+	}
 	if p.reentrant() {
 		e.runReentrant(&e.phases[i], p.String())
 		return
@@ -188,6 +205,15 @@ func (e *Application) RunPhase(p Phase) {
 	// unreachable here. That omission is deliberate: GetBefore and
 	// GetAppRouters showed what handing them out costs.
 	e.runRegistry(&e.phases[i], p.String(), "", "RunPhase("+p.String()+")")
+}
+
+// shutDownFor reports whether p is closed by a shutdown in progress.
+//
+// BeforeExit is exempt: it is the phase the shutdown exists to run, and
+// RunPhase(BeforeExit) is a legitimate call after BeginShutdown - gating it
+// would make the flag skip the cleanup it was added to protect.
+func (e *Application) shutDownFor(p Phase) bool {
+	return p != BeforeExit && e.shuttingDown.Load()
 }
 
 // PhaseSealed reports whether p has already run, i.e. whether a further

--- a/sdk/runtime/phase.go
+++ b/sdk/runtime/phase.go
@@ -1,6 +1,9 @@
 package runtime
 
-import "strconv"
+import (
+	"context"
+	"strconv"
+)
 
 // Phase names a point in the life of the application that a module can attach
 // work to.
@@ -133,7 +136,11 @@ func (e *Application) SetPhase(p Phase, f func(), opts ...CallbackOption) {
 			"but this phase runs again after a configuration reload, where exiting kills a process "+
 			"that is already serving requests", p, cb.label())
 	}
-	e.register(&e.phases[i], cb, "SetPhase("+p.String()+")", "RunPhase("+p.String()+")")
+	runner := "RunPhase(" + p.String() + ")"
+	if p == BeforeExit {
+		runner = "RunShutdown or " + runner
+	}
+	e.register(&e.phases[i], cb, "SetPhase("+p.String()+")", runner)
 }
 
 // RunPhase executes the callbacks registered for p, in registration order.
@@ -145,6 +152,11 @@ func (e *Application) SetPhase(p Phase, f func(), opts ...CallbackOption) {
 // For every phase but AfterResource this happens once: the phase is closed to
 // further registration afterwards, and calling RunPhase again is a no-op, so
 // cleanup registered in BeforeExit cannot run twice.
+//
+// BeforeExit is the other exception, in the other direction: it runs in
+// reverse registration order, because it is the phase that unwinds. See
+// SetShutdown, which registers into the same phase and is how a callback that
+// wants the remaining budget asks for it.
 //
 // AfterResource is the exception, because the resources it announces are
 // rebuilt on every configuration reload. It never closes, every registered
@@ -162,6 +174,13 @@ func (e *Application) RunPhase(p Phase) {
 	}
 	if p.reentrant() {
 		e.runReentrant(&e.phases[i], p.String())
+		return
+	}
+	if p == BeforeExit {
+		// Same registry and same reverse order as RunShutdown, which is
+		// what a caller with no budget to give is asking for. A context
+		// that never ends makes the two the same call.
+		_ = e.RunShutdown(context.Background())
 		return
 	}
 	// The getter argument is empty because no method hands phase callbacks

--- a/sdk/runtime/phase.go
+++ b/sdk/runtime/phase.go
@@ -95,6 +95,14 @@ func (p Phase) index() (int, bool) {
 	return 0, false
 }
 
+// reentrant reports whether the phase can happen more than once.
+//
+// It is derived from the phase rather than stored on the registry because the
+// registries are an array on a struct that has to work as its zero value: a
+// flag would have to be set from somewhere, and there is no constructor every
+// path goes through. See phaseCount.
+func (p Phase) reentrant() bool { return p == AfterResource }
+
 // SetPhase registers a callback to run when the application reaches p.
 //
 // The callback runs when RunPhase(p) is called, in registration order, behind
@@ -114,23 +122,46 @@ func (e *Application) SetPhase(p Phase, f func(), opts ...CallbackOption) {
 			"use AfterResource, BeforeRouter, AfterListen or BeforeExit (registered at %s)", p, site)
 		return
 	}
-	e.register(&e.phases[i], newCallback(f, site, opts),
-		"SetPhase("+p.String()+")", "RunPhase("+p.String()+")")
+	cb := newCallback(f, site, opts)
+	if p.reentrant() && cb.fatal {
+		// Kept, not stripped: "the database is unreachable, do not start"
+		// is a fair thing to say, and quietly downgrading it to a log line
+		// would be its own silent failure. The warning is here because the
+		// same option means something different on the second run - the
+		// process it exits is one that is already serving traffic.
+		e.log().Warnf("runtime: %v callback %s is marked WithFatal - reasonable on the first start, "+
+			"but this phase runs again after a configuration reload, where exiting kills a process "+
+			"that is already serving requests", p, cb.label())
+	}
+	e.register(&e.phases[i], cb, "SetPhase("+p.String()+")", "RunPhase("+p.String()+")")
 }
 
-// RunPhase executes every callback registered for p that has not run yet, in
-// registration order, and closes the phase to further registration.
+// RunPhase executes the callbacks registered for p, in registration order.
 //
-// Calling it again is a no-op: the callbacks that already ran do not run
-// twice. The callbacks run with no lock held, because they routinely call
-// back into Application and sync.RWMutex is not reentrant.
+// The callbacks run with no lock held, because they routinely call back into
+// Application and sync.RWMutex is not reentrant. A p that is not one of the
+// four constants is reported and does nothing.
 //
-// A p that is not one of the four constants is reported and does nothing.
+// For every phase but AfterResource this happens once: the phase is closed to
+// further registration afterwards, and calling RunPhase again is a no-op, so
+// cleanup registered in BeforeExit cannot run twice.
+//
+// AfterResource is the exception, because the resources it announces are
+// rebuilt on every configuration reload. It never closes, every registered
+// callback runs again on every round, and a callback that arrives while a
+// round is running is picked up by the next one. Two rounds never overlap: a
+// trigger that arrives during a round records that another round is owed and
+// returns without waiting for it, which makes RunPhase(AfterResource) the one
+// case that can return before the work is done. See runReentrant.
 func (e *Application) RunPhase(p Phase) {
 	i, ok := p.index()
 	if !ok {
 		e.log().Errorf("runtime: RunPhase(%v) did nothing - that is not a life-cycle phase; "+
 			"use AfterResource, BeforeRouter, AfterListen or BeforeExit", p)
+		return
+	}
+	if p.reentrant() {
+		e.runReentrant(&e.phases[i], p.String())
 		return
 	}
 	// The getter argument is empty because no method hands phase callbacks
@@ -142,6 +173,10 @@ func (e *Application) RunPhase(p Phase) {
 
 // PhaseSealed reports whether p has already run, i.e. whether a further
 // SetPhase for it would be dropped.
+//
+// AfterResource always reports false: it is re-entrant, so registering into
+// it is never too late - though a callback that arrives after the last reload
+// of the process will not run until the next one.
 //
 // A phase that is not one of the four constants reports true: "your callback
 // will not run in that phase" is the answer that keeps a caller from

--- a/sdk/runtime/phase.go
+++ b/sdk/runtime/phase.go
@@ -64,3 +64,97 @@ func (p Phase) String() string {
 	}
 	return "Phase(" + strconv.Itoa(int(p)) + ")"
 }
+
+// phaseCount is how many phases there are, and therefore how many registries
+// an Application carries.
+//
+// They live in a fixed-size array rather than a map because every field of
+// Application is unexported, which makes &runtime.Application{} legal outside
+// this package, and NewConfig does not initialise the before and appRouters
+// registries either - the zero value is expected to work. A nil map would
+// crash on the first SetPhase instead.
+const phaseCount = 4
+
+// index maps a phase to its registry slot, reporting false for a value that
+// is not one of the four constants.
+//
+// It is a switch and not arithmetic on int(p)/10-1: that would hand Phase(11)
+// the AfterResource slot, so a caller who got a constant slightly wrong would
+// silently attach to a phase they did not name.
+func (p Phase) index() (int, bool) {
+	switch p {
+	case AfterResource:
+		return 0, true
+	case BeforeRouter:
+		return 1, true
+	case AfterListen:
+		return 2, true
+	case BeforeExit:
+		return 3, true
+	}
+	return 0, false
+}
+
+// SetPhase registers a callback to run when the application reaches p.
+//
+// The callback runs when RunPhase(p) is called, in registration order, behind
+// the same panic guard as SetBefore: a panic is logged with the registration
+// site and the remaining callbacks still run, unless WithFatal says otherwise.
+//
+// Registering after that phase has already run is refused and reported, and
+// so is a p that is not one of the four constants - neither panics, because
+// an installer registering a hook is usually running inside an init() where a
+// panic takes the whole program down and names this file rather than the
+// caller. Ask PhaseSealed if you need to know rather than read it in a log.
+func (e *Application) SetPhase(p Phase, f func(), opts ...CallbackOption) {
+	site := callerSite(2)
+	i, ok := p.index()
+	if !ok {
+		e.log().Errorf("runtime: SetPhase ignored - %v is not a life-cycle phase; "+
+			"use AfterResource, BeforeRouter, AfterListen or BeforeExit (registered at %s)", p, site)
+		return
+	}
+	e.register(&e.phases[i], newCallback(f, site, opts),
+		"SetPhase("+p.String()+")", "RunPhase("+p.String()+")")
+}
+
+// RunPhase executes every callback registered for p that has not run yet, in
+// registration order, and closes the phase to further registration.
+//
+// Calling it again is a no-op: the callbacks that already ran do not run
+// twice. The callbacks run with no lock held, because they routinely call
+// back into Application and sync.RWMutex is not reentrant.
+//
+// A p that is not one of the four constants is reported and does nothing.
+func (e *Application) RunPhase(p Phase) {
+	i, ok := p.index()
+	if !ok {
+		e.log().Errorf("runtime: RunPhase(%v) did nothing - that is not a life-cycle phase; "+
+			"use AfterResource, BeforeRouter, AfterListen or BeforeExit", p)
+		return
+	}
+	// The getter argument is empty because no method hands phase callbacks
+	// out for the caller to loop over, so the warning it guards is
+	// unreachable here. That omission is deliberate: GetBefore and
+	// GetAppRouters showed what handing them out costs.
+	e.runRegistry(&e.phases[i], p.String(), "", "RunPhase("+p.String()+")")
+}
+
+// PhaseSealed reports whether p has already run, i.e. whether a further
+// SetPhase for it would be dropped.
+//
+// A phase that is not one of the four constants reports true: "your callback
+// will not run in that phase" is the answer that keeps a caller from
+// registering into a hole, and it is also reported, because asking about a
+// phase that does not exist is a mistake in the caller either way.
+func (e *Application) PhaseSealed(p Phase) bool {
+	i, ok := p.index()
+	if !ok {
+		e.log().Errorf("runtime: PhaseSealed(%v) reports sealed - that is not a life-cycle phase; "+
+			"use AfterResource, BeforeRouter, AfterListen or BeforeExit", p)
+		return true
+	}
+	e.mux.RLock()
+	defer e.mux.RUnlock()
+	return e.phases[i].sealed
+}

--- a/sdk/runtime/phase_reentrant_test.go
+++ b/sdk/runtime/phase_reentrant_test.go
@@ -1,0 +1,304 @@
+package runtime
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+)
+
+// AfterResource runs every registered callback again on every round, not the
+// ones registered since the last one. A configuration reload rebuilds the
+// database, the cache and the queue, and the hooks that have to attach
+// themselves to the new ones are exactly the hooks that already ran.
+func TestReentrantPhaseRunsEveryCallbackOnEveryRound(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var first, second int
+	app.SetPhase(AfterResource, func() { first++ })
+	app.SetPhase(AfterResource, func() { second++ })
+
+	for i := 0; i < 3; i++ {
+		app.RunPhase(AfterResource)
+	}
+
+	if first != 3 || second != 3 {
+		t.Errorf("callbacks ran %d and %d times over three rounds, want 3 and 3", first, second)
+	}
+}
+
+// The phase never closes, so a module that registers late is not refused -
+// and nothing is logged about it, because it is not a mistake.
+func TestReentrantPhaseNeverSeals(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	app.RunPhase(AfterResource)
+	if app.PhaseSealed(AfterResource) {
+		t.Error("AfterResource reports sealed; it is re-entrant and never closes")
+	}
+
+	late := 0
+	app.SetPhase(AfterResource, func() { late++ })
+	if errors := rec.only(logger.ErrorLevel); len(errors) != 0 {
+		t.Errorf("registering into a re-entrant phase after a round is not late, got %v", errors)
+	}
+
+	app.RunPhase(AfterResource)
+	if late != 1 {
+		t.Errorf("the late callback ran %d times, want 1", late)
+	}
+}
+
+// Two rounds must never overlap. Without that, two reloads in quick
+// succession run the same hook twice at once - which for the queue hook
+// means two sets of consumers on one adapter.
+//
+// The overlap is forced rather than raced for: the first round is held
+// inside the callback until the second trigger has been delivered.
+func TestReentrantPhaseNeverRunsTwoRoundsAtOnce(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var inFlight, overlapped, calls int32
+	entered := make(chan struct{}, 4)
+	release := make(chan struct{})
+
+	app.SetPhase(AfterResource, func() {
+		if atomic.AddInt32(&inFlight, 1) != 1 {
+			atomic.StoreInt32(&overlapped, 1)
+		}
+		atomic.AddInt32(&calls, 1)
+		entered <- struct{}{}
+		<-release
+		atomic.AddInt32(&inFlight, -1)
+	})
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		app.RunPhase(AfterResource)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the first round never started")
+	}
+
+	// The second trigger must not wait for the round in flight: the caller
+	// is the one goroutine that drives configuration reloads.
+	mustReturn(t, "RunPhase(AfterResource) while a round is in flight", func() {
+		app.RunPhase(AfterResource)
+	})
+
+	close(release)
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the rounds never finished")
+	}
+
+	if atomic.LoadInt32(&overlapped) != 0 {
+		t.Error("two rounds ran the same callback at the same time")
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("the callback ran %d times, want 2: the trigger that arrived during a round owes another round", got)
+	}
+}
+
+// The trigger that arrives during a round is owed a round, not discarded.
+// Discarding is the cheaper implementation and the dangerous one: the
+// adapter built by the second reload may have been installed after the first
+// round took its snapshot, so dropping the trigger leaves it with no
+// consumers at all.
+func TestATriggerDuringARoundIsNotDiscarded(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var rounds int32
+	entered := make(chan struct{}, 8)
+	release := make(chan struct{})
+	var once sync.Once
+
+	app.SetPhase(AfterResource, func() {
+		atomic.AddInt32(&rounds, 1)
+		entered <- struct{}{}
+		// Only the first round blocks; the later ones must be free to run.
+		once.Do(func() { <-release })
+	})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.RunPhase(AfterResource)
+	}()
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the first round never started")
+	}
+
+	// Three triggers arrive while the first round is held. They collapse
+	// into one owed round - the point is that at least one survives.
+	for i := 0; i < 3; i++ {
+		app.RunPhase(AfterResource)
+	}
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the owed round never ran: the trigger was discarded")
+	}
+	if got := atomic.LoadInt32(&rounds); got < 2 {
+		t.Errorf("the callback ran %d times; triggers that arrived during the round were dropped", got)
+	}
+}
+
+// A callback registered from inside a callback waits for the next round.
+// Sweeping it up at the end of the current one instead would never
+// terminate for a hook that registers a hook on every run.
+func TestACallbackRegisteredDuringARoundWaitsForTheNextOne(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var late int
+	var once sync.Once
+	app.SetPhase(AfterResource, func() {
+		once.Do(func() {
+			app.SetPhase(AfterResource, func() { late++ })
+		})
+	})
+
+	mustReturn(t, "RunPhase(AfterResource) with a callback that registers one", func() {
+		app.RunPhase(AfterResource)
+	})
+	if late != 0 {
+		t.Errorf("the callback registered during the round ran %d times in that round, want 0", late)
+	}
+
+	app.RunPhase(AfterResource)
+	if late != 1 {
+		t.Errorf("the callback registered during the previous round ran %d times, want 1", late)
+	}
+}
+
+// Growth across rounds is the only automatic signal that a hook is not
+// idempotent: the registry never shrinks, and every entry runs every round,
+// so a hook that registers a hook costs one more callback per reload for the
+// life of the process and reports nothing on its own.
+func TestGrowthAcrossRoundsIsWarnedAbout(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	app.SetPhase(AfterResource, func() {})
+	app.RunPhase(AfterResource)
+	if warns := rec.only(logger.WarnLevel); len(warns) != 0 {
+		t.Errorf("the first round has nothing to compare against and must not warn, got %v", warns)
+	}
+
+	app.SetPhase(AfterResource, func() {})
+	app.RunPhase(AfterResource)
+
+	warns := rec.only(logger.WarnLevel)
+	if len(warns) != 1 {
+		t.Fatalf("want one warning about the registry growing, got %v", warns)
+	}
+	for _, want := range []string{"AfterResource", "2", "1"} {
+		if !strings.Contains(warns[0], want) {
+			t.Errorf("the warning must contain %q, got:\n%s", want, warns[0])
+		}
+	}
+
+	app.RunPhase(AfterResource)
+	if warns := rec.only(logger.WarnLevel); len(warns) != 1 {
+		t.Errorf("a round that did not grow must not warn again, got %v", warns)
+	}
+}
+
+// WithFatal on the re-entrant phase keeps its meaning - refusing to start
+// when the database is unreachable is a fair thing to ask for, and silently
+// downgrading it would be its own silent failure - but it is warned about at
+// the registration site, because on the second round the process it exits is
+// one that is already serving requests.
+func TestWithFatalOnTheReentrantPhaseIsWarnedAboutAndKept(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	previous := exit
+	t.Cleanup(func() { exit = previous })
+	var codes []int
+	exit = func(code int) { codes = append(codes, code) }
+
+	app.SetPhase(AfterResource, func() { panic("boom") }, WithFatal(), WithName("db-check"))
+
+	warns := rec.only(logger.WarnLevel)
+	if len(warns) != 1 {
+		t.Fatalf("want one warning at the registration site, got %v", warns)
+	}
+	for _, want := range []string{"AfterResource", "db-check", "phase_reentrant_test.go", "WithFatal"} {
+		if !strings.Contains(warns[0], want) {
+			t.Errorf("the warning must contain %q, got:\n%s", want, warns[0])
+		}
+	}
+
+	app.RunPhase(AfterResource)
+	if len(codes) != 1 || codes[0] != 1 {
+		t.Errorf("exit was called with %v, want exactly one call with 1: WithFatal must keep its meaning", codes)
+	}
+}
+
+// The warning belongs to the re-entrant phase only. On a phase that happens
+// once, WithFatal is the option working as documented and warning about it
+// would train the reader to ignore the line.
+func TestWithFatalOnAOnceOnlyPhaseIsNotWarnedAbout(t *testing.T) {
+	for _, p := range onceOnlyPhases {
+		app := NewConfig()
+		rec := captureLogs(t, app)
+
+		app.SetPhase(p, func() {}, WithFatal())
+
+		if warns := rec.only(logger.WarnLevel); len(warns) != 0 {
+			t.Errorf("%v warned about WithFatal, got %v", p, warns)
+		}
+	}
+}
+
+// The re-entrant path under -race: triggers from many goroutines while
+// callbacks are being registered.
+func TestReentrantPhaseIsRaceFree(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var calls int64
+	for i := 0; i < 3; i++ {
+		app.SetPhase(AfterResource, func() { atomic.AddInt64(&calls, 1) })
+	}
+
+	const goroutines, iters = 12, 30
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				if (i+j)%4 == 0 {
+					app.SetPhase(AfterResource, func() { atomic.AddInt64(&calls, 1) })
+					continue
+				}
+				app.RunPhase(AfterResource)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if atomic.LoadInt64(&calls) == 0 {
+		t.Error("no callback ran at all")
+	}
+}

--- a/sdk/runtime/phase_registry_test.go
+++ b/sdk/runtime/phase_registry_test.go
@@ -14,6 +14,12 @@ import (
 // go untested, which is the point of deriving nothing from it.
 var allPhases = []Phase{AfterResource, BeforeRouter, AfterListen, BeforeExit}
 
+// onceOnlyPhases is every phase that happens exactly once. AfterResource is
+// not one of them: it runs again on every configuration reload, so the
+// promises about sealing and about not running twice are not made for it. Its
+// own promises are in phase_reentrant_test.go.
+var onceOnlyPhases = []Phase{BeforeRouter, AfterListen, BeforeExit}
+
 // Each phase runs its own callbacks, in the order they were registered, and
 // nobody else's. Order is what lets one hook rely on an earlier one having
 // run, so it is asserted rather than assumed.
@@ -61,7 +67,7 @@ func TestRunPhaseDoesNotRunAnotherPhase(t *testing.T) {
 // twice. Cleanup registered in BeforeExit is the case that makes this matter
 // - closing a pool twice is worse than not closing it.
 func TestRunPhaseTwiceDoesNotRunAnythingTwice(t *testing.T) {
-	for _, p := range allPhases {
+	for _, p := range onceOnlyPhases {
 		app := NewConfig()
 		captureLogs(t, app)
 
@@ -81,7 +87,7 @@ func TestRunPhaseTwiceDoesNotRunAnythingTwice(t *testing.T) {
 // alternative is a callback sitting in a slice nobody will walk again, which
 // is the silent failure this registry exists to remove.
 func TestSetPhaseAfterTheRunIsRefusedAndReported(t *testing.T) {
-	for _, p := range allPhases {
+	for _, p := range onceOnlyPhases {
 		app := NewConfig()
 		rec := captureLogs(t, app)
 

--- a/sdk/runtime/phase_registry_test.go
+++ b/sdk/runtime/phase_registry_test.go
@@ -1,0 +1,296 @@
+package runtime
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+	"gorm.io/gorm"
+)
+
+// allPhases is every phase the contract names, for the tests that have to
+// hold for all of them. A phase added later and left out of this list would
+// go untested, which is the point of deriving nothing from it.
+var allPhases = []Phase{AfterResource, BeforeRouter, AfterListen, BeforeExit}
+
+// Each phase runs its own callbacks, in the order they were registered, and
+// nobody else's. Order is what lets one hook rely on an earlier one having
+// run, so it is asserted rather than assumed.
+func TestRunPhaseRunsItsOwnCallbacksInRegistrationOrder(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	ran := map[Phase][]string{}
+	for _, p := range allPhases {
+		for _, name := range []string{"first", "second", "third"} {
+			app.SetPhase(p, func() { ran[p] = append(ran[p], name) })
+		}
+	}
+
+	for _, p := range allPhases {
+		app.RunPhase(p)
+		if got := strings.Join(ran[p], ","); got != "first,second,third" {
+			t.Errorf("%v ran %q, want first,second,third", p, got)
+		}
+	}
+}
+
+// Running one phase must not run another. The phases share an
+// implementation, and a single registry behind all four would pass every
+// order test above while running the shutdown work at start-up.
+func TestRunPhaseDoesNotRunAnotherPhase(t *testing.T) {
+	for _, run := range allPhases {
+		app := NewConfig()
+		captureLogs(t, app)
+
+		var ran []Phase
+		for _, p := range allPhases {
+			app.SetPhase(p, func() { ran = append(ran, p) })
+		}
+
+		app.RunPhase(run)
+
+		if len(ran) != 1 || ran[0] != run {
+			t.Errorf("RunPhase(%v) ran %v, want exactly [%v]", run, ran, run)
+		}
+	}
+}
+
+// A second RunPhase is a no-op: the callbacks that already ran do not run
+// twice. Cleanup registered in BeforeExit is the case that makes this matter
+// - closing a pool twice is worse than not closing it.
+func TestRunPhaseTwiceDoesNotRunAnythingTwice(t *testing.T) {
+	for _, p := range allPhases {
+		app := NewConfig()
+		captureLogs(t, app)
+
+		calls := 0
+		app.SetPhase(p, func() { calls++ })
+
+		app.RunPhase(p)
+		app.RunPhase(p)
+
+		if calls != 1 {
+			t.Errorf("%v callback ran %d times across two RunPhase calls, want 1", p, calls)
+		}
+	}
+}
+
+// Registering into a phase that has already run is refused and reported: the
+// alternative is a callback sitting in a slice nobody will walk again, which
+// is the silent failure this registry exists to remove.
+func TestSetPhaseAfterTheRunIsRefusedAndReported(t *testing.T) {
+	for _, p := range allPhases {
+		app := NewConfig()
+		rec := captureLogs(t, app)
+
+		app.RunPhase(p)
+		if !app.PhaseSealed(p) {
+			t.Errorf("%v is not sealed after RunPhase", p)
+		}
+
+		late := false
+		app.SetPhase(p, func() { late = true })
+		app.RunPhase(p)
+
+		if late {
+			t.Errorf("a callback registered after RunPhase(%v) ran anyway", p)
+		}
+		errors := rec.only(logger.ErrorLevel)
+		if len(errors) != 1 {
+			t.Fatalf("want one error line for the late registration into %v, got %v", p, errors)
+		}
+		for _, want := range []string{p.String(), "phase_registry_test.go"} {
+			if !strings.Contains(errors[0], want) {
+				t.Errorf("the report must name %q, got:\n%s", want, errors[0])
+			}
+		}
+	}
+}
+
+// Before the run, a phase is open: an installer that asks gets told it can
+// still register.
+func TestPhaseIsNotSealedBeforeItRuns(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+	for _, p := range allPhases {
+		if app.PhaseSealed(p) {
+			t.Errorf("%v reports sealed before RunPhase", p)
+		}
+	}
+}
+
+// A value that is not one of the four constants is a mistake in the caller,
+// and it is reported as one - but it does not panic. Registration usually
+// happens inside an init(), where a panic takes down the whole program and
+// names this file rather than the module that got the constant wrong.
+func TestSetPhaseWithAnUnknownPhaseIsDroppedAndReported(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	ran := false
+	mustReturn(t, "SetPhase with an out-of-range phase", func() {
+		app.SetPhase(Phase(42), func() { ran = true })
+	})
+
+	for _, p := range append(allPhases, Phase(42)) {
+		app.RunPhase(p)
+	}
+	if ran {
+		t.Error("a callback registered for an out-of-range phase ran anyway")
+	}
+
+	errors := rec.only(logger.ErrorLevel)
+	if len(errors) == 0 {
+		t.Fatal("dropping the callback must be reported; nothing was logged")
+	}
+	for _, want := range []string{"Phase(42)", "phase_registry_test.go"} {
+		if !strings.Contains(errors[0], want) {
+			t.Errorf("the report must contain %q, got:\n%s", want, errors[0])
+		}
+	}
+}
+
+// The same for the running side: reported, and nothing happens. In
+// particular it must not run some other phase's callbacks.
+func TestRunPhaseWithAnUnknownPhaseDoesNothingAndReports(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	ran := false
+	for _, p := range allPhases {
+		app.SetPhase(p, func() { ran = true })
+	}
+
+	mustReturn(t, "RunPhase with an out-of-range phase", func() { app.RunPhase(Phase(42)) })
+
+	if ran {
+		t.Error("RunPhase(Phase(42)) ran a real phase's callbacks")
+	}
+	errors := rec.only(logger.ErrorLevel)
+	if len(errors) != 1 || !strings.Contains(errors[0], "Phase(42)") {
+		t.Errorf("want one error line naming Phase(42), got %v", errors)
+	}
+}
+
+// An unknown phase reports sealed. "Your callback will not run in that phase"
+// is the answer that stops a caller registering into a hole; false would
+// invite exactly that.
+func TestPhaseSealedOfAnUnknownPhaseReportsSealed(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	for _, p := range []Phase{0, 1, 11, 42, -1} {
+		if !app.PhaseSealed(p) {
+			t.Errorf("PhaseSealed(%v) = false, want true for a phase that does not exist", p)
+		}
+	}
+	if len(rec.only(logger.ErrorLevel)) != 5 {
+		t.Errorf("each out-of-range question must be reported, got %v", rec.only(logger.ErrorLevel))
+	}
+}
+
+// The zero value has to work. Every field of Application is unexported, so
+// &runtime.Application{} is legal outside this package, and NewConfig does
+// not initialise the before and appRouters registries either. A map here
+// would crash on the first SetPhase - which is why the phases are an array.
+func TestZeroValueApplicationSupportsPhases(t *testing.T) {
+	app := &Application{}
+	captureLogs(t, app)
+
+	ran := false
+	mustReturn(t, "SetPhase on a zero-value Application", func() {
+		app.SetPhase(BeforeRouter, func() { ran = true })
+	})
+	mustReturn(t, "RunPhase on a zero-value Application", func() { app.RunPhase(BeforeRouter) })
+	mustReturn(t, "PhaseSealed on a zero-value Application", func() { app.PhaseSealed(BeforeRouter) })
+
+	if !ran {
+		t.Error("the callback registered on a zero-value Application never ran")
+	}
+	if !app.PhaseSealed(BeforeRouter) {
+		t.Error("a zero-value Application did not seal the phase it just ran")
+	}
+}
+
+// The phases get the guard the other registries have: a panic is logged with
+// the label and the registration site, and the rest still run.
+func TestPanicInOnePhaseCallbackDoesNotStopTheRest(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	var ran []string
+	app.SetPhase(AfterListen, func() { ran = append(ran, "first") })
+	app.SetPhase(AfterListen, func() { panic("boom") }, WithName("metrics-exporter"))
+	app.SetPhase(AfterListen, func() { ran = append(ran, "third") })
+
+	mustReturn(t, "RunPhase with a panicking callback", func() { app.RunPhase(AfterListen) })
+
+	if got := strings.Join(ran, ","); got != "first,third" {
+		t.Errorf("ran %q, want first,third", got)
+	}
+	errors := rec.only(logger.ErrorLevel)
+	if len(errors) != 1 {
+		t.Fatalf("want one error line, got %v", errors)
+	}
+	for _, want := range []string{"AfterListen", "metrics-exporter", "phase_registry_test.go", "boom", "goroutine "} {
+		if !strings.Contains(errors[0], want) {
+			t.Errorf("the report must contain %q, got:\n%s", want, errors[0])
+		}
+	}
+}
+
+// Callbacks run with no lock held. They are expected to call back into
+// Application - a hook that stores the new database is the whole point of
+// AfterResource - and sync.RWMutex is not reentrant, so holding mux across
+// one would deadlock on the first hook that does its job.
+func TestPhaseCallbacksRunWithNoLockHeld(t *testing.T) {
+	for _, p := range allPhases {
+		app := NewConfig()
+		captureLogs(t, app)
+
+		reached := false
+		app.SetPhase(p, func() {
+			app.SetDb(&gorm.DB{})
+			app.GetDb()
+			app.PhaseSealed(p)
+			reached = true
+		})
+
+		mustReturn(t, "RunPhase("+p.String()+") with a callback that calls back in", func() { app.RunPhase(p) })
+
+		if !reached {
+			t.Errorf("the %v callback did not get through calling back into Application", p)
+		}
+	}
+}
+
+// The phase registries are hammered from several goroutines at once, for
+// -race. Concurrent registration and running is not exotic: modules register
+// from init() while the process is already wiring itself up.
+func TestPhaseAccessorsAreRaceFree(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	const goroutines, iters = 16, 50
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				p := allPhases[(i+j)%len(allPhases)]
+				switch (i + j) % 3 {
+				case 0:
+					app.SetPhase(p, func() {})
+				case 1:
+					app.RunPhase(p)
+				case 2:
+					app.PhaseSealed(p)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/sdk/runtime/phase_registry_test.go
+++ b/sdk/runtime/phase_registry_test.go
@@ -20,10 +20,13 @@ var allPhases = []Phase{AfterResource, BeforeRouter, AfterListen, BeforeExit}
 // own promises are in phase_reentrant_test.go.
 var onceOnlyPhases = []Phase{BeforeRouter, AfterListen, BeforeExit}
 
-// Each phase runs its own callbacks, in the order they were registered, and
-// nobody else's. Order is what lets one hook rely on an earlier one having
-// run, so it is asserted rather than assumed.
-func TestRunPhaseRunsItsOwnCallbacksInRegistrationOrder(t *testing.T) {
+// Each phase runs its own callbacks, in a defined order, and nobody else's.
+// Order is what lets one hook rely on an earlier one having run, so it is
+// asserted rather than assumed.
+//
+// BeforeExit is the phase that unwinds, so it goes the other way: see
+// shutdown_test.go for why, and for the rest of what it promises.
+func TestRunPhaseRunsItsOwnCallbacksInADefinedOrder(t *testing.T) {
 	app := NewConfig()
 	captureLogs(t, app)
 
@@ -35,9 +38,13 @@ func TestRunPhaseRunsItsOwnCallbacksInRegistrationOrder(t *testing.T) {
 	}
 
 	for _, p := range allPhases {
+		want := "first,second,third"
+		if p == BeforeExit {
+			want = "third,second,first"
+		}
 		app.RunPhase(p)
-		if got := strings.Join(ran[p], ","); got != "first,second,third" {
-			t.Errorf("%v ran %q, want first,second,third", p, got)
+		if got := strings.Join(ran[p], ","); got != want {
+			t.Errorf("%v ran %q, want %s", p, got, want)
 		}
 	}
 }

--- a/sdk/runtime/phase_test.go
+++ b/sdk/runtime/phase_test.go
@@ -1,0 +1,64 @@
+package runtime
+
+import "testing"
+
+// A phase in a log line has to be readable as itself. "10" sends the reader
+// to the source to find out which phase failed; the name does not.
+func TestPhaseStringNamesEachPhase(t *testing.T) {
+	for _, tc := range []struct {
+		phase Phase
+		want  string
+	}{
+		{AfterResource, "AfterResource"},
+		{BeforeRouter, "BeforeRouter"},
+		{AfterListen, "AfterListen"},
+		{BeforeExit, "BeforeExit"},
+	} {
+		if got := tc.phase.String(); got != tc.want {
+			t.Errorf("Phase(%d).String() = %q, want %q", int(tc.phase), got, tc.want)
+		}
+	}
+}
+
+// An out-of-range value must not borrow a name it does not have: the
+// out-of-range reports in SetPhase and RunPhase carry this string, and a
+// report naming a real phase would send the reader after the wrong one.
+func TestPhaseStringOfAnUnknownValueIsNotAName(t *testing.T) {
+	for _, p := range []Phase{0, 1, 42, -1, 11} {
+		got := p.String()
+		for _, known := range []string{"AfterResource", "BeforeRouter", "AfterListen", "BeforeExit"} {
+			if got == known {
+				t.Errorf("Phase(%d).String() = %q: an unknown value took a known phase's name", int(p), got)
+			}
+		}
+	}
+	if got := Phase(42).String(); got != "Phase(42)" {
+		t.Errorf("Phase(42).String() = %q, want %q", got, "Phase(42)")
+	}
+}
+
+// The phases are ordered as the application runs, and comparing them with <
+// is meant to keep meaning "happens earlier".
+func TestPhasesAreOrderedByWhenTheyHappen(t *testing.T) {
+	ordered := []Phase{AfterResource, BeforeRouter, AfterListen, BeforeExit}
+	for i := 1; i < len(ordered); i++ {
+		if !(ordered[i-1] < ordered[i]) {
+			t.Errorf("%v is not before %v", ordered[i-1], ordered[i])
+		}
+	}
+}
+
+// The gaps are the reason the values are written out instead of coming from
+// iota: a phase added between two existing ones must be able to take a number
+// of its own rather than renumber the ones already compiled into somebody
+// else's binary. Switching this block to iota is what this test is here to
+// catch.
+func TestPhasesLeaveRoomForOneInBetween(t *testing.T) {
+	ordered := []Phase{AfterResource, BeforeRouter, AfterListen, BeforeExit}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i]-ordered[i-1] < 2 {
+			t.Errorf("no room between %v (%d) and %v (%d) for a phase added later",
+				ordered[i-1], int(ordered[i-1]), ordered[i], int(ordered[i]))
+		}
+	}
+}

--- a/sdk/runtime/phase_test.go
+++ b/sdk/runtime/phase_test.go
@@ -37,8 +37,10 @@ func TestPhaseStringOfAnUnknownValueIsNotAName(t *testing.T) {
 	}
 }
 
-// The phases are ordered as the application runs, and comparing them with <
-// is meant to keep meaning "happens earlier".
+// The phases are numbered in the order they are first reached, and comparing
+// them with < is meant to keep meaning "reached first". It says nothing about
+// later rounds: AfterResource holds the smallest number and runs again after
+// all of them on every configuration reload.
 func TestPhasesAreOrderedByWhenTheyHappen(t *testing.T) {
 	ordered := []Phase{AfterResource, BeforeRouter, AfterListen, BeforeExit}
 	for i := 1; i < len(ordered); i++ {

--- a/sdk/runtime/registry.go
+++ b/sdk/runtime/registry.go
@@ -40,11 +40,21 @@ func (cb callback) label() string {
 //
 // Every method here assumes the caller already holds Application.mux.
 // sync.RWMutex is not reentrant, so none of them may take it.
+//
+// A re-entrant phase uses none of cursor and sealed - it runs every entry
+// again on every round - and uses running, pending, rounds and lastCount
+// instead. Those four are described where the rounds are actually driven, in
+// runReentrant.
 type registry struct {
 	entries []callback
 	cursor  int
 	sealed  bool
 	handed  bool // Get* handed the entries out for a loop core cannot see
+
+	running   bool // a round is in flight
+	pending   bool // a trigger arrived during that round and owes another one
+	rounds    int  // rounds completed, so the first one has nothing to compare against
+	lastCount int  // len(entries) at the start of the previous round
 }
 
 // appendLocked records a callback, reporting false when the registry is closed.
@@ -85,6 +95,86 @@ func (r *registry) takePendingLocked() []callback {
 	r.cursor = len(r.entries)
 	r.sealed = true
 	return pending
+}
+
+// takeAllLocked returns every registered callback, without sealing the
+// registry and without moving the cursor.
+//
+// That is the difference between a phase that happens once and one that
+// happens again after a configuration reload: the hooks worth running the
+// second time are precisely the ones that already ran the first time. They
+// are the code that attaches itself to the database, the cache and the queue,
+// and those have just been rebuilt.
+func (r *registry) takeAllLocked() []callback {
+	return slices.Clone(r.entries)
+}
+
+// runReentrant runs every registered callback, and keeps running rounds for
+// as long as triggers keep arriving, never two rounds at once.
+//
+//	in flight? -> record that another round is owed, and return
+//	otherwise  -> take the entries under the lock, run them without it,
+//	              then take the lock again and go round once more if one
+//	              is owed
+//
+// Dropping the second trigger instead would be the cheaper thing to write and
+// the wrong thing to ship: the resource that the second reload built may have
+// been installed after the first round took its snapshot, so dropping it
+// leaves that resource with none of the consumers that were supposed to
+// attach to it - a queue nobody reads, which is the defect this whole
+// mechanism exists to close.
+//
+// A caller whose trigger only set the flag returns before the work is done.
+// Waiting instead would block the single goroutine that drives configuration
+// reloads behind hooks of unknown duration, so a re-entrant phase is the one
+// phase whose RunPhase is not always synchronous.
+//
+// Callbacks registered while a round is running are not picked up by that
+// round; the next one takes them. Sweeping them up at the end instead would
+// never terminate for a hook that registers a hook.
+func (e *Application) runReentrant(r *registry, kind string) {
+	e.mux.Lock()
+	if r.running {
+		r.pending = true
+		e.mux.Unlock()
+		return
+	}
+	r.running = true
+	e.mux.Unlock()
+
+	for {
+		e.mux.Lock()
+		batch := r.takeAllLocked()
+		grew := r.rounds > 0 && len(batch) > r.lastCount
+		previous := r.lastCount
+		r.lastCount = len(batch)
+		r.rounds++
+		e.mux.Unlock()
+
+		log := e.log()
+		if grew {
+			// The registry of a re-entrant phase only ever grows, and every
+			// entry runs on every round. A hook that registers a hook
+			// therefore costs one more callback per reload for the life of
+			// the process, and nothing else in this package can notice it:
+			// there is no failure, only a number going up.
+			log.Warnf("runtime: %s has %d callbacks, up from %d since the last round - "+
+				"a hook that registers a hook grows this registry on every configuration reload; "+
+				"if this number keeps climbing, find the hook that is not idempotent", kind, len(batch), previous)
+		}
+		for i := range batch {
+			e.invoke(kind, batch[i], log)
+		}
+
+		e.mux.Lock()
+		if !r.pending {
+			r.running = false
+			e.mux.Unlock()
+			return
+		}
+		r.pending = false
+		e.mux.Unlock()
+	}
 }
 
 // CallbackOption configures a callback registered through SetBeforeWith or

--- a/sdk/runtime/registry.go
+++ b/sdk/runtime/registry.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"context"
 	"os"
 	goruntime "runtime" // aliased: this package is itself called runtime
 	"runtime/debug"
@@ -18,9 +19,24 @@ import (
 // still has to find out who registered the thing that failed.
 type callback struct {
 	fn    func()
-	name  string // caller-supplied label; empty unless WithName was used
-	site  string // "file:line" of the SetXxx call that registered it
+	ctxFn func(context.Context) // set instead of fn by SetShutdown; see bound
+	name  string                // caller-supplied label; empty unless WithName was used
+	site  string                // "file:line" of the SetXxx call that registered it
 	fatal bool
+}
+
+// bound gives a context-taking callback its context.
+//
+// The shutdown callbacks are the only ones that take one, and this is how
+// they reach the same guard, the same registry and the same reporting as
+// every other kind rather than getting a second copy of all three.
+func (cb callback) bound(ctx context.Context) callback {
+	if cb.ctxFn == nil {
+		return cb
+	}
+	fn := cb.ctxFn
+	cb.fn = func() { fn(ctx) }
+	return cb
 }
 
 // label is "name (file:line)", or "(file:line)" when the callback is unnamed.

--- a/sdk/runtime/shutdown.go
+++ b/sdk/runtime/shutdown.go
@@ -6,6 +6,34 @@ import (
 	"sync/atomic"
 )
 
+// BeginShutdown says that the application is on its way out, and closes the
+// phases that only make sense on the way in.
+//
+// It exists because the last configuration reload can outlive the decision to
+// stop. Closing the config watcher does not wait for a reload already in
+// flight, and that reload finishes by rebuilding the database, the cache and
+// the queue and announcing them - which, in the middle of a shutdown, undoes
+// the cleanup that has just run and starts consumers on a process that is
+// being taken apart. AfterResource is also the one phase that never closes,
+// so without this there is nothing to stop code registering into it while the
+// process is going down.
+//
+// After this call SetPhase and RunPhase do nothing for every phase but
+// BeforeExit, and say so. BeforeExit keeps working: it is the phase this call
+// is on the way to. There is no way back - a process does not un-shut-down -
+// and calling it twice is harmless.
+//
+// It does not interrupt a phase already running. It closes the door; it does
+// not reach into the room.
+//
+// RunShutdown calls it, so a host that only calls RunShutdown is covered from
+// that moment on. Calling it as the first step of the shutdown path is what
+// covers the window before then, which is the wider one: it spans the whole
+// of the HTTP server's own graceful shutdown.
+func (e *Application) BeginShutdown() {
+	e.shuttingDown.Store(true)
+}
+
 // SetShutdown registers a callback to run on the way out, once the server has
 // stopped serving.
 //
@@ -62,6 +90,7 @@ func (e *Application) RunShutdown(ctx context.Context) error {
 		// cleanup: panicking here would skip all of them to report it.
 		ctx = context.Background()
 	}
+	e.BeginShutdown()
 	i, _ := BeforeExit.index()
 
 	e.mux.Lock()

--- a/sdk/runtime/shutdown.go
+++ b/sdk/runtime/shutdown.go
@@ -1,0 +1,110 @@
+package runtime
+
+import (
+	"context"
+	"slices"
+	"sync/atomic"
+)
+
+// SetShutdown registers a callback to run on the way out, once the server has
+// stopped serving.
+//
+// It is the context-taking half of SetPhase(BeforeExit, ...): both register
+// into the same phase, and one pass runs both. The context carries whatever
+// budget the host allowed for shutdown, so a callback that can cut its work
+// short - drain for what is left rather than for a fixed time - has something
+// to look at. One that cannot is free to ignore it.
+//
+// The callbacks run in reverse registration order, which is the right default
+// for a chain of hooks that built on each other: the last one registered is
+// the one most likely to depend on the others. It says nothing about
+// resources the host created for itself, which were not built by this chain
+// and are not unwound by it.
+//
+// WithFatal is not honoured here, and saying so is the point: exiting from
+// inside cleanup skips every callback after it, which is the opposite of what
+// the option is for. The callback is kept and the option is reported, because
+// refusing the registration would mean one mistyped option costs you the
+// cleanup entirely - silently.
+func (e *Application) SetShutdown(f func(context.Context), opts ...CallbackOption) {
+	site := callerSite(2)
+	cb := newCallback(nil, site, opts)
+	cb.ctxFn = f
+	if cb.fatal {
+		cb.fatal = false
+		e.log().Errorf("runtime: WithFatal ignored on the shutdown callback %s - exiting from inside "+
+			"cleanup would skip every callback after it; the callback is registered without it", cb.label())
+	}
+	i, _ := BeforeExit.index()
+	e.register(&e.phases[i], cb, "SetShutdown", "RunShutdown")
+}
+
+// RunShutdown runs the BeforeExit callbacks, in reverse registration order,
+// within the caller's context, and closes the phase.
+//
+// It returns ctx.Err() if the context ends first, and nil otherwise. Calling
+// it again runs nothing: cleanup that already ran does not run twice, because
+// closing a connection pool twice is worse than not closing it.
+//
+// What the context bounds is the wait, not the work. The callbacks run on
+// their own goroutine; when the budget is gone this method stops waiting and
+// returns, and the callback that is running carries on until the process
+// exits - possibly leaving whatever it was writing half-written. There is no
+// way to do better: Go cannot cancel a function that does not check for it,
+// which is why the callbacks are handed a context in the first place. The
+// callback holding things up is named in the log.
+//
+// With nothing registered it returns nil immediately, without a goroutine and
+// without consulting the context: nothing to run is not a timeout.
+func (e *Application) RunShutdown(ctx context.Context) error {
+	if ctx == nil {
+		// A nil context is a bug in the caller, but these callbacks are the
+		// cleanup: panicking here would skip all of them to report it.
+		ctx = context.Background()
+	}
+	i, _ := BeforeExit.index()
+
+	e.mux.Lock()
+	pending := e.phases[i].takePendingLocked()
+	e.mux.Unlock()
+
+	if len(pending) == 0 {
+		return nil
+	}
+	slices.Reverse(pending)
+
+	// current is the 1-based index of the callback being run, so the timeout
+	// report can name the one that is holding things up instead of saying
+	// only that something did.
+	var current atomic.Int32
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		log := e.log()
+		for j := range pending {
+			current.Store(int32(j) + 1)
+			e.invoke(BeforeExit.String(), pending[j].bound(ctx), log)
+		}
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		select {
+		case <-done:
+			// Both were ready. Finishing in time wins over the deadline;
+			// select would otherwise pick one at random and report a
+			// timeout for cleanup that actually completed.
+			return nil
+		default:
+		}
+		blame := "the callbacks had not started"
+		if n := current.Load(); n > 0 {
+			blame = pending[n-1].label() + " was still running"
+		}
+		e.log().Errorf("runtime: the shutdown budget ran out - %s. The wait is over, the callback is not: "+
+			"it keeps going until the process exits, and anything it half-wrote stays half-written", blame)
+		return ctx.Err()
+	}
+}

--- a/sdk/runtime/shutdown_gate_test.go
+++ b/sdk/runtime/shutdown_gate_test.go
@@ -1,0 +1,251 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+)
+
+// The window this closes: a configuration reload that started before the
+// shutdown did finishes by rebuilding the resources and announcing them. In
+// the middle of a shutdown that undoes the cleanup which has just run and
+// starts consumers on a process being taken apart.
+func TestAReloadArrivingDuringShutdownRunsNothing(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	ran := 0
+	app.SetPhase(AfterResource, func() { ran++ })
+	app.RunPhase(AfterResource)
+
+	app.BeginShutdown()
+	app.RunPhase(AfterResource)
+
+	if ran != 1 {
+		t.Errorf("the AfterResource callback ran %d times, want 1: the reload during shutdown was let through", ran)
+	}
+	warns := rec.only(logger.WarnLevel)
+	if len(warns) != 1 {
+		t.Fatalf("want one warning about the refused trigger, got %v", warns)
+	}
+	if !strings.Contains(warns[0], "AfterResource") || !strings.Contains(warns[0], "shutting down") {
+		t.Errorf("the warning must name the phase and the reason, got:\n%s", warns[0])
+	}
+}
+
+// The other half: AfterResource never closes, so without the flag anything
+// could keep registering into it while the process goes down, to be run by
+// the next reload.
+func TestRegisteringDuringShutdownIsIgnoredAndReported(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	app.BeginShutdown()
+
+	ran := false
+	app.SetPhase(AfterResource, func() { ran = true })
+	app.RunPhase(AfterResource)
+
+	if ran {
+		t.Error("a callback registered during shutdown ran anyway")
+	}
+	// The callback must not even be kept. AfterResource never seals, so
+	// without this gate anything could keep appending to a registry that is
+	// never walked again - the leak the growth warning cannot help with,
+	// because there are no further rounds to compare.
+	i, _ := AfterResource.index()
+	app.mux.RLock()
+	kept := len(app.phases[i].entries)
+	app.mux.RUnlock()
+	if kept != 0 {
+		t.Errorf("the registry kept %d callbacks registered during shutdown, want 0", kept)
+	}
+	warns := rec.only(logger.WarnLevel)
+	if len(warns) == 0 {
+		t.Fatal("dropping the registration must be reported")
+	}
+	for _, want := range []string{"AfterResource", "shutting down", "shutdown_gate_test.go"} {
+		if !strings.Contains(warns[0], want) {
+			t.Errorf("the warning must contain %q, got:\n%s", want, warns[0])
+		}
+	}
+}
+
+// The start-up phases are closed by it as well: an application on its way out
+// has no use for a router hook.
+func TestTheStartUpPhasesAreClosedByShutdown(t *testing.T) {
+	for _, p := range []Phase{AfterResource, BeforeRouter, AfterListen} {
+		app := NewConfig()
+		captureLogs(t, app)
+		app.BeginShutdown()
+
+		ran := false
+		app.SetPhase(p, func() { ran = true })
+		app.RunPhase(p)
+
+		if ran {
+			t.Errorf("%v ran during shutdown", p)
+		}
+	}
+}
+
+// BeforeExit is exempt, and this is the case that matters most: the flag is
+// set at the start of the shutdown path, so gating every phase alike would
+// make it skip the cleanup it was added to protect.
+func TestBeforeExitStillWorksAfterBeginShutdown(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	app.BeginShutdown()
+
+	var ran []string
+	app.SetShutdown(func(context.Context) { ran = append(ran, "shutdown-hook") })
+	app.SetPhase(BeforeExit, func() { ran = append(ran, "phase-hook") })
+
+	if err := app.RunShutdown(context.Background()); err != nil {
+		t.Fatalf("RunShutdown returned %v, want nil", err)
+	}
+	if got := strings.Join(ran, ","); got != "phase-hook,shutdown-hook" {
+		t.Errorf("ran %q, want phase-hook,shutdown-hook: cleanup registered after BeginShutdown must still run", got)
+	}
+}
+
+// The same through the phase spelling of the call, which is the one that
+// would silently do nothing if the gate did not exempt BeforeExit.
+func TestRunPhaseBeforeExitStillWorksAfterBeginShutdown(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	ran := false
+	app.SetPhase(BeforeExit, func() { ran = true })
+	app.BeginShutdown()
+	app.RunPhase(BeforeExit)
+
+	if !ran {
+		t.Error("RunPhase(BeforeExit) did nothing after BeginShutdown")
+	}
+}
+
+// A host that only calls RunShutdown is covered from that moment on, without
+// having to know the flag exists.
+func TestRunShutdownClosesTheStartUpPhasesToo(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	ran := 0
+	app.SetPhase(AfterResource, func() { ran++ })
+	if err := app.RunShutdown(context.Background()); err != nil {
+		t.Fatalf("RunShutdown returned %v, want nil", err)
+	}
+
+	app.RunPhase(AfterResource)
+	if ran != 0 {
+		t.Errorf("AfterResource ran %d times after RunShutdown, want 0", ran)
+	}
+}
+
+// It closes the door, it does not reach into the room: a round already
+// running finishes. Interrupting it would leave the resources half-attached,
+// which is worse than one more round of hooks that are meant to be repeatable.
+func TestBeginShutdownDoesNotInterruptARoundAlreadyRunning(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	secondRan := make(chan struct{})
+
+	// Two callbacks, because the claim is about the rest of the round: the
+	// flag is set while the first one is still inside the batch, and the
+	// second one has to run anyway. Stopping half way through would leave
+	// the resources half-attached, which is worse than one more round of
+	// hooks that are meant to be repeatable.
+	app.SetPhase(AfterResource, func() {
+		close(started)
+		<-release
+	})
+	app.SetPhase(AfterResource, func() { close(secondRan) })
+
+	go app.RunPhase(AfterResource)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the round never started")
+	}
+
+	app.BeginShutdown()
+	close(release)
+
+	select {
+	case <-secondRan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("BeginShutdown cut short a round that was already running")
+	}
+}
+
+// A process does not un-shut-down, so the call is one-way and saying it twice
+// changes nothing.
+func TestBeginShutdownIsIdempotent(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	app.BeginShutdown()
+	app.BeginShutdown()
+
+	ran := false
+	app.SetPhase(AfterResource, func() { ran = true })
+	app.RunPhase(AfterResource)
+	if ran {
+		t.Error("the phase reopened")
+	}
+}
+
+// The zero value has to work here too: the flag is an atomic that nothing
+// initialises, which is the point of choosing one.
+func TestBeginShutdownOnAZeroValueApplication(t *testing.T) {
+	app := &Application{}
+	captureLogs(t, app)
+
+	mustReturn(t, "BeginShutdown on a zero-value Application", app.BeginShutdown)
+
+	ran := false
+	app.SetPhase(AfterResource, func() { ran = true })
+	app.RunPhase(AfterResource)
+	if ran {
+		t.Error("the gate did not hold on a zero-value Application")
+	}
+}
+
+// The flag is read on paths that hold no lock and written from the signal
+// handler's goroutine, which is what an atomic is for.
+func TestTheShutdownGateIsRaceFree(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 12; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 40; j++ {
+				switch (i + j) % 4 {
+				case 0:
+					app.SetPhase(AfterResource, func() {})
+				case 1:
+					app.RunPhase(AfterResource)
+				case 2:
+					app.PhaseSealed(AfterResource)
+				case 3:
+					if i == 7 {
+						app.BeginShutdown()
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/sdk/runtime/shutdown_test.go
+++ b/sdk/runtime/shutdown_test.go
@@ -1,0 +1,352 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/v2/logger"
+	"gorm.io/gorm"
+)
+
+// Cleanup unwinds: the callback registered last is the one most likely to
+// depend on the others, so it goes first. SetShutdown and SetPhase(BeforeExit)
+// register into the same phase, so one pass runs both in one order.
+func TestShutdownCallbacksRunInReverseRegistrationOrder(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var ran []string
+	app.SetShutdown(func(context.Context) { ran = append(ran, "first") })
+	app.SetPhase(BeforeExit, func() { ran = append(ran, "second") })
+	app.SetShutdown(func(context.Context) { ran = append(ran, "third") })
+
+	if err := app.RunShutdown(context.Background()); err != nil {
+		t.Fatalf("RunShutdown returned %v, want nil", err)
+	}
+	if got := strings.Join(ran, ","); got != "third,second,first" {
+		t.Errorf("ran %q, want third,second,first", got)
+	}
+}
+
+// The context is the whole reason for the second signature: a callback that
+// can shorten its work needs to see how much of the budget is left.
+func TestShutdownCallbacksAreGivenTheContext(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var got context.Context
+	app.SetShutdown(func(c context.Context) { got = c })
+
+	if err := app.RunShutdown(ctx); err != nil {
+		t.Fatalf("RunShutdown returned %v, want nil", err)
+	}
+	if got == nil {
+		t.Fatal("the callback was not given a context")
+	}
+	if _, ok := got.Deadline(); !ok {
+		t.Error("the callback's context carries no deadline, so it cannot see the budget")
+	}
+}
+
+// Cleanup must not run twice. Closing a pool a second time is worse than not
+// closing it, which is why this phase is taken and closed in one critical
+// section rather than re-read on every call.
+func TestRunShutdownTwiceDoesNotRunCleanupTwice(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	calls := 0
+	app.SetShutdown(func(context.Context) { calls++ })
+
+	for i := 0; i < 3; i++ {
+		if err := app.RunShutdown(context.Background()); err != nil {
+			t.Fatalf("RunShutdown returned %v, want nil", err)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("the cleanup ran %d times, want 1", calls)
+	}
+}
+
+// Concurrent callers must not each get a copy of the batch either.
+func TestConcurrentRunShutdownRunsTheCleanupOnce(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	var mu sync.Mutex
+	calls := 0
+	for i := 0; i < 3; i++ {
+		app.SetShutdown(func(context.Context) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls++
+		})
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = app.RunShutdown(context.Background())
+		}()
+	}
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 3 {
+		t.Errorf("three callbacks ran %d times in total across eight concurrent calls, want 3", calls)
+	}
+}
+
+// Registering after the phase has run is refused and reported: the callback
+// would otherwise sit in a slice nobody walks again, and the thing it was
+// meant to clean up would never be cleaned up.
+func TestSetShutdownAfterTheRunIsRefusedAndReported(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	_ = app.RunShutdown(context.Background())
+
+	late := false
+	app.SetShutdown(func(context.Context) { late = true })
+	_ = app.RunShutdown(context.Background())
+
+	if late {
+		t.Error("a callback registered after RunShutdown ran anyway")
+	}
+	errors := rec.only(logger.ErrorLevel)
+	if len(errors) != 1 {
+		t.Fatalf("want one error line for the late registration, got %v", errors)
+	}
+	for _, want := range []string{"SetShutdown", "RunShutdown", "shutdown_test.go"} {
+		if !strings.Contains(errors[0], want) {
+			t.Errorf("the report must name %q, got:\n%s", want, errors[0])
+		}
+	}
+}
+
+// When the budget runs out the wait ends and the work does not. The caller
+// gets ctx.Err() promptly, the callback that is holding things up is named,
+// and it carries on - which is the honest description of what Go can do to a
+// function that does not check its context.
+func TestRunShutdownStopsWaitingWhenTheBudgetRunsOut(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	release := make(chan struct{})
+	finished := make(chan struct{})
+	ran := make(chan string, 2)
+
+	app.SetShutdown(func(context.Context) { ran <- "registered-first" })
+	app.SetShutdown(func(context.Context) {
+		ran <- "the-slow-one"
+		<-release
+		close(finished)
+	}, WithName("slow-drain"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	returned := make(chan error, 1)
+	go func() { returned <- app.RunShutdown(ctx) }()
+
+	var err error
+	select {
+	case err = <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunShutdown did not return when its budget ran out")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("RunShutdown returned %v, want context.DeadlineExceeded", err)
+	}
+
+	reports := rec.only(logger.ErrorLevel)
+	if len(reports) != 1 {
+		t.Fatalf("want one report naming the callback that ran out the budget, got %v", reports)
+	}
+	for _, want := range []string{"slow-drain", "shutdown_test.go", "budget"} {
+		if !strings.Contains(reports[0], want) {
+			t.Errorf("the report must contain %q, got:\n%s", want, reports[0])
+		}
+	}
+
+	// What was abandoned is the wait. The callback is still there, and it
+	// finishes - along with the ones behind it - if it ever gets going.
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the abandoned callback did not carry on")
+	}
+	select {
+	case <-time.After(2 * time.Second):
+		t.Fatal("the callbacks behind the slow one never ran")
+	case got := <-ran:
+		if got != "the-slow-one" {
+			t.Errorf("the first callback to run was %q, want the-slow-one (reverse order)", got)
+		}
+	}
+}
+
+// With nothing registered there is nothing to wait for, so there is no
+// goroutine, the context is never consulted, and an expired budget is not
+// reported as a timeout for work that does not exist.
+func TestRunShutdownWithNothingRegisteredIsNotATimeout(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the budget is gone before the call
+
+	if err := app.RunShutdown(ctx); err != nil {
+		t.Errorf("RunShutdown with nothing registered returned %v, want nil", err)
+	}
+}
+
+// WithFatal is stripped here and reported. Exiting from inside cleanup skips
+// every callback after it - the opposite of what the option is for - but
+// refusing the registration would mean one mistyped option silently costs
+// the whole cleanup.
+func TestWithFatalOnAShutdownCallbackIsStrippedAndReported(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	previous := exit
+	t.Cleanup(func() { exit = previous })
+	exited := false
+	exit = func(int) { exited = true }
+
+	after := false
+	app.SetShutdown(func(context.Context) { after = true })
+	app.SetShutdown(func(context.Context) { panic("boom") }, WithFatal(), WithName("pool-close"))
+
+	registration := rec.only(logger.ErrorLevel)
+	if len(registration) != 1 {
+		t.Fatalf("want one report at the registration site, got %v", registration)
+	}
+	for _, want := range []string{"WithFatal", "pool-close", "shutdown_test.go"} {
+		if !strings.Contains(registration[0], want) {
+			t.Errorf("the report must contain %q, got:\n%s", want, registration[0])
+		}
+	}
+
+	if err := app.RunShutdown(context.Background()); err != nil {
+		t.Fatalf("RunShutdown returned %v, want nil", err)
+	}
+	if exited {
+		t.Error("a shutdown callback marked WithFatal exited the process anyway")
+	}
+	if !after {
+		t.Error("the cleanup registered before the fatal one never ran")
+	}
+
+	// The option is dropped, the callback is not: refusing the registration
+	// would mean one mistyped option costs the cleanup entirely, and nothing
+	// afterwards would ever say so.
+	reports := rec.only(logger.ErrorLevel)
+	if len(reports) != 2 {
+		t.Fatalf("want the registration report and the panic report, got %v", reports)
+	}
+	for _, want := range []string{"panicked", "pool-close"} {
+		if !strings.Contains(reports[1], want) {
+			t.Errorf("the callback was kept, so its panic must be reported with %q, got:\n%s", want, reports[1])
+		}
+	}
+}
+
+// The guard covers this phase like the others: one callback panicking does
+// not cost the rest.
+func TestPanicInOneShutdownCallbackDoesNotStopTheRest(t *testing.T) {
+	app := NewConfig()
+	rec := captureLogs(t, app)
+
+	var ran []string
+	app.SetShutdown(func(context.Context) { ran = append(ran, "first") })
+	app.SetShutdown(func(context.Context) { panic("boom") })
+	app.SetShutdown(func(context.Context) { ran = append(ran, "third") })
+
+	if err := app.RunShutdown(context.Background()); err != nil {
+		t.Fatalf("RunShutdown returned %v, want nil", err)
+	}
+	if got := strings.Join(ran, ","); got != "third,first" {
+		t.Errorf("ran %q, want third,first", got)
+	}
+	if reports := rec.only(logger.ErrorLevel); len(reports) != 1 {
+		t.Errorf("want one panic report, got %v", reports)
+	}
+}
+
+// Cleanup calls back into Application - a hook that closes the database asks
+// for it first - and sync.RWMutex is not reentrant.
+func TestShutdownCallbacksRunWithNoLockHeld(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	reached := false
+	app.SetShutdown(func(context.Context) {
+		app.SetDb(&gorm.DB{})
+		app.GetDb()
+		app.PhaseSealed(BeforeExit)
+		reached = true
+	})
+
+	mustReturn(t, "RunShutdown with a callback that calls back in", func() {
+		_ = app.RunShutdown(context.Background())
+	})
+	if !reached {
+		t.Error("the callback did not get through calling back into Application")
+	}
+}
+
+// A nil context is a bug in the caller, but these callbacks are the cleanup:
+// panicking to report the bug would skip all of them.
+func TestRunShutdownWithANilContextRunsTheCleanup(t *testing.T) {
+	app := NewConfig()
+	captureLogs(t, app)
+
+	ran := false
+	app.SetShutdown(func(context.Context) { ran = true })
+
+	mustReturn(t, "RunShutdown(nil)", func() {
+		//lint:ignore SA1012 passing nil is the caller mistake under test
+		_ = app.RunShutdown(nil)
+	})
+	if !ran {
+		t.Error("a nil context cost the cleanup")
+	}
+}
+
+// The in-process test above uses the exit seam, which returns where os.Exit
+// would not. This one is the real thing: a process that runs a panicking
+// WithFatal cleanup callback has to survive it, run the rest of the cleanup,
+// and leave with status 0.
+func TestShutdownFatalDoesNotTakeTheProcessDown(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=^TestGuardChild$", "-test.v")
+	cmd.Env = append(os.Environ(), childEnv+"=shutdown-fatal")
+	out, err := cmd.CombinedOutput()
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("could not run the child: %v\n%s", err, out)
+		}
+		t.Fatalf("the child exited with %d; a fatal cleanup callback must not take the process down\n%s",
+			exitErr.ExitCode(), out)
+	}
+	for _, want := range []string{"WithFatal ignored", "CLEANUP-AFTER-THE-PANIC", "REACHED-THE-END"} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("the child must print %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/sdk/runtime/type.go
+++ b/sdk/runtime/type.go
@@ -128,4 +128,14 @@ type Runtime interface {
 	// AppRoutersSealed reports whether RunAppRouters has run, i.e. whether a
 	// further SetAppRouters would be dropped.
 	AppRoutersSealed() bool
+
+	// SetPhase registers a callback to run when the application reaches the
+	// given life-cycle phase.
+	SetPhase(p Phase, f func(), opts ...CallbackOption)
+	// RunPhase executes the callbacks registered for a phase that have not
+	// run yet, in registration order.
+	RunPhase(p Phase)
+	// PhaseSealed reports whether a phase has already run, i.e. whether a
+	// further SetPhase for it would be dropped.
+	PhaseSealed(p Phase) bool
 }

--- a/sdk/runtime/type.go
+++ b/sdk/runtime/type.go
@@ -139,6 +139,9 @@ type Runtime interface {
 	// PhaseSealed reports whether a phase has already run, i.e. whether a
 	// further SetPhase for it would be dropped.
 	PhaseSealed(p Phase) bool
+	// BeginShutdown says the application is on its way out: SetPhase and
+	// RunPhase stop doing anything for every phase but BeforeExit.
+	BeginShutdown()
 	// SetShutdown registers a cleanup callback for the BeforeExit phase,
 	// taking the context that carries the shutdown budget.
 	SetShutdown(f func(context.Context), opts ...CallbackOption)

--- a/sdk/runtime/type.go
+++ b/sdk/runtime/type.go
@@ -3,10 +3,11 @@
 package runtime
 
 import (
-	"github.com/gin-gonic/gin"
+	"context"
 	"net/http"
 
 	"github.com/casbin/casbin/v3"
+	"github.com/gin-gonic/gin"
 	"github.com/go-admin-team/go-admin-core/v2/logger"
 	"github.com/go-admin-team/go-admin-core/v2/storage"
 	"github.com/robfig/cron/v3"
@@ -138,4 +139,10 @@ type Runtime interface {
 	// PhaseSealed reports whether a phase has already run, i.e. whether a
 	// further SetPhase for it would be dropped.
 	PhaseSealed(p Phase) bool
+	// SetShutdown registers a cleanup callback for the BeforeExit phase,
+	// taking the context that carries the shutdown budget.
+	SetShutdown(f func(context.Context), opts ...CallbackOption)
+	// RunShutdown runs the BeforeExit callbacks in reverse registration
+	// order, returning ctx.Err() if the context ends first.
+	RunShutdown(ctx context.Context) error
 }


### PR DESCRIPTION
> 批次 005 的 core 侧。配套的宿主改动见 go-admin#903（可独立合并）与后续的接线 PR。
> PRD 与技术方案在仓库外的 `docs-prd/005-生命周期与优雅关闭/`。

004 给了两个能自己执行的注册表，但它们是**两个点**，不是一条生命周期。这批回答的是：一个应用模块想在「数据库好了之后」或「服务停下来之前」做点什么，往哪挂。

## 四个阶段，不是五个

```go
const (
    AfterResource Phase = 10 // db/cache/queue/casbin 就绪（可重入）
    BeforeRouter  Phase = 20
    AfterListen   Phase = 30 // socket 确实在 accept 之后
    BeforeExit    Phase = 40
)
```

初稿有第五个 `AfterConfig`，砍掉了：它承诺的「配置可用」在 `config.Setup` 返回后本来就到处可用，而它最容易被误读成「可以拿 db 了」。**加得进来，删不掉**——宁可少一个。

数值显式赋值 10/20/30/40 而不用 `iota`，留出空档；契约同时写明**数值不是契约的一部分**，不得持久化或传输。

## 三处值得单独说的设计

### `AfterResource` 可重入，而「幂等」的定义与直觉相反

它在**每次**配置热更新后重跑，因为热更新重建了它命名的那些资源。所以钩子必须是**对同一份资源幂等**，不是「第二次什么都不做」——队列消费者恰恰**必须**在 reload 后再起一个 goroutine，因为 adapter 是新的。可实现判据：记住上次见过的实例，没变就返回。

两条连带承诺写进了契约：

- **`RunPhase(AfterResource)` 不是同步的。** 轮次串行化：一轮在跑时到达的调用只标记「还欠一轮」并立即返回。
- **触发永不丢弃。** 「已在跑就丢弃」是错的——第二次变更的 adapter 可能是第一轮取完快照**之后**才换上去的，丢弃 = 新 adapter 零消费者 = **正好是 issue #892 的形状**。

registry 永不封闭，所以只增不减。**跨轮条目增长会 WARN**——这是唯一能自动发现「钩子不幂等」的信号。

### 关闭反序，且 context 界定的是等待不是工作

`SetShutdown` 是同一个阶段的「要 ctx」的那一半：两者注册进同一个 registry，一趟反序跑完。

初稿把 `BeforeExit` 常量和 `SetShutdown`/`RunShutdown` 分成两套，而接线只调 `RunShutdown`——那样 `SetPhase(BeforeExit, f)` 就是一个写在文档里、躺在 `api/core.txt` 里、**永远没人跑**的挂载点。合并掉了。

预算用尽时 `RunShutdown` 停止等待并返回 `ctx.Err()`，**而正在跑的那个回调会继续跑到进程退出**，可能留下写了一半的东西。Go 无法取消一个不检查取消的函数——这正是给回调发 context 的原因。这条写进了 doc comment。

`WithFatal` 在关闭阶段不生效：从清理内部退出会跳过它后面**所有**回调，方向正好反了。**收下回调、清掉标志、记 ERROR 指名注册点**——直接拒绝注册等于一个手滑的 option 让你整个清理都不跑，那又是一个静默失败。

### `BeginShutdown` 与它的豁免

关闭窗口里来一次配置热更新，会重跑 `AfterResource`——重建连接池和队列 adapter、重新注册消费者，**把刚做完的清理原地撤销**。置位后 `SetPhase`/`RunPhase` 对除 `BeforeExit` 外的所有阶段停止工作。

**`BeforeExit` 必须豁免**，因为这道闸就在关闭路径第一步置位——一视同弹地拦所有阶段，它就会跳过自己要保护的那批清理。两条测试钉住（`RunShutdown` 与 `RunPhase(BeforeExit)` 两种写法各一）。

拒绝时记 **WARN 不是 ERROR**：关闭窗口内的 reload 是这道闸**设计上就要赢的竞态**，不是谁写错了。把设计内的正常结果记成 ERROR，就是在训练读者跳过 ERROR 行。

## `SetupConfig` 为什么在新包里

`config.Setup` 在宿主有 4 个调用点，其中 3 个是 CLI（`migrate` ×2、`config`）——**在只跑迁移的命令里挂起队列消费者和缓存预热是错的**。所以顺序保证由 core 持有，`config.Setup` 本身保持不触发。

原计划放 `package sdk`，但那条路有环：`sdk/config/hotreload_test.go` import 了 `sdk`。

```
go build ./...   退出码 0     ← 绿的
go vet  ./...    退出码 1     ← import cycle not allowed in test
```

**`go build` 看不见测试期依赖环。** 放进 `sdk/config` 也不行：它会让该包的传递依赖从 254 涨到 356，而 `sdk/contract/actions` 正好 import 它——等于把 gin/casbin/gorm/cron 塞回 006 刚为第三方应用下沉的契约面。所以新建叶子包 `sdk/bootstrap`，只有一个函数，没人 import 它，对现有依赖图零影响。

## 验证

7 条提交，**逐条单独 checkout 验过** build / vet / test / `api-check` / staticcheck(darwin+linux)，无中间红。

**31 条反证**逐条把行为改回错误实现并确认对应测试变红。其中：

- 2 条第一次**编译失败**（import 未使用），按纪律不算数，重写成可编译版本重跑；
- 2 条第一次**没跑红，是测试不够硬**——`SetPhase` 那道闸的价值被 `RunPhase` 的闸掩盖了，需要白盒断言才能钉住它独有的作用；「腰斩正在跑的一轮」的断裂点在下一次循环开头，只注册一个回调物理上触发不到。改的是测试不是被测对象。

33 个包 `-race -short` 通过，`make lint`（staticcheck darwin+linux）无输出，`make api-check` 干净（快照 1816 → 1837 行），`check-language: ok`。

## 文档

`docs/contract.md` 第 12 节。最后一小节专写**这些钩子做不到什么**：

- **不能冲刷队列**——`Memory.Shutdown` 不排空，`BeforeExit` 回调没有可调用的东西。需要日志不丢的部署不要依赖本阶段。
- **不能做 LB 摘流**——唯一的挂载点在 HTTP 停止接收**之后**，而 k8s 要求 readiness 先失败。

不写含糊的「不保证」——无承诺的话没人会据此反推自己的钩子是空转。

`docs/known-issues.md` 新增 5 笔立案，包括**为什么直接 `close(q)` 修不了消费者泄漏**：消费者失败时会 sleep 后把消息重投回同一 channel，往已关闭的 channel 发送会 panic，**比它要修的问题更糟**。顺序必须是「先停生产 → 排空 → 再关」。
