### PR TITLE
fix🐛: 队列关闭时丢消息、且消费者永不退出

### DIFF
--- a/storage/queue/memory.go
+++ b/storage/queue/memory.go
@@ -166,7 +166,7 @@ func (m *Memory) consume(out queue, gf storage.ConsumerFunc, message storage.Mes
 		return
 	}
 	message.SetErrorCount(message.GetErrorCount() + 1)
-	// 每次间隔时长放大
+	// The back-off widens with each attempt.
 	time.Sleep(time.Second * time.Duration(message.GetErrorCount()))
 	select {
 	case out <- message:

--- a/storage/queue/memory.go
+++ b/storage/queue/memory.go
@@ -18,6 +18,7 @@ func NewMemory(poolNum uint) *Memory {
 	return &Memory{
 		queue:   new(sync.Map),
 		PoolNum: poolNum,
+		stop:    make(chan struct{}),
 	}
 }
 
@@ -27,6 +28,20 @@ type Memory struct {
 	mutex   sync.RWMutex
 	PoolNum uint
 	running bool // 标记队列是否已启动
+
+	// closed is set by Shutdown. Append refuses from then on, so nothing new
+	// arrives behind the drain.
+	closed bool
+	// stop is closed by Shutdown and is what tells each consumer to drain and
+	// return. The channels themselves are never closed: Append publishes with
+	// a non-blocking send and the retry path re-publishes, so closing
+	// underneath either one panics the process during shutdown - which is
+	// worse than the leak this replaces.
+	stop chan struct{}
+	// consumers counts the goroutines Register started, so Shutdown can wait
+	// for their drains to finish rather than return while messages are still
+	// buffered.
+	consumers sync.WaitGroup
 }
 
 func (*Memory) String() string {
@@ -68,6 +83,9 @@ func (m *Memory) queueFor(name string) queue {
 func (m *Memory) Append(message storage.Messager) error {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
+	if m.closed {
+		return storage.ErrQueueClosed
+	}
 	memoryMessage := new(Message)
 	memoryMessage.SetID(message.GetID())
 	memoryMessage.SetStream(message.GetStream())
@@ -93,25 +111,68 @@ func (m *Memory) Append(message storage.Messager) error {
 }
 
 func (m *Memory) Register(name string, f storage.ConsumerFunc) {
-	m.mutex.RLock()
-	defer m.mutex.RUnlock()
+	m.mutex.Lock()
+	if m.closed {
+		// Nothing will ever be published to it and nothing would stop it.
+		m.mutex.Unlock()
+		return
+	}
 	q := m.queueFor(name)
+	stop := m.stop
+	// Counted while holding the lock Shutdown takes, so a Register racing a
+	// Shutdown either joins the group before Wait or is refused above.
+	m.consumers.Add(1)
+	m.mutex.Unlock()
+
 	go func(out queue, gf storage.ConsumerFunc) {
-		var err error
-		for message := range q {
-			err = gf(message)
-			if err != nil {
-				if message.GetErrorCount() < 3 {
-					message.SetErrorCount(message.GetErrorCount() + 1)
-					// 每次间隔时长放大
-					i := time.Second * time.Duration(message.GetErrorCount())
-					time.Sleep(i)
-					out <- message
+		defer m.consumers.Done()
+		for {
+			select {
+			case message := <-out:
+				m.consume(out, gf, message, true)
+			case <-stop:
+				// Deliver what is already buffered, then stop. This is the
+				// only place the messages accepted before Shutdown can still
+				// be handled - the process usually exits as soon as Shutdown
+				// returns, which is why Shutdown waits for this loop.
+				for {
+					select {
+					case message := <-out:
+						m.consume(out, gf, message, false)
+					default:
+						return
+					}
 				}
-				err = nil
 			}
 		}
 	}(q, f)
+}
+
+// consume runs one message through the handler, retrying up to three times
+// while the queue is still open.
+//
+// retry is false during the drain. Re-publishing there would put the message
+// back into the channel this loop is emptying, so the drain would either never
+// finish or hold the shutdown open for the back-off sleep on every failure.
+//
+// The re-publish is a non-blocking send. The blocking one it replaces could
+// deadlock a consumer against its own full queue - it is the only reader, so
+// nothing would ever make room.
+func (m *Memory) consume(out queue, gf storage.ConsumerFunc, message storage.Messager, retry bool) {
+	if err := gf(message); err == nil || !retry {
+		return
+	}
+	if message.GetErrorCount() >= 3 {
+		return
+	}
+	message.SetErrorCount(message.GetErrorCount() + 1)
+	// 每次间隔时长放大
+	time.Sleep(time.Second * time.Duration(message.GetErrorCount()))
+	select {
+	case out <- message:
+	default:
+		log.Printf("memory queue for stream %s is full, dropping a retried message", message.GetStream())
+	}
 }
 
 func (m *Memory) Run() {
@@ -127,13 +188,33 @@ func (m *Memory) Run() {
 	m.wait.Wait()
 }
 
+// Shutdown stops the queue and returns once the consumers have delivered what
+// was already accepted.
+//
+// It used to release Run's wait group and return, leaving every consumer
+// goroutine blocked on a channel that was never closed - one leaked per
+// consumer per rebuild, and the messages still buffered were lost when the
+// process exited. Waiting is the point: a caller shuts a queue down because it
+// is about to stop, so anything not delivered by the time this returns is not
+// delivered at all.
 func (m *Memory) Shutdown() {
 	m.mutex.Lock()
-	defer m.mutex.Unlock()
+	if m.closed {
+		m.mutex.Unlock()
+		return
+	}
+	m.closed = true
 
 	// 只有在运行状态才调用 Done()
 	if m.running {
 		m.running = false
 		m.wait.Done()
 	}
+	stop := m.stop
+	m.mutex.Unlock()
+
+	if stop != nil {
+		close(stop)
+	}
+	m.consumers.Wait()
 }

--- a/storage/queue/memory_shutdown_test.go
+++ b/storage/queue/memory_shutdown_test.go
@@ -1,0 +1,159 @@
+package queue
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/v2/storage"
+)
+
+func memMsg(stream string) storage.Messager {
+	m := new(Message)
+	m.SetStream(stream)
+	m.SetValues(map[string]interface{}{"a": "b"})
+	return m
+}
+
+// Shutdown has to deliver what the queue already accepted before it returns.
+//
+// It used to release Run's wait group and return immediately, which read as
+// harmless in a test - the consumer goroutines were still alive, because
+// nothing stopped them, so they carried on and the messages arrived. In a
+// process it is total loss: Shutdown returning is the last thing that happens
+// before the process exits, and those goroutines go with it.
+//
+// So the count is read the instant Shutdown returns. Sleeping first measures
+// the leak, not the fix.
+func TestShutdownDeliversWhatIsStillBuffered(t *testing.T) {
+	m := NewMemory(64)
+
+	var delivered atomic.Int64
+	m.Register("t", func(storage.Messager) error {
+		time.Sleep(20 * time.Millisecond) // slow enough that a backlog forms
+		delivered.Add(1)
+		return nil
+	})
+
+	const n = 20
+	for i := 0; i < n; i++ {
+		if err := m.Append(memMsg("t")); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+	go m.Run()
+
+	m.Shutdown()
+
+	if got := delivered.Load(); got != n {
+		t.Errorf("Shutdown returned with %d of %d messages undelivered", int64(n)-got, n)
+	}
+}
+
+// Nothing may be delivered after Shutdown returns.
+//
+// This is the observable half of "the consumers are gone": a goroutine that
+// survived would keep reading its channel, and a later Append would reach a
+// handler on a queue the caller believes is shut. It is asserted through
+// behaviour rather than through a goroutine count, which is process-wide and
+// answers "is anything still running" rather than "is this still running".
+func TestNothingIsDeliveredAfterShutdownReturns(t *testing.T) {
+	m := NewMemory(64)
+
+	var delivered atomic.Int64
+	m.Register("t", func(storage.Messager) error {
+		delivered.Add(1)
+		return nil
+	})
+	go m.Run()
+
+	if err := m.Append(memMsg("t")); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	m.Shutdown()
+	at := delivered.Load()
+
+	// A closed queue refuses new work, which is the first half of why nothing
+	// more can arrive.
+	if err := m.Append(memMsg("t")); !errors.Is(err, storage.ErrQueueClosed) {
+		t.Errorf("Append after Shutdown returned %v, want %v", err, storage.ErrQueueClosed)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if now := delivered.Load(); now != at {
+		t.Errorf("%d messages were delivered after Shutdown returned", now-at)
+	}
+}
+
+// A consumer that survived Shutdown would still be reading its channel, and
+// that is directly observable from inside the package: put a message into the
+// channel by hand and see whether anything takes it.
+//
+// This replaces a runtime.NumGoroutine comparison, which was in this file
+// briefly and failed - the count is process-wide, so goroutines other tests in
+// this binary left behind sit in the baseline and it never comes back down. It
+// answers "is anything still running" rather than "is this still running".
+func TestShutdownLeavesNoConsumerReadingTheChannel(t *testing.T) {
+	m := NewMemory(8)
+
+	var delivered atomic.Int64
+	m.Register("t", func(storage.Messager) error {
+		delivered.Add(1)
+		return nil
+	})
+	go m.Run()
+	m.Shutdown()
+
+	at := delivered.Load()
+
+	// Straight into the channel, bypassing Append, which now refuses. Only a
+	// consumer goroutine still in its loop could take this.
+	ch := m.queueFor("t")
+	select {
+	case ch <- memMsg("t"):
+	default:
+		t.Fatal("could not place a message in the channel; the test proves nothing")
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	if now := delivered.Load(); now != at {
+		t.Errorf("a consumer took %d message(s) after Shutdown: it is still running", now-at)
+	}
+}
+
+// Shutting a queue down twice must not panic on a channel already closed, and
+// must not wait a second time.
+func TestShutdownIsIdempotent(t *testing.T) {
+	m := NewMemory(8)
+	m.Register("t", func(storage.Messager) error { return nil })
+	go m.Run()
+
+	m.Shutdown()
+	done := make(chan struct{})
+	go func() { m.Shutdown(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the second Shutdown blocked")
+	}
+}
+
+// Registering on a queue that is already shut does nothing rather than start a
+// goroutine nothing would ever stop.
+func TestRegisterAfterShutdownStartsNothing(t *testing.T) {
+	m := NewMemory(8)
+	m.Shutdown()
+
+	var delivered atomic.Int64
+	m.Register("t", func(storage.Messager) error {
+		delivered.Add(1)
+		return nil
+	})
+	_ = m.Append(memMsg("t")) // refused, but assert on the handler anyway
+
+	time.Sleep(200 * time.Millisecond)
+	if delivered.Load() != 0 {
+		t.Error("a consumer registered after Shutdown received a message")
+	}
+}

--- a/storage/queue/memqueue.go
+++ b/storage/queue/memqueue.go
@@ -30,10 +30,15 @@ type MemQueue struct {
 	started  bool
 	stopOnce sync.Once
 	stop     chan struct{}
-	// drained is closed by Start when it returns, which is after it has
-	// emptied the buffer. Close waits on it, because inFlight alone cannot
-	// say whether the drain has begun: a Wait taken before the first delivery
-	// of the drain sees a count of zero and returns.
+	// drained is closed by Start when it returns. Close waits on it, because
+	// inFlight alone cannot say whether the drain has begun: a Wait taken
+	// before the drain's first delivery sees a count of zero and returns.
+	//
+	// It means "Start is finished", not "the buffer is empty". Start reached
+	// through Close does drain first, but a Start that returns because its own
+	// context was cancelled leaves whatever is buffered where it is - the
+	// contract calls that cancellation rather than an error, and a caller who
+	// cancels is asking to stop now.
 	drained chan struct{}
 }
 
@@ -159,8 +164,11 @@ func (q *MemQueue) deliver(ctx context.Context, msg storage.Message) {
 		q.mu.RUnlock()
 		return
 	}
-	// Registered while holding the lock Close uses to publish q.closed, so a
-	// counter increment can never race with Close's Wait.
+	// What keeps this increment from racing Close's Wait is that Close waits
+	// on q.drained first, and Start closes that only after its drain has
+	// returned - so every deliver this queue will ever make has already
+	// happened by then. It is no longer the lock: deliver stopped consulting
+	// q.closed when that check turned out to be what discarded the drain.
 	q.inFlight.Add(1)
 	q.mu.RUnlock()
 	defer q.inFlight.Done()

--- a/storage/queue/memqueue.go
+++ b/storage/queue/memqueue.go
@@ -30,6 +30,11 @@ type MemQueue struct {
 	started  bool
 	stopOnce sync.Once
 	stop     chan struct{}
+	// drained is closed by Start when it returns, which is after it has
+	// emptied the buffer. Close waits on it, because inFlight alone cannot
+	// say whether the drain has begun: a Wait taken before the first delivery
+	// of the drain sees a count of zero and returns.
+	drained chan struct{}
 }
 
 var _ storage.Queue = (*MemQueue)(nil)
@@ -48,6 +53,7 @@ func NewMemQueue(size int) *MemQueue {
 		handlers: make(map[string]storage.Handler),
 		messages: make(chan storage.Message, size),
 		stop:     make(chan struct{}),
+		drained:  make(chan struct{}),
 	}
 }
 
@@ -105,12 +111,20 @@ func (q *MemQueue) Publish(ctx context.Context, msg storage.Message) error {
 
 func (q *MemQueue) Start(ctx context.Context) error {
 	q.mu.Lock()
+	if q.closed {
+		q.mu.Unlock()
+		return storage.ErrQueueClosed
+	}
 	if q.started {
 		q.mu.Unlock()
 		return storage.ErrQueueAlreadyStarted
 	}
 	q.started = true
 	q.mu.Unlock()
+
+	// Signals the drain below has finished, which is what Close waits for.
+	defer close(q.drained)
+
 	for {
 		select {
 		case msg := <-q.messages:
@@ -136,7 +150,12 @@ func (q *MemQueue) Start(ctx context.Context) error {
 func (q *MemQueue) deliver(ctx context.Context, msg storage.Message) {
 	q.mu.RLock()
 	h := q.handlers[msg.Topic]
-	if h == nil || q.closed {
+	// Deliberately not gated on q.closed. The drain in Start runs after Close
+	// has set that flag, so refusing here made the drain take every remaining
+	// message out of the buffer and throw it away - the opposite of what the
+	// comment above it promised. Publish is where a closed queue stops
+	// accepting; delivery of what it already accepted is what Close is for.
+	if h == nil {
 		q.mu.RUnlock()
 		return
 	}
@@ -155,8 +174,16 @@ func (q *MemQueue) Close() error {
 	q.stopOnce.Do(func() {
 		q.mu.Lock()
 		q.closed = true
+		started := q.started
 		q.mu.Unlock()
 		close(q.stop)
+
+		// Only if something is consuming. Waiting on a queue nobody started
+		// would block for ever, and there is nothing to drain in that case
+		// anyway - no handler has ever seen a message.
+		if started {
+			<-q.drained
+		}
 	})
 
 	// Start observes q.stop, drains what is already queued and returns on its

--- a/storage/queue/memqueue_drain_test.go
+++ b/storage/queue/memqueue_drain_test.go
@@ -1,0 +1,132 @@
+package queue
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-admin-team/go-admin-core/v2/storage"
+)
+
+// startedQueue returns a queue with a counting handler and a Start already in
+// its loop, so that a test can publish into a running queue rather than into a
+// buffer nobody is reading.
+func startedQueue(t *testing.T, size int) (*MemQueue, *atomic.Int64) {
+	t.Helper()
+	q := NewMemQueue(size)
+
+	var delivered atomic.Int64
+	running := make(chan struct{})
+	var once sync.Once
+	if err := q.Subscribe("t", func(context.Context, storage.Message) error {
+		delivered.Add(1)
+		once.Do(func() { close(running) })
+		return nil
+	}); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	go func() { _ = q.Start(context.Background()) }()
+
+	if err := q.Publish(context.Background(), storage.Message{Topic: "t"}); err != nil {
+		t.Fatalf("publish the first message: %v", err)
+	}
+	select {
+	case <-running:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start never consumed anything")
+	}
+	return q, &delivered
+}
+
+// Close has to deliver what the queue already accepted.
+//
+// It did not. Close set the closed flag and only then signalled the drain, and
+// deliver returned early whenever that flag was set - so the drain took every
+// remaining message out of the buffer and dropped it, which is the opposite of
+// what the comment above the drain said it was for. Twenty published, one
+// delivered.
+//
+// Publish is where a closed queue refuses work. Delivering what it accepted
+// before that is the whole job of Close.
+func TestCloseDeliversWhatIsStillBuffered(t *testing.T) {
+	q, delivered := startedQueue(t, 64)
+
+	const buffered = 20
+	for i := 0; i < buffered; i++ {
+		if err := q.Publish(context.Background(), storage.Message{Topic: "t"}); err != nil {
+			t.Fatalf("publish %d: %v", i, err)
+		}
+	}
+
+	if err := q.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// No sleep: Close returning is the claim under test. If it can return
+	// before the drain has finished, this reads a short count.
+	if got := delivered.Load(); got != buffered+1 {
+		t.Errorf("Close returned with %d of %d messages delivered", got, buffered+1)
+	}
+}
+
+// Close must not report success before the drain has run. inFlight alone
+// cannot carry that: a Wait taken before the drain's first delivery sees a
+// count of zero and returns, so the messages land after the caller has been
+// told the queue is closed - or not at all, if the process is exiting.
+func TestCloseWaitsForTheDrainRatherThanForInFlightAlone(t *testing.T) {
+	q, delivered := startedQueue(t, 64)
+
+	for i := 0; i < 50; i++ {
+		if err := q.Publish(context.Background(), storage.Message{Topic: "t"}); err != nil {
+			t.Fatalf("publish %d: %v", i, err)
+		}
+	}
+	_ = q.Close()
+
+	// Read immediately and again after a pause. If Close waited properly the
+	// two are equal; if it returned early, the second is larger.
+	immediately := delivered.Load()
+	time.Sleep(300 * time.Millisecond)
+	if later := delivered.Load(); later != immediately {
+		t.Errorf("%d more messages were delivered after Close returned: it did not wait for the drain", later-immediately)
+	}
+}
+
+// Closing a queue nobody started must not block. There is nothing to drain -
+// no handler has seen a message - and waiting for a Start that will never come
+// would hang the shutdown it is part of.
+func TestCloseDoesNotBlockOnAQueueThatWasNeverStarted(t *testing.T) {
+	q := NewMemQueue(8)
+	if err := q.Subscribe("t", func(context.Context, storage.Message) error { return nil }); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- q.Close() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close blocked on a queue that was never started")
+	}
+}
+
+// Start after Close is refused rather than quietly starting a consumer on a
+// queue that will never be closed again - the flag Close sets is the same one
+// Publish reads, and a Start that ignored it would leave the drain signal
+// already spent.
+func TestStartAfterCloseIsRefused(t *testing.T) {
+	q := NewMemQueue(8)
+	if err := q.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := q.Start(context.Background()); !errors.Is(err, storage.ErrQueueClosed) {
+		t.Errorf("Start after Close returned %v, want %v", err, storage.ErrQueueClosed)
+	}
+}


### PR DESCRIPTION
`docs/known-issues.md` 第 3 条的一半（`MemQueue`）。

## 缺陷

`Close` 先置 `closed` 再通知排空，而 `deliver` 只要看到这个标志就提前返回。
于是 `Start` 里那段排空**把缓冲区里剩下的消息一条条取出来扔掉**——
和它上面那句注释说的正好相反：

```go
// Drain what is already queued so Close does not lose messages
// that were accepted before it was called.
```

复现与立案时的实测一致：**向运行中的队列投 20 条，只投递了 1 条。**

## 修法

`Publish` 本来就在 `closed` 时拒绝新消息，所以 `deliver` 里那个判断对
「停止收新消息」是多余的；**投递已经收下的消息正是 `Close` 的全部职责**。
去掉它。

只做这一步不够。`inFlight` 说不出「排空有没有开始」——
在排空的第一次投递之前取 `Wait`，计数为零、直接返回，
于是 `Close` 会在消息还在缓冲区里时报告成功，或者干脆丢掉
（关队列的进程通常紧接着就要退出）。

`Start` 返回时关闭一个 `drained` 通道，`Close` 等它。

两个会被这个等待破坏的情况：

- **没人 Start 过的队列**没有东西可排、也没有 Start 可等，`Close` 跳过等待，
  否则会挂在一个永远不会到来的信号上
- **Close 之后再 Start** 返回 `ErrQueueClosed`。否则一个在 `Close` 读到
  `started == false` 之后到达的 `Start`，会在排空信号已经用掉的队列上开始消费

## 反证

两个都编译通过、都跑红：

| 反证 | 报错 |
|---|---|
| 把 `closed` 判断放回 `deliver` | `Close returned with 1 of 21 messages delivered` |
| `Close` 不等 `drained` | 上面那条 + 顺序测试一起红 |

第一条的数字与立案时的实测完全一致。

## 不在本 PR 内

第 3 条的另一半是 legacy 的 `Memory` 队列——它需要第 2 条描述的
per-consumer stop channel，两件事该分开改。

## 验证

`check-language` / `go build` / `go vet` / `make api-check` 退出码均为 0；
`go test ./storage/... -race` 全绿；全仓 32 个包通过
（`tools/database` 需要真实 MySQL，本机连不上，CI 有 service）。



---

## 追加：`Memory` 那一半也在本 PR 里了

原本打算分开，但两者是同一条契约的两个实现，分开合会让 `known-issues`
第 3 条处于"修了一半"的状态。

`Memory` 是 **go-admin 默认部署实际使用的那个**（`QueueConfig.Setup()` 在没有
redis 段时返回 `queue.NewMemory`，不经过 `MemQueue`）。

### 复现过程推翻了我的预期

先写的测试是「Shutdown 后放行消费者、睡一会儿再数」——**20/20 全投递，绿了**。
原因正是泄漏本身：没人停得下那些 goroutine，它们在 Shutdown 之后继续消费，
把消息救了回来。

真正的丢失发生在**进程紧接着退出**时。改成在 `Shutdown` 返回的那一刻读数：**0/20**。

这个缺陷「在测试里几乎看不见，在生产上是全丢」，而看不见的原因恰恰是另一个缺陷。

### 修法

`Shutdown` 置 `closed`（`Append` 开始拒收）→ 关 `stop` → 消费者排空后返回 →
`consumers.Wait()`。

**channel 本身仍然不关。** `Append` 是非阻塞发送、重试路径还会回投，
在它们下面关会在关闭过程中打崩进程——比泄漏更糟，这也是第 2 条自己写明的。

顺带三处：排空期间的重试不回投（否则排空永不结束）；回投改为非阻塞发送
（原来的阻塞发送会让消费者与自己的满队列死锁，它是唯一的读者）；
已关闭的队列上 `Register` 不再启动 goroutine。

### 反证

| 反证 | 结果 |
|---|---|
| `Shutdown` 不等 consumers | `20 of 20 messages undelivered` |
| 保留 stop 但去掉排空 | `18 of 20 undelivered` |
| 消费者完全不理 stop | **挂死，不算干净反证**，已在提交消息里说明不采用 |

### 一个被我删掉的坏测试

泄漏检测最初用 `runtime.NumGoroutine()`——正是本仓 #148 刚修掉的进程全局写法，
当场就红在同包其他测试留下的 goroutine 上。换成确定性的：
Shutdown 之后直接往底层 channel 塞一条消息，只有还在循环里的消费者才可能取走。

本 PR 覆盖 `docs/known-issues.md` 的**第 2 条与第 3 条**。
