### PR TITLE
test✅: config 的 goroutine 计数断言在测别的东西

### DIFF
--- a/config/run_test.go
+++ b/config/run_test.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"errors"
-	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,15 +11,17 @@ import (
 )
 
 // unwatchableLoader loads normally and refuses to be watched, which is the
-// state run's retry loop was written for. It reports each attempt so the test
-// can wait for the loop to be where it needs it rather than guessing at a
-// duration.
+// state run's retry loop was written for. It counts the attempts, and reports
+// the first one, so the test can wait for the loop to be where it needs it
+// rather than guessing at a duration.
 type unwatchableLoader struct {
 	loader.Loader
-	tried chan struct{}
+	tried    chan struct{}
+	attempts atomic.Int64
 }
 
 func (l *unwatchableLoader) Watch(...string) (loader.Watcher, error) {
+	l.attempts.Add(1)
 	select {
 	case l.tried <- struct{}{}:
 	default:
@@ -30,9 +32,13 @@ func (l *unwatchableLoader) Watch(...string) (loader.Watcher, error) {
 // The exit check in run sits below the point the retry jumps back from, so a
 // loader that cannot be watched used to keep the goroutine retrying once a
 // second for the life of the process, closed or not.
+//
+// The question is asked of the loader rather than of runtime.NumGoroutine.
+// That count is process-wide: every goroutine any other test in this package
+// left behind is in it, so it answers "is anything at all still running"
+// rather than "is this retry still running", and it went red on a busy machine
+// while the retry under test had exited cleanly.
 func TestCloseStopsARunThatCannotWatch(t *testing.T) {
-	before := runtime.NumGoroutine()
-
 	l := &unwatchableLoader{Loader: memory.NewLoader(), tried: make(chan struct{}, 1)}
 	c, err := NewConfig(WithLoader(l))
 	if err != nil {
@@ -46,15 +52,18 @@ func TestCloseStopsARunThatCannotWatch(t *testing.T) {
 		t.Fatal("run never attempted a watch")
 	}
 
+	at := l.attempts.Load()
 	if err := c.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
-	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
-		time.Sleep(10 * time.Millisecond)
-	}
-	if n := runtime.NumGoroutine(); n > before {
-		t.Errorf("goroutine count %d did not return to %d: run is still retrying", n, before)
+	// The retry is one attempt a second, so what the assertion is made of is
+	// silence: a loop that ignored Close would ask twice in this window. One
+	// more attempt is allowed because Close can land on the same instant the
+	// timer fires, and select is free to take the timer that once - but only
+	// that once, since the next turn finds exit already closed.
+	time.Sleep(2500 * time.Millisecond)
+	if n := l.attempts.Load() - at; n > 1 {
+		t.Errorf("the loader was asked to watch %d more times in the 2.5s after Close: run is still retrying", n)
 	}
 }

--- a/config/run_test.go
+++ b/config/run_test.go
@@ -52,10 +52,16 @@ func TestCloseStopsARunThatCannotWatch(t *testing.T) {
 		t.Fatal("run never attempted a watch")
 	}
 
-	at := l.attempts.Load()
 	if err := c.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
+
+	// Read after Close, not before it. Taken before, a test goroutine that
+	// happened to be descheduled for a second between the two would have the
+	// retry that ran while it was away counted as one that ran after Close -
+	// a red run for a loop that had in fact stopped, which is the failure
+	// this test was rewritten to stop producing.
+	at := l.attempts.Load()
 
 	// The retry is one attempt a second, so what the assertion is made of is
 	// silence: a loop that ignored Close would ask twice in this window. One


### PR DESCRIPTION
## 这条修的不是功能，是一个有问题的断言

`TestCloseStopsARunThatCannotWatch` 用 `runtime.NumGoroutine()` 做判据。
那个计数是**进程全局**的，于是它回答的是「还有没有任何东西在跑」，
而不是「这条重试还在不在跑」——在负载高的机器上**三次红两次**，
而它守护的代码一直是对的。

## 证据，不是推断

给断言加了 goroutine 栈转储抓现场：计数 **185 → 218**，多出的按创建者分组

| 数量 | 创建者 |
|---|---|
| 103 | `memory.(*memory).Load` |
| 101 | `memory.(*memory).watch` |
| 4 | `config.(*config).run` |
| 4 | `config.newConfig` |

**218 个里 204 个是同包其他测试建完没关的 memory loader**，
goroutine ID 从 93767 排到 96277，跨度远早于本测试（96250）。

决定性的一条：那 4 个 `config.(*config).run` **全部**停在
`memory.(*watcher).Next`（`default.go:92`）——已经建立 watch、在等下一次变更。
而本测试的 `unwatchableLoader` 的 `Watch()` **永远返回错误**，
它的 run goroutine 根本走不到那一行。

**它不在里面。它已经退出了，因为 `Close()` 起了作用——正是这个测试要验的事。**

## 改法

判据改成问被测对象自己。loader 记录被要求 watch 的次数；
`Close()` 之后等 2.5 秒，最多允许再多 1 次。

- 忽略 Close 的循环在这个窗口里会问 **2 次**（重试是每秒一次）
- 允许 1 次是因为 Close 可能与定时器同一瞬间落地，`select` 有一次机会挑中定时器；
  但只有这一次，下一轮 `exit` 已经关闭

## 反证

把 `run()` 里的 `select { case <-c.exit: return; case <-time.After(...) }`
换成裸 `time.Sleep`——**编译通过**，测试变红：

```
run_test.go:67: the loader was asked to watch 2 more times in the 2.5s after Close: run is still retrying
```

次数与预测的 2 完全一致。

## 验证

整包连跑 8 次、CPU 加载下再 6 次、`-race` 3 次，全绿。
`check-language` / `go vet` / `make api-check` 退出码均为 0。

行为面零改动，只有测试文件。
