### PR TITLE
Add sdk/contract/app: an application's manifest, and the one comparator for its version

### DIFF
--- a/api/core.txt
+++ b/api/core.txt
@@ -957,6 +957,20 @@ type DataPermission struct {
 	RoleId    int
 func GetPermissionFromContext(c *gin.Context) *DataPermission
 
+## github.com/go-admin-team/go-admin-core/v2/sdk/contract/app
+func Compare(a, b string) (int, error)
+func Register(m Manifest)
+func Snapshot() map[string]Manifest
+type Manifest struct {
+	Code string
+	Name string
+	Version string
+	Description string
+	Author      string
+	Requires []string
+	Pricing string
+	License string
+
 ## github.com/go-admin-team/go-admin-core/v2/sdk/contract/dto
 func MakeCondition(q interface{}) func(db *gorm.DB) *gorm.DB
 func OrderDest(sort string, desc bool) func(db *gorm.DB) *gorm.DB

--- a/sdk/contract/app/app.go
+++ b/sdk/contract/app/app.go
@@ -1,0 +1,125 @@
+// Package app lets an application declare, once, what it is: a stable
+// identity (Code), a human-readable name and version, and the other
+// applications it depends on. That declaration is what a host's installer
+// reads to answer "what applications exist, and at what version" - a gap
+// PRD 008 (go-admin) calls G1: today an application's existence is only
+// inferred from the migrations it happens to have registered, with no
+// name, version, author, or dependency list recorded anywhere.
+//
+// Code is shared with sdk/contract/migration.ForApp and
+// sdk/contract/seed.SeedMenus: one application, one code, normalized the
+// same way (migration.NormalizeAppCode) so a string typed on a CLI flag
+// matches what all three registries were called with.
+//
+// core does not read Requires, Pricing, or License in this batch - it only
+// carries them. Requires exists so a host's installer can refuse to install
+// an application ahead of its declared dependencies rather than guess at an
+// order; Pricing and License are reserved for a later authorization stage
+// (PRD 003, PRD 008 open question 1) so that a first batch of published
+// applications does not force a breaking change once that stage arrives.
+package app
+
+import (
+	"sync"
+
+	"github.com/go-admin-team/go-admin-core/v2/sdk/contract/migration"
+)
+
+// Manifest is what an application declares about itself once, at process
+// init(), independently of how many migration files or seed.SeedMenus
+// calls it makes.
+type Manifest struct {
+	// Code is the same identifier passed to migration.ForApp(code) and
+	// seed.SeedMenus(tx, appCode, ...). Register normalizes it the same way
+	// migration.ForApp does, so all three registries agree on one spelling
+	// regardless of the case or whitespace the caller wrote it with.
+	Code string
+	// Name is a short, human-readable display name.
+	Name string
+	// Version is a semantic version string; see Compare. It is opaque to
+	// this package outside of that one comparison - core does not
+	// otherwise interpret it.
+	Version string
+	// Description and Author are free-form display text; core does not
+	// interpret either one.
+	Description string
+	Author      string
+	// Requires lists other applications' Code values this application
+	// depends on. core neither validates nor orders installation by this
+	// field in this batch; it only carries it for a host's installer to
+	// read.
+	Requires []string
+
+	// Pricing and License are reserved for a later authorization stage
+	// (PRD 003, PRD 008 open question 1). This package defines the fields
+	// so a first batch of published applications does not force a
+	// breaking change later, and neither reads nor interprets either one.
+	Pricing string
+	License string
+}
+
+// mu guards registry. Registration relies on Go's package-init ordering to
+// be free of concurrent writers, the same convention migration.ForApp and
+// config.RegisterExtend document - the mutex only protects Register racing
+// Snapshot at run time, which should not happen but must not corrupt the
+// map if it does.
+var (
+	mu       sync.Mutex
+	registry = map[string]Manifest{}
+)
+
+// Register claims one application's identity. Call it from init(), before
+// a host's installer runs - the same convention migration.ForApp and
+// config.RegisterExtend use.
+//
+// Code is normalized through migration.NormalizeAppCode, and the empty
+// string or migration.FrameworkAppCode ("core", reserved for the framework
+// itself) are rejected, exactly as migration.ForApp rejects them - this
+// package must not invent a second normalization or reservation rule that
+// quietly diverges from the one three other packages already share.
+//
+// Name and Version are required. Registering the same code twice is a
+// programming error - two applications, or two init() calls for the same
+// application, silently taking turns owning one identity, is worse than a
+// panic naming the offender - and panics immediately, the same convention
+// config.RegisterExtend uses for a duplicate key.
+func Register(m Manifest) {
+	code := migration.NormalizeAppCode(m.Code)
+	switch code {
+	case "":
+		panic("app: Register called with an empty Code")
+	case migration.FrameworkAppCode:
+		panic("app: Register: code " + migration.FrameworkAppCode + " is reserved for the framework")
+	}
+	if m.Name == "" {
+		panic("app: Register: Name is required")
+	}
+	if m.Version == "" {
+		panic("app: Register: Version is required")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if _, dup := registry[code]; dup {
+		panic("app: Register called twice for code " + code)
+	}
+	m.Code = code
+	registry[code] = m
+}
+
+// Snapshot returns a copy of every registered manifest, keyed by Code - the
+// only way a host reads this registry, the same reasoning
+// migration.Registry.Snapshot documents: a copy, not the live map, so a
+// host can iterate it without holding this package's lock across a
+// database call, mutating what it received cannot corrupt the registry,
+// and a Register call made after a Snapshot was taken cannot retroactively
+// appear in it.
+func Snapshot() map[string]Manifest {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make(map[string]Manifest, len(registry))
+	for k, v := range registry {
+		out[k] = v
+	}
+	return out
+}

--- a/sdk/contract/app/app.go
+++ b/sdk/contract/app/app.go
@@ -48,6 +48,13 @@ type Manifest struct {
 	// depends on. core neither validates nor orders installation by this
 	// field in this batch; it only carries it for a host's installer to
 	// read.
+	//
+	// Unlike every other field on Manifest, this one is a reference type:
+	// both Register and Snapshot copy it (see cloneRequires) rather than
+	// storing or returning the caller's slice header, so that mutating a
+	// slice you passed to Register, or one Snapshot handed back, can never
+	// reach the registry. A nil Requires stays nil through both copies,
+	// rather than becoming an empty non-nil slice.
 	Requires []string
 
 	// Pricing and License are reserved for a later authorization stage
@@ -104,6 +111,13 @@ func Register(m Manifest) {
 		panic("app: Register called twice for code " + code)
 	}
 	m.Code = code
+	// Requires is the one field on Manifest that is a reference type: if it
+	// were stored as-is, the caller would still be holding the same slice
+	// header, and mutating it after Register returns would silently rewrite
+	// an already-registered application's dependency list. Clone it into a
+	// slice this package alone holds a reference to, the same reasoning
+	// Snapshot's copy of Requires below documents for the read side.
+	m.Requires = cloneRequires(m.Requires)
 	registry[code] = m
 }
 
@@ -114,12 +128,40 @@ func Register(m Manifest) {
 // database call, mutating what it received cannot corrupt the registry,
 // and a Register call made after a Snapshot was taken cannot retroactively
 // appear in it.
+//
+// Copying the map is not enough on its own: a map holding Manifest values
+// by value still leaves every value's Requires slice pointing at the same
+// backing array the registry itself uses, because copying a struct copies
+// a slice's header, not what the header points to. Without also cloning
+// Requires per entry, a caller mutating one element of a returned
+// snapshot's Requires would reach through to the registry's own copy -
+// and, from there, into every other snapshot ever taken, since they would
+// all still be aliasing that one array. Each returned Manifest gets its
+// own Requires clone below for the same reason Register clones the
+// caller's slice on the write side.
 func Snapshot() map[string]Manifest {
 	mu.Lock()
 	defer mu.Unlock()
 	out := make(map[string]Manifest, len(registry))
 	for k, v := range registry {
+		v.Requires = cloneRequires(v.Requires)
 		out[k] = v
 	}
+	return out
+}
+
+// cloneRequires returns an independent copy of req: a new slice with its
+// own backing array, so neither Register nor Snapshot ever hands out, or
+// stores, a slice header that still aliases a caller's own slice or the
+// registry's. A nil req returns nil rather than an empty non-nil slice, so
+// a Manifest that never set Requires round-trips through Register and
+// Snapshot exactly as the zero value - nil, not []string{} - rather than
+// this package inventing a distinction the caller never made.
+func cloneRequires(req []string) []string {
+	if req == nil {
+		return nil
+	}
+	out := make([]string, len(req))
+	copy(out, req)
 	return out
 }

--- a/sdk/contract/app/app_test.go
+++ b/sdk/contract/app/app_test.go
@@ -150,3 +150,41 @@ func TestSnapshotIsACopy(t *testing.T) {
 		t.Error("mutating a returned snapshot leaked into the registry")
 	}
 }
+
+// TestSnapshotIsACopy only proves the map itself is a copy - Requires is a
+// reference type, so a Manifest value copied into that map can still alias
+// the registry's own backing array underneath it. Register must clone the
+// caller's slice before storing it, or mutating the slice you passed in,
+// after Register has already returned, would silently rewrite an
+// already-registered application's dependency list.
+func TestRegisterCopiesRequires(t *testing.T) {
+	resetRegistry(t)
+	requires := []string{"crm"}
+	Register(Manifest{Code: "order", Name: "Order", Version: "1.0.0", Requires: requires})
+
+	requires[0] = "tampered"
+
+	entries := Snapshot()
+	if got := entries["order"].Requires[0]; got != "crm" {
+		t.Errorf("Requires[0] = %q after mutating the caller's own slice post-Register, want %q", got, "crm")
+	}
+}
+
+// The same aliasing risk exists on the read side: copying the map's
+// Manifest values (what TestSnapshotIsACopy checks) does not copy what
+// each value's Requires slice points to, so two Snapshot calls would
+// otherwise both be looking at the registry's own backing array. Mutating
+// one snapshot's Requires must not be visible through a later, independent
+// Snapshot call.
+func TestSnapshotCopiesRequires(t *testing.T) {
+	resetRegistry(t)
+	Register(Manifest{Code: "order", Name: "Order", Version: "1.0.0", Requires: []string{"crm"}})
+
+	first := Snapshot()
+	first["order"].Requires[0] = "tampered"
+
+	second := Snapshot()
+	if got := second["order"].Requires[0]; got != "crm" {
+		t.Errorf("Requires[0] = %q after mutating a previously taken snapshot, want %q", got, "crm")
+	}
+}

--- a/sdk/contract/app/app_test.go
+++ b/sdk/contract/app/app_test.go
@@ -1,0 +1,152 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/go-admin-team/go-admin-core/v2/sdk/contract/migration"
+)
+
+// resetRegistry clears the process-wide registration for the duration of
+// one test. Production code has no legitimate reason to unregister an
+// application - this exists so tests do not leak state into one another,
+// the same reasoning sdk/contract/seed's resetSeeder documents.
+func resetRegistry(t *testing.T) {
+	t.Helper()
+	mu.Lock()
+	previous := registry
+	registry = map[string]Manifest{}
+	mu.Unlock()
+	t.Cleanup(func() {
+		mu.Lock()
+		registry = previous
+		mu.Unlock()
+	})
+}
+
+// An app code differing only in case or surrounding whitespace would
+// register as two different applications from migration.ForApp's point of
+// view, for no reason a reader could guess.
+func TestRegisterNormalizesTheCode(t *testing.T) {
+	resetRegistry(t)
+
+	Register(Manifest{Code: "  CRM  ", Name: "CRM", Version: "1.0.0"})
+
+	entries := Snapshot()
+	entry, ok := entries["crm"]
+	if !ok {
+		t.Fatalf("no entry for \"crm\"; got %v", entries)
+	}
+	if entry.Code != "crm" {
+		t.Errorf("Manifest.Code = %q, want \"crm\"", entry.Code)
+	}
+}
+
+// Register must reject exactly what migration.ForApp rejects, for the same
+// reason: an empty code has nothing to key the registry on, and "core" is
+// reserved for the framework itself in that registry, so this package must
+// not let an application quietly claim it here instead.
+func TestRegisterRejectsReservedCodes(t *testing.T) {
+	for _, code := range []string{"", "   ", migration.FrameworkAppCode, "CORE"} {
+		t.Run("code="+code, func(t *testing.T) {
+			resetRegistry(t)
+			defer func() {
+				if recover() == nil {
+					t.Errorf("Register(code=%q) did not panic", code)
+				}
+			}()
+			Register(Manifest{Code: code, Name: "x", Version: "1.0.0"})
+		})
+	}
+}
+
+func TestRegisterRequiresName(t *testing.T) {
+	resetRegistry(t)
+	defer func() {
+		if recover() == nil {
+			t.Error("Register with an empty Name did not panic")
+		}
+	}()
+	Register(Manifest{Code: "order", Version: "1.0.0"})
+}
+
+func TestRegisterRequiresVersion(t *testing.T) {
+	resetRegistry(t)
+	defer func() {
+		if recover() == nil {
+			t.Error("Register with an empty Version did not panic")
+		}
+	}()
+	Register(Manifest{Code: "order", Name: "Order"})
+}
+
+// Two applications - or two init() calls for the same one - silently
+// taking turns owning one code would mean whichever ran last wins with no
+// indication the first Manifest was ever discarded. A duplicate code must
+// panic instead, the same convention config.RegisterExtend uses.
+func TestRegisterPanicsOnDuplicateCode(t *testing.T) {
+	resetRegistry(t)
+	Register(Manifest{Code: "order", Name: "Order", Version: "1.0.0"})
+
+	defer func() {
+		if recover() == nil {
+			t.Error("second Register for the same code did not panic")
+		}
+	}()
+	// Different case, same normalized code - must still collide.
+	Register(Manifest{Code: "ORDER", Name: "Order v2", Version: "2.0.0"})
+}
+
+// Every field a Manifest carries must reach Snapshot unchanged, including
+// Requires, Pricing and License - core does not interpret the latter two in
+// this batch, but it must not drop them either, since a host's installer
+// (and, later, the authorization stage PRD 003 anticipates) reads them back
+// from here.
+func TestSnapshotReturnsEveryField(t *testing.T) {
+	resetRegistry(t)
+	Register(Manifest{
+		Code:        "order",
+		Name:        "Order",
+		Version:     "1.0.0",
+		Description: "order management",
+		Author:      "go-admin-team",
+		Requires:    []string{"crm", "payment"},
+		Pricing:     "paid",
+		License:     "commercial",
+	})
+
+	entries := Snapshot()
+	entry, ok := entries["order"]
+	if !ok {
+		t.Fatalf("no entry for \"order\"; got %v", entries)
+	}
+	if entry.Name != "Order" || entry.Version != "1.0.0" ||
+		entry.Description != "order management" || entry.Author != "go-admin-team" ||
+		entry.Pricing != "paid" || entry.License != "commercial" {
+		t.Errorf("Snapshot did not round-trip every field: %+v", entry)
+	}
+	if len(entry.Requires) != 2 || entry.Requires[0] != "crm" || entry.Requires[1] != "payment" {
+		t.Errorf("Requires = %v, want [crm payment]", entry.Requires)
+	}
+}
+
+// Snapshot must be a copy: a host iterates and filters it without holding
+// this package's lock, so mutating what Snapshot returned must not corrupt
+// the registry, and a Register call made after a Snapshot was taken must
+// not retroactively appear in it - the same property
+// migration.Registry.Snapshot guarantees.
+func TestSnapshotIsACopy(t *testing.T) {
+	resetRegistry(t)
+	Register(Manifest{Code: "order", Name: "Order", Version: "1.0.0"})
+
+	snap := Snapshot()
+	delete(snap, "order")
+	snap["injected"] = Manifest{Code: "injected", Name: "x", Version: "1.0.0"}
+
+	again := Snapshot()
+	if _, ok := again["order"]; !ok {
+		t.Error("mutating a returned snapshot deleted the registry's own entry")
+	}
+	if _, ok := again["injected"]; ok {
+		t.Error("mutating a returned snapshot leaked into the registry")
+	}
+}

--- a/sdk/contract/app/version.go
+++ b/sdk/contract/app/version.go
@@ -1,0 +1,68 @@
+package app
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Compare compares two semantic version strings a and b, returning -1, 0,
+// or 1 depending on whether a is less than, equal to, or greater than b.
+// It is the one place this module compares application versions - a host's
+// installer (deciding whether an install is an upgrade, a same-version
+// no-op, or a rejected downgrade) and `migrate status` are both expected to
+// call this rather than each writing their own comparison.
+//
+// Only MAJOR.MINOR.PATCH is accepted: three dot-separated, non-negative
+// decimal integers, none with a leading zero. Pre-release and
+// build-metadata suffixes ("-rc1", "+build5") are not parsed - a version
+// carrying one is rejected rather than guessed at. An application's version
+// is written by the application's own author; ordering a guess against a
+// real version the way go-version-style permissive parsers do would risk
+// installing the wrong one with no error to show for it.
+func Compare(a, b string) (int, error) {
+	va, err := parseVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	vb, err := parseVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	for i := range va {
+		if va[i] != vb[i] {
+			if va[i] < vb[i] {
+				return -1, nil
+			}
+			return 1, nil
+		}
+	}
+	return 0, nil
+}
+
+// parseVersion accepts exactly MAJOR.MINOR.PATCH: three dot-separated,
+// non-negative decimal integers, none with a leading zero unless the
+// component is exactly "0". Anything else - a pre-release/build suffix, a
+// missing or extra component, a non-numeric component, an empty component -
+// is an error rather than a best-effort guess.
+func parseVersion(v string) ([3]int, error) {
+	var out [3]int
+	if strings.ContainsAny(v, "-+") {
+		return out, fmt.Errorf("app: version %q carries a pre-release or build-metadata suffix, which Compare does not parse", v)
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		return out, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
+	}
+	for i, p := range parts {
+		if p == "" || (len(p) > 1 && p[0] == '0') {
+			return out, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return out, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
+		}
+		out[i] = n
+	}
+	return out, nil
+}

--- a/sdk/contract/app/version.go
+++ b/sdk/contract/app/version.go
@@ -15,11 +15,14 @@ import (
 //
 // Only MAJOR.MINOR.PATCH is accepted: three dot-separated, non-negative
 // decimal integers, none with a leading zero. Pre-release and
-// build-metadata suffixes ("-rc1", "+build5") are not parsed - a version
-// carrying one is rejected rather than guessed at. An application's version
-// is written by the application's own author; ordering a guess against a
-// real version the way go-version-style permissive parsers do would risk
-// installing the wrong one with no error to show for it.
+// build-metadata suffixes ("-rc1", "+build5") are not parsed, and neither is
+// a negative component ("-1.0.0") - either one is rejected, with an error
+// that names which of the two it was, rather than guessed at. An
+// application's version is written by the application's own author;
+// ordering a guess against a real version the way go-version-style
+// permissive parsers do would risk installing the wrong one with no error
+// to show for it, and telling an operator the wrong one of these two
+// reasons would send them looking for a suffix that was never there.
 func Compare(a, b string) (int, error) {
 	va, err := parseVersion(a)
 	if err != nil {
@@ -42,38 +45,59 @@ func Compare(a, b string) (int, error) {
 
 // parseVersion accepts exactly MAJOR.MINOR.PATCH: three dot-separated,
 // non-negative decimal integers, none with a leading zero unless the
-// component is exactly "0". Anything else - a pre-release/build suffix, a
-// missing or extra component, a non-numeric component, an empty component -
-// is an error rather than a best-effort guess.
+// component is exactly "0". Anything else is an error rather than a
+// best-effort guess; parseComponent reports which of the specific reasons
+// applies to whichever component is at fault.
 func parseVersion(v string) ([3]int, error) {
 	var out [3]int
-	// This check's one load-bearing job is rejecting a negative component:
-	// "-1.0.0" or "1.-2.0" would otherwise parse cleanly, because
-	// strconv.Atoi("-1") is a perfectly valid integer, and nothing below
-	// this check inspects sign. Everything else this check also happens to
-	// catch - "1.0.0-rc1", "1.0.0+build5" - is caught a second time anyway,
-	// by the loop below failing to strconv.Atoi a component like "0-rc1" or
-	// "0+build5". Do not delete this thinking it is redundant with that
-	// loop: a counterproof that only tries pre-release/build-metadata
-	// suffixes stays green with this check removed, and only a negative
-	// component turns it red - see TestCompareRejectsMalformedVersions's
-	// "-1.0.0"/"1.-2.0"/"1.0.-3" cases.
-	if strings.ContainsAny(v, "-+") {
-		return out, fmt.Errorf("app: version %q carries a pre-release or build-metadata suffix, which Compare does not parse", v)
-	}
 	parts := strings.Split(v, ".")
 	if len(parts) != 3 {
 		return out, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
 	}
 	for i, p := range parts {
-		if p == "" || (len(p) > 1 && p[0] == '0') {
-			return out, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
-		}
-		n, err := strconv.Atoi(p)
+		n, err := parseComponent(v, p)
 		if err != nil {
-			return out, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
+			return out, err
 		}
 		out[i] = n
 	}
 	return out, nil
+}
+
+// parseComponent parses one dot-separated component p of version v (v is
+// only kept to quote in an error), distinguishing two reasons Compare does
+// not parse it that must not share one error message:
+//
+//   - a '+' anywhere in p, or a '-' anywhere in p other than as its very
+//     first character, means p carries build metadata or a pre-release
+//     identifier ("0-rc1", "0+build5") - the version is not bare
+//     MAJOR.MINOR.PATCH;
+//   - a '-' as the first character of p is a negative number ("-1"), which
+//     strconv.Atoi parses without complaint on its own - nothing else here
+//     inspects sign, so this needs its own check, and its own, accurate
+//     error. Reporting this case with the pre-release/build-metadata
+//     message above would be actively wrong: a caller who wrote "-1.0.0"
+//     and is told about a suffix is being pointed at something that is not
+//     in their version string.
+//
+// Everything else - an empty component, a leading zero, a non-numeric
+// component - falls through to the generic "not MAJOR.MINOR.PATCH" error.
+func parseComponent(v, p string) (int, error) {
+	if p == "" {
+		return 0, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
+	}
+	if strings.Contains(p, "+") || strings.Contains(p[1:], "-") {
+		return 0, fmt.Errorf("app: version %q carries a pre-release or build-metadata suffix, which Compare does not parse", v)
+	}
+	if strings.HasPrefix(p, "-") {
+		return 0, fmt.Errorf("app: version %q has a negative component, which is not a valid MAJOR.MINOR.PATCH version", v)
+	}
+	if len(p) > 1 && p[0] == '0' {
+		return 0, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
+	}
+	n, err := strconv.Atoi(p)
+	if err != nil {
+		return 0, fmt.Errorf("app: version %q is not MAJOR.MINOR.PATCH", v)
+	}
+	return n, nil
 }

--- a/sdk/contract/app/version.go
+++ b/sdk/contract/app/version.go
@@ -47,6 +47,17 @@ func Compare(a, b string) (int, error) {
 // is an error rather than a best-effort guess.
 func parseVersion(v string) ([3]int, error) {
 	var out [3]int
+	// This check's one load-bearing job is rejecting a negative component:
+	// "-1.0.0" or "1.-2.0" would otherwise parse cleanly, because
+	// strconv.Atoi("-1") is a perfectly valid integer, and nothing below
+	// this check inspects sign. Everything else this check also happens to
+	// catch - "1.0.0-rc1", "1.0.0+build5" - is caught a second time anyway,
+	// by the loop below failing to strconv.Atoi a component like "0-rc1" or
+	// "0+build5". Do not delete this thinking it is redundant with that
+	// loop: a counterproof that only tries pre-release/build-metadata
+	// suffixes stays green with this check removed, and only a negative
+	// component turns it red - see TestCompareRejectsMalformedVersions's
+	// "-1.0.0"/"1.-2.0"/"1.0.-3" cases.
 	if strings.ContainsAny(v, "-+") {
 		return out, fmt.Errorf("app: version %q carries a pre-release or build-metadata suffix, which Compare does not parse", v)
 	}

--- a/sdk/contract/app/version_test.go
+++ b/sdk/contract/app/version_test.go
@@ -63,15 +63,51 @@ func TestCompareRejectsMalformedVersions(t *testing.T) {
 		"1..0",
 		"v1.0.0",
 		// A negative component parses as a valid integer on its own
-		// (strconv.Atoi("-1") succeeds), so only the "-"/"+" guard for
-		// pre-release/build-metadata suffixes stops it from being read as
-		// a valid, if unusual, version.
+		// (strconv.Atoi("-1") succeeds; nothing about Atoi inspects sign),
+		// so only parseComponent's dedicated leading-"-" check stops it
+		// from being read as a valid, if unusual, version. See
+		// TestCompareDistinguishesNegativeFromSuffix for why that check
+		// has to report a reason different from a pre-release/build-
+		// metadata suffix.
 		"-1.0.0",
 		"1.-2.0",
 		"1.0.-3",
 	} {
 		if _, err := Compare(v, "1.0.0"); err == nil {
 			t.Errorf("Compare(%q, \"1.0.0\") did not error", v)
+		}
+	}
+}
+
+// A negative component ("-1.0.0") and a pre-release/build-metadata suffix
+// ("1.0.0-rc1") are both rejected, but for genuinely different reasons, and
+// the error must say which one actually applied - not the same message for
+// both. Reporting a suffix to a caller who wrote a negative number points
+// them at something that is not in their version string.
+func TestCompareDistinguishesNegativeFromSuffix(t *testing.T) {
+	for _, v := range []string{"-1.0.0", "1.-2.0", "1.0.-3"} {
+		_, err := Compare(v, "1.0.0")
+		if err == nil {
+			t.Fatalf("Compare(%q, ...) did not error", v)
+		}
+		if !strings.Contains(err.Error(), "negative component") {
+			t.Errorf("Compare(%q, ...) error = %q, want it to name a negative component", v, err.Error())
+		}
+		if strings.Contains(err.Error(), "suffix") {
+			t.Errorf("Compare(%q, ...) error = %q, wrongly blames a pre-release/build-metadata suffix", v, err.Error())
+		}
+	}
+
+	for _, v := range []string{"1.0.0-rc1", "1.0.0+build5"} {
+		_, err := Compare(v, "1.0.0")
+		if err == nil {
+			t.Fatalf("Compare(%q, ...) did not error", v)
+		}
+		if !strings.Contains(err.Error(), "suffix") {
+			t.Errorf("Compare(%q, ...) error = %q, want it to name a pre-release/build-metadata suffix", v, err.Error())
+		}
+		if strings.Contains(err.Error(), "negative") {
+			t.Errorf("Compare(%q, ...) error = %q, wrongly blames a negative component", v, err.Error())
 		}
 	}
 }

--- a/sdk/contract/app/version_test.go
+++ b/sdk/contract/app/version_test.go
@@ -1,0 +1,90 @@
+package app
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompareOrdersByNumericComponent(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.0", "1.0.1", -1},
+		{"1.0.1", "1.0.0", 1},
+		{"1.0.0", "1.1.0", -1},
+		{"1.1.0", "1.0.0", 1},
+		{"1.0.0", "2.0.0", -1},
+		{"2.0.0", "1.0.0", 1},
+		// Numeric, not lexicographic: "2" < "10" even though "2" > "1" as
+		// a string prefix comparison would suggest.
+		{"1.2.0", "1.10.0", -1},
+		{"1.10.0", "1.2.0", 1},
+		{"0.0.0", "0.0.0", 0},
+	}
+	for _, c := range cases {
+		got, err := Compare(c.a, c.b)
+		if err != nil {
+			t.Errorf("Compare(%q, %q) returned error: %v", c.a, c.b, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// A pre-release or build-metadata suffix must be rejected, not silently
+// dropped and compared as if it were a bare MAJOR.MINOR.PATCH - see
+// Compare's doc comment for why guessing is worse than erroring here.
+func TestCompareRejectsPreReleaseAndBuildMetadata(t *testing.T) {
+	for _, v := range []string{"1.0.0-rc1", "1.0.0+build5", "1.0.0-rc1+build5"} {
+		if _, err := Compare(v, "1.0.0"); err == nil {
+			t.Errorf("Compare(%q, \"1.0.0\") did not error", v)
+		}
+		if _, err := Compare("1.0.0", v); err == nil {
+			t.Errorf("Compare(\"1.0.0\", %q) did not error", v)
+		}
+	}
+}
+
+func TestCompareRejectsMalformedVersions(t *testing.T) {
+	for _, v := range []string{
+		"",
+		"1.0",
+		"1.0.0.0",
+		"1.0.a",
+		"01.0.0",
+		"1.00.0",
+		"1.0.00",
+		" 1.0.0",
+		"1.0.0 ",
+		"1..0",
+		"v1.0.0",
+		// A negative component parses as a valid integer on its own
+		// (strconv.Atoi("-1") succeeds), so only the "-"/"+" guard for
+		// pre-release/build-metadata suffixes stops it from being read as
+		// a valid, if unusual, version.
+		"-1.0.0",
+		"1.-2.0",
+		"1.0.-3",
+	} {
+		if _, err := Compare(v, "1.0.0"); err == nil {
+			t.Errorf("Compare(%q, \"1.0.0\") did not error", v)
+		}
+	}
+}
+
+// The error must name the offending version, the same way
+// migration.GetFilename's panic names the offending file - a caller
+// reporting this error to an operator needs to say which string was bad.
+func TestCompareErrorNamesTheOffendingVersion(t *testing.T) {
+	_, err := Compare("not-a-version", "1.0.0")
+	if err == nil {
+		t.Fatal("Compare did not error on a malformed version")
+	}
+	if !strings.Contains(err.Error(), "not-a-version") {
+		t.Errorf("error %q does not name the offending version", err.Error())
+	}
+}


### PR DESCRIPTION
An application currently has no way to say what it is. Its migrations register under an app code, so a code that has migrations is the only evidence the application exists at all — there is nowhere to put its name, its version, who wrote it, or what it needs installed first. This adds that declaration, and the one comparator that reads its version.

## `Manifest` and the registry

`Manifest` carries code, name, version, description, author and requires. It also carries `Pricing` and `License`, which nothing here reads: they are declared now so that adding them later is not a breaking change for applications already published.

The registry follows `config.RegisterExtend` — a process-wide map behind a mutex, filled from `init()`, panicking on a second registration of the same code — rather than `migration.Registry`, because an application has one manifest, not a collection. There is no seal API. The three comparable registries in this module (`migration.Registry`, `seed.Seeder`, `config.RegisterExtend`) do not have one, and a fourth that did would be an inconsistency without a reason behind it.

`Register` normalises the code through `migration.NormalizeAppCode` and refuses the reserved framework code, so a code typed into a manifest and the same code typed into `migration.ForApp` resolve to the same application.

`Requires` is `[]string`, not a delimited string. How a host stores the list is the host's decision — go-admin's `sys_app.requires` will hold it as CSV — and letting a storage format reach up into the declaration would make the next host's different choice a change to this package.

## `Compare`

One comparator, so that an installer deciding "upgrade, no-op, or refuse as a downgrade" and a status command listing versions cannot disagree about which of two versions is newer.

It accepts `MAJOR.MINOR.PATCH` and nothing else: three non-negative decimal components, no leading zeros, no pre-release or build-metadata suffix. A version it cannot parse is an error rather than a guess. Application versions are written by application authors, and a permissive parser that orders a malformed version against a real one installs the wrong one with nothing to show for it.

## A note on the third commit

The `-`/`+` guard in `parseVersion` looks redundant next to the loop that parses each component, and removing it leaves the tests green — every pre-release and build-metadata string it rejects is rejected a second time when `strconv.Atoi` meets a component like `0-rc1`.

Its one load-bearing job is the negative component: `strconv.Atoi("-1")` is a perfectly valid integer, and nothing below that check inspects sign. `-1.0.0` parses cleanly without it.

This was found while counter-proving the tests, when removing the guard produced no failure — two independent defences were covering the same degradation, and the counter-proof was worthless until cases only that guard can catch (`-1.0.0`, `1.-2.0`, `1.0.-3`) were added. The third commit writes that down beside the code, because the next reader will otherwise reach the same "this is redundant" conclusion and delete it with the suite still green.

## Checks

`make build`, `make vet`, `make test` and `scripts/check-language.sh origin/main` all pass. Pure addition — one new directory, no existing file touched.

Every behaviour has a test, and every test was counter-proved by degrading the implementation and confirming a specific assertion fails. Beyond the guard above, the ones worth naming: `Snapshot` returning the registry itself rather than a copy is caught in both directions (mutating the returned map reaching the registry, and vice versa); and comparing components as strings instead of integers is caught by `Compare("1.2.0", "1.10.0")`, which the single-digit cases alone would not have found.
