### PR TITLE
The queue drain has a caller now, and it is the host's

### DIFF
--- a/docs/contract.md
+++ b/docs/contract.md
@@ -573,10 +573,15 @@ flag skip the very work it was added to protect.
 
 - **They do not drain the queue on their own.** Since v2.7.0 `Memory.Shutdown`
   delivers what is still buffered rather than discarding it, so a `BeforeExit`
-  callback now has something to call - but nothing calls it. A host that
-  rebuilds its adapter on reload shuts down the *previous* one; at exit the
-  installed adapter is simply abandoned. A deployment that cannot lose audit
-  rows has to register that shutdown itself. See `known-issues.md`.
+  callback has something to call - but the callback is the host's to register.
+  Rebuilding the adapter on reload shuts down the *previous* one; the installed
+  one is abandoned at exit unless something asks for it.
+
+  go-admin registers that callback, so a deployment of it does not have to.
+  A host written from scratch does: shut down the adapter *it* installed rather
+  than whatever `GetQueueAdapter` returns, because that accessor never returns
+  nil and with nothing configured it wraps this module's own fallback queue -
+  closing a queue the host neither built nor started. See `known-issues.md`.
 - **They cannot take the process out of a load balancer.** The only hook here
   runs *after* the HTTP server stopped accepting, so nothing an application
   registers can be observed by a balancer while the instance is still serving.

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -76,10 +76,17 @@ released in v2.7.0. `MemQueue.Close` waits for its drain loop to finish and
 delivers what it holds instead of discarding it; `Memory.Shutdown` waits for
 every consumer to drain its own channel.
 
-**The call still has to come from somewhere.** Nothing shuts the adapter down
-when the process exits - go-admin calls `Shutdown` only on the previous adapter
-during a reload - so the messages buffered at SIGTERM are still lost. Section
-12 of `contract.md` records what changed and what did not.
+**The call has to come from the host, and now does.** This module provides the
+drain; it does not decide when a process exits. Until
+[go-admin-team/go-admin#918](https://github.com/go-admin-team/go-admin/pull/918)
+the installed adapter was simply abandoned at exit - `Shutdown` ran only on the
+*previous* adapter during a reload - and what was buffered at SIGTERM was lost.
+go-admin now registers a `BeforeExit` callback that shuts down the adapter it
+installed, so on that host the drain runs.
+
+A host that registers nothing still loses the backlog, and this module cannot
+tell it so: there is no point at which it could notice the absence. Section 12
+of `contract.md` says what a host has to do.
 
 ## 4. A reload can rebuild resources while the process is shutting down
 


### PR DESCRIPTION
Two statements in the documentation stopped being true when [go-admin#918](https://github.com/go-admin-team/go-admin/pull/918) landed, and both are the kind that sends a reader somewhere unhelpful.

`known-issues.md` entry 2 said the messages buffered at SIGTERM **are still lost**. v2.7.0 fixed the drain itself, and that entry correctly recorded that nothing was calling it — go-admin shut down only the *previous* adapter during a reload, and abandoned the installed one at exit. go-admin now registers a `BeforeExit` callback for it. A reader following the old text would either build something that already exists, or plan around a data-loss risk that is no longer there.

`contract.md` section 12 said a deployment that cannot lose audit rows **has to register that shutdown itself**. Also no longer true of go-admin, and the sentence left a host writing its own wiring with nothing to go on.

The replacement says what to do, and names the trap that made the go-admin implementation harder than it looks: shut down the adapter the host installed, not whatever `GetQueueAdapter` returns. That accessor never returns nil — with no queue section configured the runtime wraps its own fallback — so going through it closes a queue the host neither built nor started, while looking like it worked.

What has not changed is where the call comes from. This module provides the drain and has no point at which it could notice a host that never asks for it. A host that registers nothing still loses its backlog, silently, and both files now say that rather than implying the problem is gone.

Documentation only.
