### PR TITLE
docs📝: 第 6 条（单租户 cron）已修，标记状态

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -68,10 +68,18 @@ watcher goroutine on each reload, while every log call in the process reads it
 without a lock. An interface value is two words; a torn read is a crash, not a
 stale line. It is a bare exported variable, so the fix is not local.
 
-## 6. Only the first tenant gets a cron scheduler
+## 6. Only the first tenant gets a cron scheduler - fixed
 
-`app/jobs`'s `Setup` loops over the tenant databases calling `setup`, and
-`setup` ends in `select {}` and never returns. With more than one entry under
-`databases:`, the loop never reaches the second one. The same `select {}` also
-makes the `defer crontab.Stop()` above it unreachable, so the scheduler has
-never been stopped on the way out either.
+Kept as a record rather than deleted: this one was filed against go-admin from
+here because the phase work exposed it, and a reader who met the symptom before
+the fix should be able to find out what happened to it.
+
+`app/jobs`'s `Setup` looped over the tenant databases calling `setup`, and
+`setup` ended in `select {}` and never returned. With more than one entry under
+`databases:`, the loop never reached the second one. The same `select {}` also
+made the `defer crontab.Stop()` above it unreachable, so the scheduler was never
+stopped on the way out either.
+
+Fixed in go-admin by deleting the `select {}`, which was blocking for nothing -
+`cron.Start` is itself `go c.run()`. The stop became a `BeforeExit` callback
+that waits on the context `cron.Stop()` returns, bounded by the shutdown budget.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -80,6 +80,8 @@ the fix should be able to find out what happened to it.
 made the `defer crontab.Stop()` above it unreachable, so the scheduler was never
 stopped on the way out either.
 
-Fixed in go-admin by deleting the `select {}`, which was blocking for nothing -
-`cron.Start` is itself `go c.run()`. The stop became a `BeforeExit` callback
-that waits on the context `cron.Stop()` returns, bounded by the shutdown budget.
+Fixed in
+[go-admin-team/go-admin#906](https://github.com/go-admin-team/go-admin/pull/906)
+by deleting the `select {}`, which was blocking for nothing - `cron.Start` is
+itself `go c.run()`. The stop became a `BeforeExit` callback that waits on the
+context `cron.Stop()` returns, bounded by the shutdown budget.


### PR DESCRIPTION
第 6 条记的是 go-admin 侧的缺陷——`app/jobs` 的 `setup` 以 `select {}` 结尾、
永不返回，于是租户循环走不到第二个库，上一行的 `defer crontab.Stop()` 也不可达。
它是本仓的阶段工作暴露出来的，所以记在这里。

go-admin 已经修掉（#906）：删掉那个 `select {}`（`cron.Start` 本来就是
`go c.run()`，它在白挡），停止改为 `BeforeExit` 回调，等待 `cron.Stop()`
返回的 context，受关闭预算约束。

已核实 master 上的状态，不是凭"改过那段代码"下的结论：
`select {}` 只剩注释里的引用，`SetShutdown` 在位，循环体完整。

**标记而不是删除。** 在旧版本上撞见过这个症状的人，应该能查到它后来怎么了；
而一个只增不减的清单是没人会看第二遍的。
