### PR TITLE
docs📝: 队列两条已修，另修掉一条不成立的 Kubernetes 表述

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -571,10 +571,12 @@ flag skip the very work it was added to protect.
 
 ### What these phases cannot do
 
-- **They cannot drain the queue.** `Memory.Shutdown` does not deliver what is
-  still buffered, so a `BeforeExit` callback has nothing to call that would
-  flush the log queue. See `known-issues.md`. A deployment that cannot lose
-  audit rows must not rely on this phase for that.
+- **They do not drain the queue on their own.** Since v2.7.0 `Memory.Shutdown`
+  delivers what is still buffered rather than discarding it, so a `BeforeExit`
+  callback now has something to call - but nothing calls it. A host that
+  rebuilds its adapter on reload shuts down the *previous* one; at exit the
+  installed adapter is simply abandoned. A deployment that cannot lose audit
+  rows has to register that shutdown itself. See `known-issues.md`.
 - **They cannot take the process out of a load balancer.** The only hook here
   runs *after* the HTTP server stopped accepting, and Kubernetes expects
   readiness to start failing *before* that so endpoints are withdrawn first.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -578,7 +578,11 @@ flag skip the very work it was added to protect.
   installed adapter is simply abandoned. A deployment that cannot lose audit
   rows has to register that shutdown itself. See `known-issues.md`.
 - **They cannot take the process out of a load balancer.** The only hook here
-  runs *after* the HTTP server stopped accepting, and Kubernetes expects
-  readiness to start failing *before* that so endpoints are withdrawn first.
-  There is no pre-shutdown hook yet; without one, a rolling update can still
-  produce connection refused.
+  runs *after* the HTTP server stopped accepting, so nothing an application
+  registers can be observed by a balancer while the instance is still serving.
+  Failing readiness earlier is the host's job, and on its own it is not
+  enough: Kubernetes withdraws an endpoint when the Pod receives a
+  `deletionTimestamp`, concurrently with SIGTERM and independent of the probe
+  result, and any balancer that does poll needs a delay long enough to see the
+  change. Without a configured delay a rolling update can still produce
+  connection refused.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -17,7 +17,7 @@ instance matching the hard-coded DSN is reachable.
 **Plan:** move the DSN behind an environment variable so the test can run
 against a CI service container instead of being skipped.
 
-## 2. A hot reload leaks the previous queue's consumers
+## 2. A hot reload leaks the previous queue's consumers - fixed
 
 `storage/queue/memory.go`'s `Shutdown` sets a flag and releases its wait
 group. It does not close the per-stream channels, and every consumer started
@@ -36,7 +36,20 @@ during shutdown - worse than the leak. It needs a per-consumer stop channel,
 and the re-publish path has to stop first. **Order: stop publishing, drain,
 then close.**
 
-## 3. Nothing can drain a queue on the way out
+Fixed in
+[go-admin-team/go-admin-core#150](https://github.com/go-admin-team/go-admin-core/pull/150),
+released in v2.7.0. `Memory` gained a `stop` channel and a `consumers` wait
+group: `Shutdown` closes `stop`, each consumer leaves its `range` after
+draining what is buffered, and `Shutdown` returns only once they have all
+returned.
+
+The last step of the order above was dropped rather than implemented. The
+per-stream channels are never closed - a producer holding the adapter across
+the swap would panic on a send, and there is no cheap way to exclude one.
+Leaving them to the garbage collector costs nothing once no consumer is
+reading.
+
+## 3. Nothing can drain a queue on the way out - fixed in core, unused by the host
 
 Neither `Memory.Shutdown` nor `MemQueue.Close` delivers what is still
 buffered. `MemQueue.Close` sets `closed` before it signals its drain loop, and
@@ -49,8 +62,16 @@ Measured: with a consumer blocked and twenty messages published,
 End to end, 227 requests produced zero `sys_opera_log` rows across a shutdown
 that exited 0 and logged "Server exiting" - the successful path.
 
-This is why section 12 of `contract.md` says a `BeforeExit` callback cannot
-flush the queue: today there is nothing for it to call.
+Fixed in
+[go-admin-team/go-admin-core#150](https://github.com/go-admin-team/go-admin-core/pull/150),
+released in v2.7.0. `MemQueue.Close` waits for its drain loop to finish and
+delivers what it holds instead of discarding it; `Memory.Shutdown` waits for
+every consumer to drain its own channel.
+
+**The call still has to come from somewhere.** Nothing shuts the adapter down
+when the process exits - go-admin calls `Shutdown` only on the previous adapter
+during a reload - so the messages buffered at SIGTERM are still lost. Section
+12 of `contract.md` records what changed and what did not.
 
 ## 4. A reload can rebuild resources while the process is shutting down
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -19,6 +19,10 @@ against a CI service container instead of being skipped.
 
 ## 2. A hot reload leaks the previous queue's consumers - fixed
 
+The description below is what the code did before the fix, kept as a record.
+What it says is no longer current behaviour; the fix is at the end of the
+entry.
+
 `storage/queue/memory.go`'s `Shutdown` sets a flag and releases its wait
 group. It does not close the per-stream channels, and every consumer started
 by `Register` is blocked in `for message := range q` on one of them, so none
@@ -50,6 +54,10 @@ Leaving them to the garbage collector costs nothing once no consumer is
 reading.
 
 ## 3. Nothing can drain a queue on the way out - fixed in core, unused by the host
+
+The description below is what the code did before the fix, kept as a record.
+Core no longer behaves this way; what has not changed is that nothing calls
+the drain at exit, which is why this entry is not simply "fixed".
 
 Neither `Memory.Shutdown` nor `MemQueue.Close` delivers what is still
 buffered. `MemQueue.Close` sets `closed` before it signals its drain loop, and


### PR DESCRIPTION
两份文档停在了 #150 之前的状态，另有一条从一开始就不成立。

## 1. known-issues 第 2、3 条已由 #150 修掉（v2.7.0）

清单里仍列为未修。现在按第 6 条的体例标注，保留正文当记录。

两条各有一处**没有按原计划落地**，一并写进去：

- 第 2 条原文写「顺序：停止投递 → 排空 → 关闭」。**最后一步被放弃而不是实现了**——
  跨换挡持有 adapter 的生产者会在 send 上 panic，没有便宜的办法把它排除掉。
  channel 交给 GC，没有消费者在读之后不花任何代价。
- 第 3 条**状态不是「已修」而是「core 修了、宿主没用」**：进程退出时没有任何地方
  关闭已安装的 adapter（go-admin 只在热重载时关掉**上一个**），
  所以 SIGTERM 时缓冲区里的消息照样丢。

## 2. contract.md 第 12 节：`BeforeExit` 现在有东西可调了

原文写「没有任何东西可以调用来排空日志队列」。v2.7.0 之后有了。
没变的是没有人调它，所以那句话改成「不会自己排空」，并写明要谁来注册。

## 3. contract.md 第 12 节：摘除 endpoint 的不是 readiness

原文写「Kubernetes 期望 readiness 在服务器停止接收之前开始失败，这样 endpoint 会先被摘掉」。

**摘除由 Pod 的 `deletionTimestamp` 驱动**，它与 SIGTERM 并发到达，不看探针结果。
提前失败 readiness 仍然是宿主该做的，但它单独不构成窗口——需要有人在轮询，
且需要一个长到轮询能落进来的延迟。按这个说法重写，不再当成一个自己就能生效的机制。

## 验证

`scripts/check-language.sh origin/main` 退出码 0。仅文档改动。
